### PR TITLE
Log retry durations

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -310,6 +310,7 @@ function useProvideMessages(): MessagesContextValue {
           const { data: refreshData, error: refreshError } = await Promise.race([refreshPromise, refreshTimeoutPromise]) as any;
           const retryRefreshEndTime = performance.now();
           const retryRefreshDuration = retryRefreshEndTime - retryRefreshStartTime;
+          console.log(`${logPrefix}: Session refresh duration`, retryRefreshDuration);
           
           
           if (!refreshError && refreshData.session) {
@@ -331,6 +332,7 @@ function useProvideMessages(): MessagesContextValue {
             const retry = await Promise.race([retryPromise, retryTimeoutPromise]) as any;
             const retryInsertEndTime = performance.now();
             const retryInsertDuration = retryInsertEndTime - retryInsertStartTime;
+            console.log(`${logPrefix}: Retry insert duration`, retryInsertDuration);
             
             
             data = retry.data;


### PR DESCRIPTION
## Summary
- log session refresh duration during retry
- log insert retry duration

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e8ed267008327ac2e88e94f20ddf1