### PR TITLE
Fix session refresh on auth reconnect

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -122,8 +122,13 @@ export const getCurrentUser = async () => {
 
   try {
     console.log('🔐 Refreshing session...');
-    // Ensure we refresh the session so getUser() has a valid access token
-    await supabase.auth.getSession()
+    // Explicitly refresh the session so getUser() has a valid access token
+    const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession()
+    if (refreshError) {
+      console.error('❌ Failed to refresh session:', refreshError)
+    } else {
+      console.log('✅ Session refreshed:', !!refreshData.session)
+    }
 
     console.log('🔐 Checking auth user...');
     const { data: { user }, error: authError } = await supabase.auth.getUser()


### PR DESCRIPTION
## Summary
- call `refreshSession` when fetching the current user

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685daa5bdee48327aea56d09b80d9dd6