### PR TITLE
Optimize message rendering

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,0 +1,247 @@
+import React, { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  Pin,
+  PinOff,
+  Edit3,
+  Trash2,
+  Reply,
+  MoreHorizontal,
+  ThumbsUp,
+  Copy,
+  Check,
+} from 'lucide-react'
+import { Avatar } from '../ui/Avatar'
+import { Button } from '../ui/Button'
+import { formatTime, shouldGroupMessage } from '../../lib/utils'
+import { toggleReaction } from '../../lib/supabase'
+import { useAuth } from '../../hooks/useAuth'
+
+interface MessageItemProps {
+  message: any
+  previousMessage?: any
+  onReply?: (messageId: string, content: string) => void
+  onEdit: (messageId: string, content: string) => Promise<void>
+  onDelete: (messageId: string) => Promise<void>
+  onTogglePin: (messageId: string) => Promise<void>
+}
+
+export const MessageItem: React.FC<MessageItemProps> = React.memo(
+  ({ message, previousMessage, onReply, onEdit, onDelete, onTogglePin }) => {
+    const { profile } = useAuth()
+    const [isEditing, setIsEditing] = useState(false)
+    const [editContent, setEditContent] = useState(message.content)
+    const [showActions, setShowActions] = useState(false)
+
+    const isGrouped = shouldGroupMessage(message, previousMessage)
+    const isOwner = profile?.id === message.user_id
+
+    const handleEditSave = async () => {
+      if (!editContent.trim()) return
+      await onEdit(message.id, editContent)
+      setIsEditing(false)
+    }
+
+    const handleReaction = async (emoji: string) => {
+      await toggleReaction(message.id, emoji, false)
+    }
+
+    const handleCopyMessage = () => {
+      navigator.clipboard.writeText(message.content)
+    }
+
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className={`group flex space-x-3 ${isGrouped ? 'mt-1' : 'mt-4'}`}
+      >
+        {/* Avatar */}
+        <div className="flex-shrink-0 w-10">
+          {!isGrouped && (
+            <Avatar
+              src={message.user?.avatar_url}
+              alt={message.user?.display_name}
+              size="md"
+              color={message.user?.color}
+              status={message.user?.status}
+              showStatus
+            />
+          )}
+        </div>
+
+        {/* Message Content */}
+        <div className="flex-1 min-w-0">
+          {!isGrouped && (
+            <div className="flex items-baseline space-x-2 mb-1">
+              <span className="font-semibold text-gray-900 dark:text-gray-100">
+                {message.user?.display_name}
+              </span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {formatTime(message.created_at)}
+              </span>
+              {message.edited_at && (
+                <span className="text-xs text-gray-400 dark:text-gray-500">
+                  (edited)
+                </span>
+              )}
+            </div>
+          )}
+
+          {isEditing ? (
+            <div className="space-y-2">
+              <textarea
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+                className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 resize-none"
+                rows={2}
+              />
+              <div className="flex space-x-2">
+                <Button size="sm" onClick={handleEditSave}>
+                  <Check className="w-4 h-4 mr-1" />
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setIsEditing(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="text-gray-900 dark:text-gray-100 break-words">
+                {message.content}
+              </div>
+              <MessageReactions message={message} onReact={handleReaction} />
+            </>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="relative">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowActions(!showActions)}
+            className="opacity-0 group-hover:opacity-100 transition-opacity"
+          >
+            <MoreHorizontal className="w-4 h-4" />
+          </Button>
+
+          <AnimatePresence>
+            {showActions && (
+              <motion.div
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-10 min-w-[160px]"
+              >
+                <button
+                  onClick={() => handleReaction('👍')}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
+                >
+                  <ThumbsUp className="w-4 h-4" />
+                  <span>React</span>
+                </button>
+
+                <button
+                  onClick={handleCopyMessage}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
+                >
+                  <Copy className="w-4 h-4" />
+                  <span>Copy</span>
+                </button>
+
+                {onReply && (
+                  <button
+                    onClick={() => onReply(message.id, message.content)}
+                    className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
+                  >
+                    <Reply className="w-4 h-4" />
+                    <span>Reply</span>
+                  </button>
+                )}
+
+                {isOwner && (
+                  <>
+                    <button
+                      onClick={() => {
+                        setIsEditing(true)
+                        setEditContent(message.content)
+                      }}
+                      className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
+                    >
+                      <Edit3 className="w-4 h-4" />
+                      <span>Edit</span>
+                    </button>
+
+                    <button
+                      onClick={() => onDelete(message.id)}
+                      className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 text-red-600 dark:text-red-400 flex items-center space-x-2"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                      <span>Delete</span>
+                    </button>
+                  </>
+                )}
+
+                <button
+                  onClick={() => onTogglePin(message.id)}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
+                >
+                  {message.pinned ? (
+                    <PinOff className="w-4 h-4" />
+                  ) : (
+                    <Pin className="w-4 h-4" />
+                  )}
+                  <span>{message.pinned ? 'Unpin' : 'Pin'}</span>
+                </button>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </motion.div>
+    )
+  }
+)
+
+MessageItem.displayName = 'MessageItem'
+
+const MessageReactions: React.FC<{ message: any; onReact: (emoji: string) => void }> = ({ message, onReact }) => {
+  const { profile } = useAuth()
+  const reactions = message.reactions || {}
+  const hasReactions = Object.keys(reactions).length > 0
+
+  if (!hasReactions) return null
+
+  return (
+    <div className="flex flex-wrap gap-1 mt-2">
+      {Object.entries(reactions).map(([emoji, data]: [string, any]) => {
+        const isReacted = data.users?.includes(profile?.id)
+        return (
+          <motion.button
+            key={emoji}
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.9 }}
+            onClick={() => onReact(emoji)}
+            className={`inline-flex items-center space-x-1 px-2 py-1 rounded-full text-xs transition-colors ${
+              isReacted
+                ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+            }`}
+          >
+            <span>{emoji}</span>
+            <span>{data.count}</span>
+          </motion.button>
+        )
+      })}
+    </div>
+  )
+}
+
+

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,25 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { 
-  Pin, 
-  PinOff, 
-  Edit3, 
-  Trash2, 
-  Reply, 
-  MoreHorizontal,
-  Heart,
-  ThumbsUp,
-  Laugh,
-  Copy,
-  Check
-} from 'lucide-react'
-import { useAuth } from '../../hooks/useAuth'
+import { Pin } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
 import { useTyping } from '../../hooks/useTyping'
-import { toggleReaction } from '../../lib/supabase'
-import { Avatar } from '../ui/Avatar'
-import { Button } from '../ui/Button'
-import { formatTime, formatDate, groupMessagesByDate, shouldGroupMessage } from '../../lib/utils'
+import { groupMessagesByDate } from '../../lib/utils'
+import { MessageItem } from './MessageItem'
 import toast from 'react-hot-toast'
 
 interface MessageListProps {
@@ -27,7 +12,6 @@ interface MessageListProps {
 }
 
 export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
-  const { profile } = useAuth()
   const { messages, loading, editMessage, deleteMessage, togglePin } = useMessages()
   const { typingUsers } = useTyping('general')
   
@@ -44,9 +28,6 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     console.log('🔄 MessageList: Component will re-render with', messages.length, 'messages');
   }, [messages, loading]);
   
-  const [editingMessage, setEditingMessage] = useState<string | null>(null)
-  const [editContent, setEditContent] = useState('')
-  const [selectedMessage, setSelectedMessage] = useState<string | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
 
@@ -55,15 +36,11 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  const groupedMessages = groupMessagesByDate(messages)
+  const groupedMessages = useMemo(() => groupMessagesByDate(messages), [messages])
 
-  const handleEdit = async (messageId: string) => {
-    if (!editContent.trim()) return
-
+  const handleEdit = async (messageId: string, content: string) => {
     try {
-      await editMessage(messageId, editContent)
-      setEditingMessage(null)
-      setEditContent('')
+      await editMessage(messageId, content)
       toast.success('Message updated')
     } catch (error) {
       toast.error('Failed to update message')
@@ -77,141 +54,6 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     } catch (error) {
       toast.error('Failed to delete message')
     }
-  }
-
-  const handleReaction = async (messageId: string, emoji: string) => {
-    try {
-      await toggleReaction(messageId, emoji, false)
-    } catch (error) {
-      toast.error('Failed to add reaction')
-    }
-  }
-
-  const handleCopyMessage = (content: string) => {
-    navigator.clipboard.writeText(content)
-    toast.success('Message copied')
-  }
-
-  const startEditing = (messageId: string, content: string) => {
-    setEditingMessage(messageId)
-    setEditContent(content)
-  }
-
-  const MessageActions: React.FC<{ message: any }> = ({ message }) => {
-    const isOwner = profile?.id === message.user_id
-    const [showActions, setShowActions] = useState(false)
-
-    return (
-      <div className="relative">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setShowActions(!showActions)}
-          className="opacity-0 group-hover:opacity-100 transition-opacity"
-        >
-          <MoreHorizontal className="w-4 h-4" />
-        </Button>
-
-        <AnimatePresence>
-          {showActions && (
-            <motion.div
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.95 }}
-              className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-10 min-w-[160px]"
-            >
-              <button
-                onClick={() => handleReaction(message.id, '👍')}
-                className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
-              >
-                <ThumbsUp className="w-4 h-4" />
-                <span>React</span>
-              </button>
-
-              <button
-                onClick={() => handleCopyMessage(message.content)}
-                className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
-              >
-                <Copy className="w-4 h-4" />
-                <span>Copy</span>
-              </button>
-
-              {onReply && (
-                <button
-                  onClick={() => onReply(message.id, message.content)}
-                  className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
-                >
-                  <Reply className="w-4 h-4" />
-                  <span>Reply</span>
-                </button>
-              )}
-
-              {isOwner && (
-                <>
-                  <button
-                    onClick={() => startEditing(message.id, message.content)}
-                    className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
-                  >
-                    <Edit3 className="w-4 h-4" />
-                    <span>Edit</span>
-                  </button>
-
-                  <button
-                    onClick={() => handleDelete(message.id)}
-                    className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 text-red-600 dark:text-red-400 flex items-center space-x-2"
-                  >
-                    <Trash2 className="w-4 h-4" />
-                    <span>Delete</span>
-                  </button>
-                </>
-              )}
-
-              <button
-                onClick={() => togglePin(message.id)}
-                className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2"
-              >
-                {message.pinned ? <PinOff className="w-4 h-4" /> : <Pin className="w-4 h-4" />}
-                <span>{message.pinned ? 'Unpin' : 'Pin'}</span>
-              </button>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
-    )
-  }
-
-  const MessageReactions: React.FC<{ message: any }> = ({ message }) => {
-    const reactions = message.reactions || {}
-    const hasReactions = Object.keys(reactions).length > 0
-
-    if (!hasReactions) return null
-
-    return (
-      <div className="flex flex-wrap gap-1 mt-2">
-        {Object.entries(reactions).map(([emoji, data]: [string, any]) => {
-          const isReacted = data.users?.includes(profile?.id)
-          
-          return (
-            <motion.button
-              key={emoji}
-              initial={{ scale: 0 }}
-              animate={{ scale: 1 }}
-              whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 0.9 }}
-              onClick={() => handleReaction(message.id, emoji)}
-              className={`inline-flex items-center space-x-1 px-2 py-1 rounded-full text-xs transition-colors ${
-                isReacted
-                  ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
-              }`}
-            >
-              <span>{emoji}</span>
-              <span>{data.count}</span>
-            </motion.button>
-          )
-        })}
-      </div>
-    )
   }
 
   if (loading) {
@@ -267,93 +109,17 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
 
           {/* Messages */}
           <div className="space-y-3">
-            {group.messages.map((message, index) => {
-              const previousMessage = group.messages[index - 1]
-              const isGrouped = shouldGroupMessage(message, previousMessage)
-              const isEditing = editingMessage === message.id
-
-              return (
-                <motion.div
-                  key={message.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  className={`group flex space-x-3 ${isGrouped ? 'mt-1' : 'mt-4'}`}
-                >
-                  {/* Avatar */}
-                  <div className="flex-shrink-0 w-10">
-                    {!isGrouped && (
-                      <Avatar
-                        src={message.user?.avatar_url}
-                        alt={message.user?.display_name}
-                        size="md"
-                        color={message.user?.color}
-                        status={message.user?.status}
-                        showStatus
-                      />
-                    )}
-                  </div>
-
-                  {/* Message Content */}
-                  <div className="flex-1 min-w-0">
-                    {!isGrouped && (
-                      <div className="flex items-baseline space-x-2 mb-1">
-                        <span className="font-semibold text-gray-900 dark:text-gray-100">
-                          {message.user?.display_name}
-                        </span>
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
-                          {formatTime(message.created_at)}
-                        </span>
-                        {message.edited_at && (
-                          <span className="text-xs text-gray-400 dark:text-gray-500">
-                            (edited)
-                          </span>
-                        )}
-                      </div>
-                    )}
-
-                    {isEditing ? (
-                      <div className="space-y-2">
-                        <textarea
-                          value={editContent}
-                          onChange={(e) => setEditContent(e.target.value)}
-                          className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 resize-none"
-                          rows={2}
-                        />
-                        <div className="flex space-x-2">
-                          <Button
-                            size="sm"
-                            onClick={() => handleEdit(message.id)}
-                          >
-                            <Check className="w-4 h-4 mr-1" />
-                            Save
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() => {
-                              setEditingMessage(null)
-                              setEditContent('')
-                            }}
-                          >
-                            Cancel
-                          </Button>
-                        </div>
-                      </div>
-                    ) : (
-                      <>
-                        <div className="text-gray-900 dark:text-gray-100 break-words">
-                          {message.content}
-                        </div>
-                        <MessageReactions message={message} />
-                      </>
-                    )}
-                  </div>
-
-                  {/* Actions */}
-                  <MessageActions message={message} />
-                </motion.div>
-              )
-            })}
+            {group.messages.map((message, index) => (
+              <MessageItem
+                key={message.id}
+                message={message}
+                previousMessage={group.messages[index - 1]}
+                onReply={onReply}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+                onTogglePin={togglePin}
+              />
+            ))}
           </div>
         </div>
       ))}


### PR DESCRIPTION
## Summary
- extract new `MessageItem` component and memoize individual messages
- simplify `MessageList` to use `MessageItem` and remove per-message state

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_685da3ec7954832799019b2ea73c72cf