### PR TITLE
Fix auth state change handler

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -143,13 +143,7 @@ export function useAuth() {
               }
             }
           } else {
-            console.log('📝 Profile in auth change:', profile ? 'Profile loaded' : 'No profile');
-            if (profile) {
-              if (mountedRef.current) setUser(profile);
-            } else {
-              console.log('❌ Failed to get profile, keeping user as null');
-              if (mountedRef.current) setUser(null);
-            }
+            // No authenticated user in the session
             console.log('❌ No user in auth change');
             if (mountedRef.current) setUser(null);
           }


### PR DESCRIPTION
## Summary
- stop referencing undefined `profile` variable in `useAuth`

## Testing
- `npm run lint` *(fails: unexpected any, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685d8f9694f8832788bb1a543c36c218