### PR TITLE
Add migration for display_name column

### DIFF
--- a/supabase/migrations/20250626123000_add_display_name_column.sql
+++ b/supabase/migrations/20250626123000_add_display_name_column.sql
@@ -1,0 +1,3 @@
+-- Add display_name column to users if not exists
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS display_name text;


### PR DESCRIPTION
## Summary
- add migration to ensure `display_name` column exists in `users` table

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_685d6f18837083279d9aa1d916ec23e8