### PR TITLE
fix: use onKeyDown for message submit

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -53,7 +53,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }, [message])
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (
+    e: React.FormEvent<HTMLFormElement> | React.KeyboardEvent<HTMLTextAreaElement>
+  ) => {
     e.preventDefault()
     
     if (!message.trim() || disabled) return
@@ -73,7 +75,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       handleSubmit(e)
@@ -161,7 +163,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
             ref={textareaRef}
             value={message}
             onChange={handleInputChange}
-            onKeyPress={handleKeyPress}
+            onKeyDown={handleKeyDown}
             placeholder={placeholder}
             disabled={disabled}
             rows={1}


### PR DESCRIPTION
## Summary
- swap to `onKeyDown` in the message input to properly handle Enter

## Testing
- `npm run lint` *(fails: Unexpected any in many files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e92203014832785a31d29b8a44f88