### PR TITLE
Fix message send after page revisit

### DIFF
--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -281,6 +281,13 @@ export function useConversationMessages(conversationId: string | null) {
 
     setSending(true);
     try {
+      // Refresh the session to avoid invalid token errors
+      try {
+        await supabase.auth.refreshSession()
+      } catch (err) {
+        console.error('Error refreshing session before sending DM:', err)
+      }
+
       const { data, error } = await supabase
         .from('dm_messages')
         .insert({

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -31,6 +31,12 @@ function useProvideMessages(): MessagesContextValue {
   // Fetch initial messages
   useEffect(() => {
     const fetchMessages = async () => {
+      // Refresh the session to ensure the access token is valid
+      try {
+        await supabase.auth.refreshSession()
+      } catch (err) {
+        console.error('Error refreshing session before fetching messages:', err)
+      }
       console.log('📥 Fetching initial messages...');
       try {
         const { data, error } = await supabase
@@ -236,8 +242,15 @@ function useProvideMessages(): MessagesContextValue {
 
     console.log('📤 Sending message:', { userId: user.id, content, messageType });
     setSending(true);
-    
+
     try {
+      // Ensure we have a fresh session before attempting to send
+      try {
+        await supabase.auth.refreshSession()
+      } catch (err) {
+        console.error('Error refreshing session before sending message:', err)
+      }
+
       const messageData = {
         user_id: user.id,
         content: content.trim(),


### PR DESCRIPTION
## Summary
- refresh auth session before fetching chat messages
- refresh auth session before sending chat messages and DMs

## Testing
- `npm run lint` *(fails: unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_685db22b204c8327a65d20d953435420