### PR TITLE
Add debug logging flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # Optional: Presence update interval in milliseconds (default: 30000)
 VITE_PRESENCE_INTERVAL_MS=30000
+
+# Optional: Enable verbose logging for Supabase requests (true/false)
+VITE_DEBUG_LOGS=false

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 
 // Global debug flag used to gate verbose logging
-export const DEBUG = import.meta.env.DEV
+export const DEBUG = import.meta.env.VITE_DEBUG_LOGS === 'true'
 
 // Custom fetch that logs all request and response details for debugging
 const loggingFetch: typeof fetch = async (input, init) => {


### PR DESCRIPTION
## Summary
- gate Supabase console logs behind a `VITE_DEBUG_LOGS` flag
- document the new flag in `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2267500483278c66238eec596ba3