### PR TITLE
Update useAuth to use AuthUser type

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import { supabase, User } from '../lib/supabase';
-import { AuthService, SignUpData } from '../lib/auth';
+import { supabase } from '../lib/supabase';
+import { AuthService, SignUpData, AuthUser } from '../lib/auth';
 
 export function useAuth() {
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -97,7 +97,7 @@ export function useAuth() {
     }
   };
 
-  const updateProfile = async (updates: Partial<User>) => {
+  const updateProfile = async (updates: Partial<AuthUser>) => {
     if (!user) return;
     
     const updatedUser = await AuthService.updateProfile(updates);


### PR DESCRIPTION
## Summary
- import `AuthUser` from `lib/auth`
- store `AuthUser` in state in `useAuth`
- update `updateProfile` param to match new type

## Testing
- `npm run build`
- `npm run lint` *(fails: no-unused-vars, explicit-any, etc.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685d6a25eb8483279ee322e89b53f63e