### PR TITLE
Update channelRef on visibility re-subscribe

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -243,6 +243,7 @@ function useProvideMessages(): MessagesContextValue {
         if (channel && channel.state !== 'joined') {
           supabase.removeChannel(channel)
           channel = subscribeToChannel()
+          channelRef.current = channel
         }
         fetchMessages()
       }


### PR DESCRIPTION
## Summary
- ensure real-time subscription reference updates when resubscribing on visibility change

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e930e79bc83278b78fc6c5d5e4b13