### PR TITLE
Fix signIn argument passing

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -134,7 +134,7 @@ export function useAuth() {
   const signIn = async (email: string, password: string) => {
     setLoading(true);
     try {
-      await AuthService.signIn(email, password);
+      await AuthService.signIn({ email, password });
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- fix `useAuth` `signIn` argument to pass an object

## Testing
- `npm run lint` *(fails: 33 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d6f5c290083278b01c33be6e27cab