### PR TITLE
Add tests for hooks

### DIFF
--- a/tests/useAuth.test.tsx
+++ b/tests/useAuth.test.tsx
@@ -1,0 +1,94 @@
+import { renderHook, act } from '@testing-library/react';
+import { AuthProvider, useAuth } from '../src/hooks/useAuth';
+import { supabase } from '../src/lib/supabase';
+import * as auth from '../src/lib/auth';
+
+jest.mock('../src/lib/supabase', () => {
+  return {
+    supabase: {
+      from: jest.fn(),
+      channel: jest.fn(),
+      removeChannel: jest.fn(),
+      auth: {
+        getSession: jest.fn(),
+        onAuthStateChange: jest.fn(),
+        refreshSession: jest.fn(),
+        signOut: jest.fn(),
+      },
+    },
+    updateUserPresence: jest.fn(),
+  };
+});
+
+jest.mock('../src/lib/auth');
+
+type SupabaseMock = jest.Mocked<typeof supabase>;
+const authModule = auth as jest.Mocked<typeof auth>;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  const sb = supabase as SupabaseMock;
+  sb.auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+  sb.auth.onAuthStateChange.mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } } as any);
+  sb.channel.mockReturnValue({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: jest.fn() } as any);
+  sb.removeChannel.mockResolvedValue();
+  sb.from.mockImplementation(() => ({
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    contains: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    rpc: jest.fn().mockReturnThis(),
+  } as any));
+});
+
+test('signIn calls auth.signIn', async () => {
+  authModule.signIn.mockResolvedValue({} as any);
+
+  const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await act(async () => {
+    await result.current.signIn('a@test.com', 'pw');
+  });
+
+  expect(authModule.signIn).toHaveBeenCalledWith({ email: 'a@test.com', password: 'pw' });
+  expect(result.current.loading).toBe(false);
+  expect(result.current.error).toBeNull();
+});
+
+test('signUp sets user when session returned', async () => {
+  const profile = { id: '1' } as any;
+  authModule.signUp.mockResolvedValue({ session: {}, profile, user: {} } as any);
+
+  const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await act(async () => {
+    await result.current.signUp('x@y.com', 'pw', { full_name: 'X', username: 'user' });
+  });
+
+  expect(authModule.signUp).toHaveBeenCalledWith({
+    email: 'x@y.com',
+    password: 'pw',
+    username: 'user',
+    displayName: 'X',
+  });
+  expect(result.current.user).toEqual(profile);
+});
+
+test('signOut calls auth.signOut', async () => {
+  authModule.signOut.mockResolvedValue();
+
+  const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await act(async () => {
+    await result.current.signOut();
+  });
+
+  expect(authModule.signOut).toHaveBeenCalled();
+});

--- a/tests/useDirectMessages.test.tsx
+++ b/tests/useDirectMessages.test.tsx
@@ -1,0 +1,111 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDirectMessages } from '../src/hooks/useDirectMessages';
+import { useAuth } from '../src/hooks/useAuth';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/hooks/useAuth');
+jest.mock('../src/lib/supabase', () => {
+  return {
+    supabase: {
+      from: jest.fn(),
+      channel: jest.fn(),
+      removeChannel: jest.fn(),
+      auth: { getSession: jest.fn(), refreshSession: jest.fn() },
+    },
+  };
+});
+
+type SupabaseMock = jest.Mocked<typeof supabase>;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  (useAuth as jest.Mock).mockReturnValue({ user: { id: 'u1' } });
+
+  const sb = supabase as SupabaseMock;
+  sb.from.mockImplementation(() => ({
+    insert: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: [], error: null }),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    contains: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    rpc: jest.fn().mockReturnThis(),
+  } as any));
+  sb.channel.mockReturnValue({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: jest.fn(), state: 'joined' } as any);
+  sb.removeChannel.mockResolvedValue();
+});
+
+test('sendMessage retries on 401 error', async () => {
+  const insertFail = jest.fn(() => ({
+    select: () => ({
+      single: () => Promise.resolve({ data: null, error: { status: 401, message: 'unauth' } }),
+    }),
+  }));
+  const insertSuccess = jest.fn(() => ({
+    select: () => ({
+      single: () => Promise.resolve({ data: { id: '1' }, error: null }),
+    }),
+  }));
+
+  const sb = supabase as SupabaseMock;
+  sb.from.mockImplementation(() => ({
+    insert: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: [], error: null }),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    contains: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    rpc: jest.fn().mockReturnThis(),
+  } as any));
+
+  const { result } = renderHook(() => useDirectMessages());
+
+  await act(async () => {
+    result.current.setCurrentConversation('conv1');
+  });
+
+  sb.from.mockClear();
+  (sb.from as jest.Mock).mockImplementationOnce(() => ({
+    insert: insertFail,
+    select: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: [], error: null }),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    contains: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    rpc: jest.fn().mockReturnThis(),
+  } as any)).mockImplementationOnce(() => ({
+    insert: insertSuccess,
+    select: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: [], error: null }),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    contains: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    rpc: jest.fn().mockReturnThis(),
+  } as any));
+
+  sb.auth.refreshSession.mockResolvedValue({ data: { session: {} }, error: null } as any);
+
+  await act(async () => {
+    await result.current.sendMessage('hello');
+  });
+
+  expect(insertFail).toHaveBeenCalled();
+  expect(sb.auth.refreshSession).toHaveBeenCalled();
+  expect(insertSuccess).toHaveBeenCalled();
+});

--- a/tests/useTyping.test.tsx
+++ b/tests/useTyping.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTyping } from '../src/hooks/useTyping';
+import { useAuth } from '../src/hooks/useAuth';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/hooks/useAuth');
+jest.mock('../src/lib/supabase', () => {
+  return {
+    supabase: {
+      from: jest.fn(),
+      channel: jest.fn(),
+      removeChannel: jest.fn(),
+      auth: { getSession: jest.fn(), refreshSession: jest.fn() },
+    },
+  };
+});
+
+type SupabaseMock = jest.Mocked<typeof supabase>;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  (useAuth as jest.Mock).mockReturnValue({ user: { id: 'u1', username: 'u', display_name: 'U' } });
+
+  const sb = supabase as SupabaseMock;
+  sb.channel.mockReturnValue({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: jest.fn() } as any);
+  sb.removeChannel.mockResolvedValue();
+});
+
+test('startTyping sends typing true broadcast', async () => {
+  const sendMock = jest.fn();
+  (supabase.channel as jest.Mock).mockReturnValueOnce({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: sendMock } as any);
+
+  const { result } = renderHook(() => useTyping('general'));
+
+  await act(async () => {
+    await result.current.startTyping();
+  });
+
+  expect(sendMock).toHaveBeenCalledWith({
+    type: 'broadcast',
+    event: 'typing',
+    payload: {
+      user: { id: 'u1', username: 'u', display_name: 'U' },
+      typing: true,
+    },
+  });
+  expect(result.current.isTyping).toBe(true);
+});
+
+test('stopTyping sends typing false broadcast', async () => {
+  const sendMock = jest.fn();
+  (supabase.channel as jest.Mock).mockReturnValueOnce({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: sendMock } as any);
+
+  const { result } = renderHook(() => useTyping('general'));
+
+  await act(async () => {
+    await result.current.startTyping();
+    await result.current.stopTyping();
+  });
+
+  expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({ payload: expect.objectContaining({ typing: false }) }));
+  expect(result.current.isTyping).toBe(false);
+});


### PR DESCRIPTION
## Summary
- test `useAuth` sign in/out/up flows
- test `useTyping` broadcast helpers
- test `useDirectMessages` retry logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2169bec88327931cd4ddd5c0de10