### PR TITLE
Fix Supabase signup username check

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -27,7 +27,7 @@ export const signUp = async ({ email, password, username, displayName }: SignUpD
     .from('users')
     .select('username')
     .eq('username', username)
-    .single()
+    .maybeSingle()
 
   if (existingUser) {
     throw new Error('Username is already taken')


### PR DESCRIPTION
## Summary
- avoid 406 error when checking username availability

## Testing
- `npm run lint` *(fails: 31 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d5dabf580832785a4106b1f3c098d