### PR TITLE
Add Jest test setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts']
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
@@ -22,6 +23,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.10",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
@@ -30,8 +35,11 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "identity-obj-proxy": "^3.0.1",
+    "jest": "^29.7.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
+    "ts-jest": "^29.1.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2"

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tests/useMessages.test.tsx
+++ b/tests/useMessages.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook, act } from '@testing-library/react';
+import { MessagesProvider, useMessages } from '../src/hooks/useMessages';
+import { useAuth } from '../src/hooks/useAuth';
+import { supabase, ensureSession } from '../src/lib/supabase';
+
+jest.mock('../src/hooks/useAuth');
+jest.mock('../src/lib/supabase', () => {
+  return {
+    supabase: {
+      from: jest.fn(),
+      channel: jest.fn(),
+      removeChannel: jest.fn(),
+      auth: { getSession: jest.fn(), refreshSession: jest.fn() },
+    },
+    ensureSession: jest.fn(),
+  };
+});
+
+type SupabaseMock = jest.Mocked<typeof supabase>;
+
+describe('sendMessage', () => {
+  const user = { id: 'user1' } as any;
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (useAuth as jest.Mock).mockReturnValue({ user });
+
+    const sb = supabase as SupabaseMock;
+
+    // default mock implementations
+    sb.from.mockImplementation(() => {
+      return {
+        insert: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: [], error: null }),
+        order: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        update: jest.fn().mockReturnThis(),
+        delete: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        rpc: jest.fn().mockReturnThis(),
+      } as any;
+    });
+    sb.channel.mockReturnValue({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn(),
+      send: jest.fn(),
+    } as any);
+    sb.removeChannel.mockResolvedValue();
+    sb.auth = {
+      getSession: jest.fn(),
+      refreshSession: jest.fn(),
+    } as any;
+    (ensureSession as jest.Mock).mockResolvedValue(true);
+  });
+
+  it('calls ensureSession and inserts message', async () => {
+    const insertFn = jest.fn(() => ({
+      select: () => ({
+        single: () => Promise.resolve({ data: { id: '1' }, error: null }),
+      }),
+    }));
+    (supabase.from as jest.Mock).mockReturnValueOnce({
+      insert: insertFn,
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: [], error: null }),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      rpc: jest.fn().mockReturnThis(),
+    } as any);
+
+    const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
+
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    expect(ensureSession).toHaveBeenCalled();
+    expect(insertFn).toHaveBeenCalled();
+  });
+
+  it('refreshes session and retries on 401 insert error', async () => {
+    const insertFail = jest.fn(() => ({
+      select: () => ({
+        single: () => Promise.resolve({ data: null, error: { status: 401, message: 'unauthorized' } }),
+      }),
+    }));
+    const insertSuccess = jest.fn(() => ({
+      select: () => ({
+        single: () => Promise.resolve({ data: { id: '1' }, error: null }),
+      }),
+    }));
+
+    (supabase.from as jest.Mock).mockReturnValueOnce({
+      insert: insertFail,
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: [], error: null }),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      rpc: jest.fn().mockReturnThis(),
+    } as any).mockReturnValueOnce({
+      insert: insertSuccess,
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: [], error: null }),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      rpc: jest.fn().mockReturnThis(),
+    } as any);
+
+    (supabase.auth.refreshSession as jest.Mock).mockResolvedValue({ data: { session: {} }, error: null });
+
+    const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
+
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    expect(insertFail).toHaveBeenCalled();
+    expect(supabase.auth.refreshSession).toHaveBeenCalled();
+    expect(insertSuccess).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest configuration and test script
- include React Testing Library helpers
- create tests for `sendMessage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e96992ae88327bb2ffb02f17be8a9