### PR TITLE
Fix status message display in profile view

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -218,7 +218,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => 
                   {profile.status_message && (
                     <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg">
                       <p className="text-gray-700 dark:text-gray-300">
-                        "{profile.status_message}"
+                        {profile.status_message}
                       </p>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- remove stray quotes around profile status message so it renders as plain text

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npx tsc --noEmit`
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f215a47288327b4f13ca7e089d57c