### PR TITLE
Add delete policy for user DM messages

### DIFF
--- a/supabase/migrations/20250626110500_delete_own_dm_policy.sql
+++ b/supabase/migrations/20250626110500_delete_own_dm_policy.sql
@@ -1,0 +1,4 @@
+CREATE POLICY "Users can delete own DM messages"
+  ON dm_messages FOR DELETE
+  TO authenticated
+  USING (auth.uid() = sender_id);


### PR DESCRIPTION
## Summary
- add migration with policy so users can delete their own direct messages

## Testing
- `npm run lint` *(fails: unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c054c7c832784869857cd7c738b