### PR TITLE
Fix profile status message display

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -211,7 +211,7 @@ export const ProfileView: React.FC = () => {
                   {profile.status_message && (
                     <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg">
                       <p className="text-gray-700 dark:text-gray-300">
-                        "{profile.status_message}"
+                        {profile.status_message}
                       </p>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- fix ProfileView to render `profile.status_message` correctly

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d59156a308327abce93e60c353414