### PR TITLE
Fix realtime by enabling publication

### DIFF
--- a/supabase/migrations/20250626194146_enable_realtime.sql
+++ b/supabase/migrations/20250626194146_enable_realtime.sql
@@ -1,0 +1,5 @@
+-- Enable realtime on important chat tables
+ALTER PUBLICATION supabase_realtime ADD TABLE IF NOT EXISTS messages;
+ALTER PUBLICATION supabase_realtime ADD TABLE IF NOT EXISTS dm_messages;
+ALTER PUBLICATION supabase_realtime ADD TABLE IF NOT EXISTS dm_conversations;
+ALTER PUBLICATION supabase_realtime ADD TABLE IF NOT EXISTS users;


### PR DESCRIPTION
## Summary
- ensure new chat tables are included in the `supabase_realtime` publication

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685da2048ebc83279db755962cd46af9