### PR TITLE
Fix getCurrentUser hang

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -121,15 +121,6 @@ export const getCurrentUser = async () => {
   console.log('🔍 getCurrentUser called');
 
   try {
-    console.log('🔐 Refreshing session...');
-    // Explicitly refresh the session so getUser() has a valid access token
-    const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession()
-    if (refreshError) {
-      console.error('❌ Failed to refresh session:', refreshError)
-    } else {
-      console.log('✅ Session refreshed:', !!refreshData.session)
-    }
-
     console.log('🔐 Checking auth user...');
     const { data: { user }, error: authError } = await supabase.auth.getUser()
     


### PR DESCRIPTION
## Summary
- avoid refreshing session before reading user data

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dabdd96188327bd55439f2fc1b0f7