### PR TITLE
Fix auth initialization

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -61,12 +61,10 @@ export function useAuth() {
             }
           }
         } else {
-          console.log('📝 Profile result:', profile ? 'Profile loaded' : 'No profile');
-          if (mountedRef.current) {
-            setUser(profile);
-          }
           console.log('❌ No user in session');
-          if (mountedRef.current) setUser(null);
+          if (mountedRef.current) {
+            setUser(null);
+          }
         }
       } catch (error) {
         console.error('Error getting initial session:', error);


### PR DESCRIPTION
## Summary
- ensure `useAuth` doesn't reference undefined `profile` when no session exists

## Testing
- `npm run lint` *(fails: 34 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_685d8bbe1ccc832792d32809e52db056