### PR TITLE
Refresh session on focus

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -167,6 +167,10 @@ function useProvideAuth() {
     // Update on page visibility change
     const handleVisibilityChange = () => {
       if (!document.hidden) {
+        // Refresh the auth session when the page comes back into focus
+        supabase.auth.refreshSession().catch((err) => {
+          console.error('Error refreshing session on visibility change:', err)
+        })
         updatePresence();
       }
     };

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -207,8 +207,23 @@ function useProvideMessages(): MessagesContextValue {
 
     channel = subscribeToChannel();
 
+    const handleVisibility = () => {
+      if (!document.hidden) {
+        supabase.auth.refreshSession().catch(err => {
+          console.error('Error refreshing session on visibility change:', err)
+        })
+        if (channel && channel.state !== 'joined') {
+          supabase.removeChannel(channel)
+          channel = subscribeToChannel()
+        }
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibility)
+
     return () => {
       console.log('🔌 Cleaning up real-time subscription');
+      document.removeEventListener('visibilitychange', handleVisibility)
       if (channel) supabase.removeChannel(channel);
     };
   }, [user]);


### PR DESCRIPTION
## Summary
- refresh Supabase auth session when the page regains visibility
- resubscribe realtime channel if it closed while hidden

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_685dad21e2208327b1daa5a38b1cb7b0