### PR TITLE
Improve session refresh in auth

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -119,8 +119,12 @@ export const signOut = async () => {
 
 export const getCurrentUser = async () => {
   console.log('🔍 getCurrentUser called');
-  
+
   try {
+    console.log('🔐 Refreshing session...');
+    // Ensure we refresh the session so getUser() has a valid access token
+    await supabase.auth.getSession()
+
     console.log('🔐 Checking auth user...');
     const { data: { user }, error: authError } = await supabase.auth.getUser()
     


### PR DESCRIPTION
## Summary
- refresh Supabase session before fetching user in `getCurrentUser`

## Testing
- `npm run lint` *(fails: 25 errors, 3 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685da7e3a0dc8327a414ef53b4b5c64c