### PR TITLE
Fix race condition when signing up

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -61,7 +61,11 @@ export const signUp = async ({ email, password, username, displayName }: SignUpD
 
     if (profileError) {
       console.error('Error creating user profile:', profileError)
-      throw profileError
+      // Ignore duplicate key errors caused by race conditions with the
+      // auth state change handler which may also insert the profile.
+      if (profileError.code !== '23505') {
+        throw profileError
+      }
     }
 
     // If user is confirmed (auto-login), fetch and return the profile


### PR DESCRIPTION
## Summary
- handle duplicate profile insertion gracefully during sign up

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_685d885289a88327aac79531b3bfb7c8