### PR TITLE
Fix realtime channel subscription loop

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -188,9 +188,14 @@ function useProvideMessages(): MessagesContextValue {
         if (status === 'SUBSCRIBED') {
           console.log('✅ Successfully subscribed to real-time messages');
         }
-        if (status === 'CLOSED' || status === 'TIMED_OUT' || status === 'CHANNEL_ERROR') {
-          console.warn(`⚠️ Channel ${status}, resubscribing...`);
-          supabase.removeChannel(newChannel);
+        if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+          console.warn(`⚠️ Channel ${status}, removing and resubscribing...`);
+          await supabase.removeChannel(newChannel);
+          setTimeout(() => {
+            channel = subscribeToChannel();
+          }, 1000);
+        } else if (status === 'CLOSED') {
+          console.warn('⚠️ Channel closed, resubscribing...');
           setTimeout(() => {
             channel = subscribeToChannel();
           }, 1000);


### PR DESCRIPTION
## Summary
- prevent recursion when realtime channel closes by removing the channel only on error or timeout
- resubscribe cleanly when closed

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685daad069748327a31bf8354d1b345a