### PR TITLE
Add warning when skipping sendMessage

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -237,6 +237,7 @@ function useProvideMessages(): MessagesContextValue {
     const logPrefix = `🚀 [${timestamp}] MESSAGE_SEND`;
 
     if (!user || !content.trim()) {
+      console.warn(`${logPrefix}: Skipped send — missing user or empty content`, { hasUser: !!user, content });
       return;
     }
 


### PR DESCRIPTION
## Summary
- add console warning in `sendMessage` for missing user or empty content

## Testing
- `npm run lint` *(fails: 35 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685e8ed35ebc8327b03657de419fabda