### PR TITLE
Add mobile sidebar toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A trigger on dm_messages updates the last_message_at timestamp on the correspond
 --- ## Advanced UI / UX Features ### Navigation
 Persistent sidebar navigation with icons for Chat, DMs, Profile, and Settings
 Collapsible on mobile and tablet
+Menu buttons in each view header toggle the sidebar on small screens
 Sidebar shows unread message badges and typing indicators
 ### Dark Mode
 Theme toggle available in settings

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ type View = 'chat' | 'dms' | 'profile' | 'settings'
 function App() {
   const { user } = useAuth()
   const [currentView, setCurrentView] = useState<View>('chat')
+  const [sidebarOpen, setSidebarOpen] = useState(false)
   const [isDarkMode, setIsDarkMode] = useState(() => {
     if (typeof window !== 'undefined') {
       return localStorage.getItem('darkMode') === 'true' ||
@@ -52,31 +53,46 @@ function App() {
     setIsDarkMode(!isDarkMode)
   }
 
+  const toggleSidebar = () => {
+    setSidebarOpen((prev) => !prev)
+  }
+
+  const closeSidebar = () => setSidebarOpen(false)
+
   const renderCurrentView = () => {
     switch (currentView) {
       case 'chat':
-        return <ChatView />
+        return <ChatView onToggleSidebar={toggleSidebar} />
       case 'dms':
-        return <DirectMessagesView />
+        return <DirectMessagesView onToggleSidebar={toggleSidebar} />
       case 'profile':
-        return <ProfileView />
+        return <ProfileView onToggleSidebar={toggleSidebar} />
       case 'settings':
-        return <SettingsView />
+        return <SettingsView onToggleSidebar={toggleSidebar} />
       default:
-        return <ChatView />
+        return <ChatView onToggleSidebar={toggleSidebar} />
     }
   }
 
   return (
     <AuthGuard>
       <MessagesProvider>
-        <div className="h-screen flex bg-gray-100 dark:bg-gray-900">
+        <div className="h-screen flex flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
           <Sidebar
             currentView={currentView}
             onViewChange={setCurrentView}
             isDarkMode={isDarkMode}
             onToggleDarkMode={toggleDarkMode}
+            isOpen={sidebarOpen}
+            onClose={closeSidebar}
           />
+
+          {sidebarOpen && (
+            <div
+              className="fixed inset-0 bg-black/40 md:hidden"
+              onClick={closeSidebar}
+            />
+          )}
 
           <main className="flex-1 flex flex-col min-w-0">
             {renderCurrentView()}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,13 +1,17 @@
 import React, { useEffect } from 'react'
 import { motion } from 'framer-motion'
-import { Hash, Users, Pin } from 'lucide-react'
+import { Hash, Users, Pin, Menu } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
 import { useAuth } from '../../hooks/useAuth'
 import { MessageList } from './MessageList'
 import { MessageInput } from './MessageInput'
 import toast from 'react-hot-toast'
 
-export const ChatView: React.FC = () => {
+interface ChatViewProps {
+  onToggleSidebar: () => void
+}
+
+export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar }) => {
   const { sendMessage, messages, loading } = useMessages()
   const { user } = useAuth()
 
@@ -41,6 +45,12 @@ export const ChatView: React.FC = () => {
       <div className="flex-shrink-0 px-6 py-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
+            <button
+              onClick={onToggleSidebar}
+              className="md:hidden p-2 -ml-2"
+            >
+              <Menu className="w-5 h-5" />
+            </button>
             <div className="flex items-center space-x-2">
               <div className="p-2 bg-blue-100 dark:bg-blue-900 rounded-lg">
                 <Hash className="w-5 h-5 text-blue-600 dark:text-blue-400" />

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { 
-  MessageSquare, 
-  Search, 
-  Plus, 
+import {
+  MessageSquare,
+  Search,
+  Plus,
   ArrowLeft,
-  UserPlus
+  UserPlus,
+  Menu
 } from 'lucide-react'
 import { useDirectMessages } from '../../hooks/useDirectMessages'
 import { useAuth } from '../../hooks/useAuth'
@@ -16,7 +17,11 @@ import { MessageInput } from '../chat/MessageInput'
 import { formatTime, shouldGroupMessage } from '../../lib/utils'
 import toast from 'react-hot-toast'
 
-export const DirectMessagesView: React.FC = () => {
+interface DirectMessagesViewProps {
+  onToggleSidebar: () => void
+}
+
+export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggleSidebar }) => {
   const { profile } = useAuth()
   const {
     conversations,
@@ -80,9 +85,14 @@ export const DirectMessagesView: React.FC = () => {
         {/* Header */}
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            <div className="flex items-center">
+              <button onClick={onToggleSidebar} className="md:hidden p-2 -ml-2 mr-2">
+                <Menu className="w-5 h-5" />
+              </button>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
               Direct Messages
-            </h2>
+              </h2>
+            </div>
             <Button
               size="sm"
               onClick={() => setShowNewConversation(true)}
@@ -213,6 +223,9 @@ export const DirectMessagesView: React.FC = () => {
             {/* Header */}
             <div className="flex-shrink-0 px-6 py-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center space-x-3">
+                <button onClick={onToggleSidebar} className="md:hidden p-2 -ml-2">
+                  <Menu className="w-5 h-5" />
+                </button>
                 <Button
                   variant="ghost"
                   size="sm"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MessageSquare, Users, User, Settings, Plus, Moon, Sun } from 'lucide-react';
+import { MessageSquare, Users, User, Settings, Plus, Moon, Sun, X } from 'lucide-react';
 import { Avatar } from '../ui/Avatar';
 import { useAuth } from '../../hooks/useAuth';
 import { useDirectMessages } from '../../hooks/useDirectMessages';
@@ -10,6 +10,8 @@ interface SidebarProps {
   isDarkMode: boolean;
   onToggleDarkMode: () => void;
   onNewDM?: () => void;
+  isOpen: boolean;
+  onClose: () => void;
 }
 
 export function Sidebar({
@@ -18,6 +20,8 @@ export function Sidebar({
   isDarkMode,
   onToggleDarkMode,
   onNewDM,
+  isOpen,
+  onClose,
 }: SidebarProps) {
   const { user } = useAuth();
   const { conversations } = useDirectMessages();
@@ -52,7 +56,17 @@ export function Sidebar({
   ];
 
   return (
-    <div className="w-64 bg-white border-r border-gray-200 flex flex-col h-full">
+    <div
+      className={`w-64 bg-white border-r border-gray-200 flex flex-col h-full fixed inset-y-0 left-0 z-40 transform transition-transform md:relative md:translate-x-0 ${
+        isOpen ? '' : '-translate-x-full'
+      }`}
+    >
+      <button
+        onClick={onClose}
+        className="absolute top-2 right-2 p-2 rounded-md text-gray-500 hover:text-gray-700 md:hidden"
+      >
+        <X className="w-4 h-4" />
+      </button>
       {/* Header */}
       <div className="p-4 border-b border-gray-200">
         <div className="flex items-center space-x-3">

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { motion } from 'framer-motion'
-import { Camera, Edit3, Save, X, Upload } from 'lucide-react'
+import { Camera, Edit3, Save, X, Upload, Menu } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import { Avatar } from '../ui/Avatar'
 import { Button } from '../ui/Button'
@@ -20,7 +20,11 @@ const colorOptions = [
   '#06B6D4', '#84CC16', '#F97316', '#EC4899', '#6366F1'
 ]
 
-export const ProfileView: React.FC = () => {
+interface ProfileViewProps {
+  onToggleSidebar: () => void
+}
+
+export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => {
   const { profile, updateProfile } = useAuth()
   const [isEditing, setIsEditing] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -71,6 +75,9 @@ export const ProfileView: React.FC = () => {
       className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900"
     >
       <div className="max-w-2xl mx-auto p-6">
+        <button onClick={onToggleSidebar} className="md:hidden p-2 -ml-2 mb-2">
+          <Menu className="w-5 h-5" />
+        </button>
         {/* Header */}
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
           {/* Banner */}

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -10,15 +10,18 @@ import {
   Database,
   Download,
   Trash2,
-  AlertTriangle
+  AlertTriangle,
+  Menu
 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { signOut } from '../../lib/auth'
 import toast from 'react-hot-toast'
 
-interface SettingsViewProps {}
+interface SettingsViewProps {
+  onToggleSidebar: () => void
+}
 
-export const SettingsView: React.FC<SettingsViewProps> = () => {
+export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) => {
   const [notifications, setNotifications] = useState(true)
   const [sounds, setSounds] = useState(true)
   const [showDangerZone, setShowDangerZone] = useState(false)
@@ -74,6 +77,9 @@ export const SettingsView: React.FC<SettingsViewProps> = () => {
       className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900"
     >
       <div className="max-w-2xl mx-auto p-6">
+        <button onClick={onToggleSidebar} className="md:hidden p-2 -ml-2 mb-2">
+          <Menu className="w-5 h-5" />
+        </button>
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">


### PR DESCRIPTION
## Summary
- add mobile open/close props to `Sidebar`
- manage sidebar state in `App`
- add menu buttons across views
- update README with sidebar instructions

## Testing
- `npm run lint` *(fails: unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_685daf7e66248327b56d84981ed04db0