### PR TITLE
Fix toggleReaction parameters

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -67,7 +67,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
 
   const handleReaction = async (messageId: string, emoji: string) => {
     try {
-      await toggleReaction(messageId, emoji, false)
+      await toggleReaction(messageId, emoji)
     } catch (error) {
       toast.error('Failed to add reaction')
     }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -79,11 +79,10 @@ export const updateUserPresence = async () => {
   if (error) console.error('Error updating presence:', error)
 }
 
-export const toggleReaction = async (messageId: string, emoji: string, isDM = false) => {
+export const toggleReaction = async (messageId: string, emoji: string) => {
   const { error } = await supabase.rpc('toggle_message_reaction', {
-    message_id: messageId,
-    emoji,
-    is_dm: isDM
+    message_id_param: messageId,
+    emoji_param: emoji,
   })
   if (error) console.error('Error toggling reaction:', error)
 }


### PR DESCRIPTION
## Summary
- update supabase toggleReaction call to use `message_id_param` and `emoji_param`
- remove unused isDM parameter
- update message list to use new toggleReaction signature

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d5912a51c832791d1f56df9ab5940