### PR TITLE
Fix message state merging and improve auto-scroll

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -33,6 +33,10 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
 
   // Auto-scroll to bottom
   useEffect(() => {
+    const list = listRef.current
+    if (list) {
+      list.scrollTop = list.scrollHeight
+    }
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
@@ -42,7 +46,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     try {
       await editMessage(messageId, content)
       toast.success('Message updated')
-    } catch (error) {
+    } catch {
       toast.error('Failed to update message')
     }
   }
@@ -51,7 +55,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     try {
       await deleteMessage(messageId)
       toast.success('Message deleted')
-    } catch (error) {
+    } catch {
       toast.error('Failed to delete message')
     }
   }

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -44,9 +44,16 @@ function useProvideMessages(): MessagesContextValue {
 
         if (error) {
           console.error('❌ Error fetching messages:', error);
-        } else {
-          console.log('✅ Fetched messages:', data?.length || 0);
-          setMessages(data || []);
+        } else if (data) {
+          console.log('✅ Fetched messages:', data.length);
+          setMessages(prev => {
+            if (prev.length === 0) {
+              return data as Message[];
+            }
+            const ids = new Set(prev.map(m => m.id));
+            const merged = [...prev, ...data.filter(m => !ids.has(m.id))];
+            return merged;
+          });
         }
       } catch (error) {
         console.error('❌ Exception fetching messages:', error);


### PR DESCRIPTION
## Summary
- merge fetched messages with any existing messages
- ensure message list scrolls as new messages arrive
- remove unused error vars in message list

## Testing
- `npx eslint src/hooks/useMessages.tsx src/components/chat/MessageList.tsx`
- `npm run lint` *(fails: Unexpected any errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_685dc0d938f08327b0511ecd94e3f9b6