### PR TITLE
Add avatar color and status props

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -108,7 +108,9 @@ export function Sidebar({ activeSection, onSectionChange, onNewDM }: SidebarProp
                     src={conversation.other_user?.avatar_url}
                     alt={conversation.other_user?.full_name || 'User'}
                     size="sm"
+                    color={conversation.other_user?.color}
                     status={conversation.other_user?.status}
+                    showStatus
                   />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-gray-900 truncate">
@@ -139,7 +141,9 @@ export function Sidebar({ activeSection, onSectionChange, onNewDM }: SidebarProp
             src={user?.avatar_url}
             alt={user?.full_name || 'You'}
             size="md"
+            color={user?.color}
             status={user?.status}
+            showStatus
           />
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium text-gray-900 truncate">

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -7,6 +7,8 @@ interface AvatarProps {
   fallback?: string;
   className?: string;
   status?: 'online' | 'away' | 'busy' | 'offline';
+  color?: string;
+  showStatus?: boolean;
 }
 
 const sizeClasses = {
@@ -23,21 +25,33 @@ const statusColors = {
   offline: 'bg-gray-400',
 };
 
-export function Avatar({ src, alt, size = 'md', fallback, className = '', status }: AvatarProps) {
+export function Avatar({
+  src,
+  alt,
+  size = 'md',
+  fallback,
+  className = '',
+  status,
+  color,
+  showStatus,
+}: AvatarProps) {
   const initials = fallback || alt.split(' ').map(n => n[0]).join('').toUpperCase();
   
   return (
     <div className={`relative inline-block ${className}`}>
-      <div className={`
-        ${sizeClasses[size]} 
-        rounded-full 
-        overflow-hidden 
-        bg-gradient-to-br from-blue-500 to-purple-600
+      <div
+        className={`
+        ${sizeClasses[size]}
+        rounded-full
+        overflow-hidden
+        ${color ? '' : 'bg-gradient-to-br from-blue-500 to-purple-600'}
         flex items-center justify-center
         text-white font-medium
         ring-2 ring-white
         transition-all duration-200 hover:scale-105
-      `}>
+      `}
+        style={color ? { backgroundColor: color } : undefined}
+      >
         {src ? (
           <img
             src={src}
@@ -52,7 +66,7 @@ export function Avatar({ src, alt, size = 'md', fallback, className = '', status
         )}
       </div>
       
-      {status && (
+      {showStatus && status && (
         <div className={`
           absolute -bottom-0.5 -right-0.5
           w-3 h-3 rounded-full border-2 border-white


### PR DESCRIPTION
## Summary
- allow custom color and status visibility in `<Avatar>` component
- pass color and status props from Sidebar avatars
- verify TypeScript build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d9d3d6cc48327930c86a605524c62