### PR TITLE
Fix users join for messages

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -15,7 +15,7 @@ export function useMessages() {
         .from('messages')
         .select(`
           *,
-          user:users(*)
+          user:users!messages_user_id_fkey(*)
         `)
         .order('created_at', { ascending: true })
         .limit(100);
@@ -48,7 +48,7 @@ export function useMessages() {
             .from('messages')
             .select(`
               *,
-              user:users(*)
+              user:users!messages_user_id_fkey(*)
             `)
             .eq('id', payload.new.id)
             .single();
@@ -71,7 +71,7 @@ export function useMessages() {
             .from('messages')
             .select(`
               *,
-              user:users(*)
+              user:users!messages_user_id_fkey(*)
             `)
             .eq('id', payload.new.id)
             .single();


### PR DESCRIPTION
## Summary
- fix supabase `user` join in message fetches

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d6a134e5c8327add09257919db1ff