### PR TITLE
Refresh session when page regains focus

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -26,6 +26,53 @@ function useProvideAuth() {
   const initialLoadRef = useRef(false);
   const mountedRef = useRef(true);
 
+  const refreshSessionOnFocus = async () => {
+    console.log('🔄 Refreshing session and profile on focus...');
+    try {
+      const {
+        data: { session },
+        error: sessionError,
+      } = await supabase.auth.getSession();
+
+      if (
+        sessionError &&
+        sessionError.message?.includes('User from sub claim in JWT does not exist')
+      ) {
+        console.log('🧹 Invalid JWT detected during focus refresh, clearing session...');
+        await supabase.auth.signOut();
+        if (mountedRef.current) setUser(null);
+        return;
+      }
+
+      if (sessionError) {
+        console.error('Session error during focus refresh:', sessionError);
+        if (mountedRef.current) {
+          setError(sessionError.message);
+          setUser(null);
+        }
+        return;
+      }
+
+      if (session?.user) {
+        try {
+          const profile = await getCurrentUser();
+          if (mountedRef.current) setUser(profile);
+        } catch (err) {
+          console.error('Failed to load profile during focus refresh:', err);
+          if (mountedRef.current) {
+            setError('Failed to load user profile.');
+            setUser(null);
+          }
+        }
+      } else if (mountedRef.current) {
+        setUser(null);
+      }
+    } catch (err) {
+      console.error('Unexpected error during focus refresh:', err);
+      if (mountedRef.current) setUser(null);
+    }
+  };
+
   useEffect(() => {
     mountedRef.current = true;
     
@@ -167,8 +214,7 @@ function useProvideAuth() {
     // Update on page visibility change
     const handleVisibilityChange = () => {
       if (!document.hidden) {
-        // Refresh the auth session when the page comes back into focus
-        supabase.auth.refreshSession().catch((err) => {
+        refreshSessionOnFocus().catch((err) => {
           console.error('Error refreshing session on visibility change:', err)
         })
         updatePresence();

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -283,10 +283,7 @@ export function useConversationMessages(conversationId: string | null) {
 
     const handleVisibility = () => {
       if (!document.hidden) {
-        supabase.auth.refreshSession().catch(err => {
-          console.error('Error refreshing session on visibility change:', err);
-        });
-        if (channel && channel.state !== 'joined') {
+        if (channel) {
           supabase.removeChannel(channel);
           channel = subscribeToChannel();
         }

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -228,10 +228,7 @@ function useProvideMessages(): MessagesContextValue {
 
     const handleVisibility = () => {
       if (!document.hidden) {
-        // supabase.auth.refreshSession().catch(err => {
-        //   console.error('Error refreshing session on visibility change:', err)
-        // })
-        if (channel && channel.state !== 'joined') {
+        if (channel) {
           supabase.removeChannel(channel)
           channel = subscribeToChannel()
         }


### PR DESCRIPTION
## Summary
- add `refreshSessionOnFocus` helper in auth hook
- refresh session & profile when window regains focus
- re-create realtime channels on focus for messages and DMs

## Testing
- `npm run lint` *(fails: 30 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ed4179c6883279076a40bc5281e28