### PR TITLE
Fix signup insert columns and schema names

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -53,6 +53,7 @@ export const signUp = async ({ email, password, username, displayName }: SignUpD
       .from('users')
       .insert({
         id: data.user.id,
+        email,
         username,
         display_name: displayName,
         status: 'online'

--- a/supabase/migrations/20250625113317_crystal_shape.sql
+++ b/supabase/migrations/20250625113317_crystal_shape.sql
@@ -28,13 +28,13 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TABLE IF NOT EXISTS users (
   id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
   email text UNIQUE NOT NULL,
-  full_name text,
+  display_name text,
   username text UNIQUE,
   avatar_url text,
   banner_url text,
   status text DEFAULT 'online',
   status_message text,
-  chat_color text DEFAULT '#3B82F6',
+  color text DEFAULT '#3B82F6',
   last_active timestamptz DEFAULT now(),
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now()


### PR DESCRIPTION
## Summary
- rename `full_name`->`display_name` and `chat_color`->`color` in schema
- insert email in signup profile creation
- ensure signup sets initial status to online

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d6a02322083278d64c13c8493f8bb