### PR TITLE
Remove unused variables from ChatView

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { motion } from 'framer-motion'
 import { Hash, Users, Pin, Menu } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
-import { useAuth } from '../../hooks/useAuth'
 import { MessageList } from './MessageList'
 import { MessageInput } from './MessageInput'
 import toast from 'react-hot-toast'
@@ -13,12 +12,6 @@ interface ChatViewProps {
 
 export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar }) => {
   const { sendMessage, messages, loading } = useMessages()
-  const { user } = useAuth()
-
-  // Sync with messages state changes
-  useEffect(() => {
-    // Intentionally left blank to react to updates
-  }, [messages, loading]);
 
   const handleSendMessage = async (content: string) => {
     try {


### PR DESCRIPTION
## Summary
- tidy up `ChatView` by removing unused `user` constant
- drop empty effect and corresponding imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f16b25d8c8327866339a213c1a582