### PR TITLE
Add theme support with modern color schemes

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -62,13 +62,13 @@ export function LoginForm() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[var(--color-accent-light)] via-white to-white">
       <div className="max-w-md w-full mx-4">
         <div className="bg-white rounded-2xl shadow-2xl p-8 space-y-6">
           {/* Header */}
           <div className="text-center">
             <div className="flex justify-center mb-4">
-              <div className="p-3 bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl">
+            <div className="p-3 bg-gradient-to-r from-[var(--color-primary-start)] to-[var(--color-primary-end)] rounded-2xl">
                 <MessageSquare className="w-8 h-8 text-white" />
               </div>
             </div>
@@ -155,7 +155,7 @@ export function LoginForm() {
             <button
               type="button"
               onClick={() => setIsLogin(!isLogin)}
-              className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+              className="text-sm text-[var(--color-accent)] hover:underline font-medium"
             >
               {isLogin 
                 ? "Don't have an account? Sign up" 

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -39,8 +39,8 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar }) => {
               <Menu className="w-5 h-5" />
             </button>
             <div className="flex items-center space-x-2">
-              <div className="p-2 bg-blue-100 dark:bg-blue-900 rounded-lg">
-                <Hash className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+              <div className="p-2 bg-[var(--color-accent-light)] rounded-lg">
+                <Hash className="w-5 h-5 text-[var(--color-accent)]" />
               </div>
               <div>
                 <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -133,7 +133,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                   onClick={() => insertSlashCommand(cmd.command)}
                   className="w-full text-left px-2 py-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
                 >
-                  <div className="font-mono text-sm text-blue-600 dark:text-blue-400">
+                  <div className="font-mono text-sm text-[var(--color-accent)]">
                     {cmd.command}
                   </div>
                   <div className="text-xs text-gray-500 dark:text-gray-400">
@@ -169,7 +169,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
             placeholder={placeholder}
             disabled={disabled}
             rows={1}
-            className="w-full px-4 py-3 pr-12 border border-gray-300 dark:border-gray-600 rounded-xl bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-none max-h-32"
+            className="w-full px-4 py-3 pr-12 border border-gray-300 dark:border-gray-600 rounded-xl bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-[var(--color-accent)] resize-none max-h-32"
           />
           
           {/* Input Actions */}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -23,7 +23,7 @@ export function MobileNav({ currentView, onViewChange }: MobileNavProps) {
               onClick={() => onViewChange(item.id)}
               className={`flex flex-col items-center py-2 text-xs focus:outline-none w-full ${
                 currentView === item.id
-                  ? 'text-blue-600 dark:text-blue-400'
+                  ? 'text-[var(--color-accent)]'
                   : 'text-gray-500 dark:text-gray-400'
               }`}
             >

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -70,7 +70,7 @@ export function Sidebar({
       {/* Header */}
       <div className="p-4 border-b border-gray-200">
         <div className="flex items-center space-x-3">
-          <div className="p-2 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg">
+          <div className="p-2 bg-gradient-to-r from-[var(--color-primary-start)] to-[var(--color-primary-end)] rounded-lg">
             <MessageSquare className="w-6 h-6 text-white" />
           </div>
           <div>
@@ -90,7 +90,7 @@ export function Sidebar({
               w-full flex items-center space-x-3 px-3 py-2 rounded-lg
               transition-all duration-200
               ${currentView === item.id
-                ? 'bg-gradient-to-r from-blue-50 to-purple-50 text-blue-700 border-l-4 border-blue-500'
+                ? 'bg-[var(--color-accent-light)] text-[var(--color-accent)] border-l-4 border-[var(--color-accent)]'
                 : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
               }
             `}

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 import { 
   Bell, 
-  Moon, 
-  Sun, 
-  Volume2, 
-  VolumeX, 
-  Shield, 
+  Moon,
+  Sun,
+  Volume2,
+  VolumeX,
+  Palette,
+  Shield,
   Database,
   Download,
   Trash2,
@@ -16,6 +17,7 @@ import {
 import { Button } from '../ui/Button'
 import { signOut } from '../../lib/auth'
 import toast from 'react-hot-toast'
+import { useTheme, colorSchemes, ColorScheme } from '../../hooks/useTheme'
 
 interface SettingsViewProps {
   onToggleSidebar: () => void
@@ -25,6 +27,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
   const [notifications, setNotifications] = useState(true)
   const [sounds, setSounds] = useState(true)
   const [showDangerZone, setShowDangerZone] = useState(false)
+  const { scheme, setScheme } = useTheme()
 
   const handleExportData = () => {
     toast.success('Data export started - you will receive an email when ready')
@@ -120,7 +123,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
                       onClick={() => setting.onChange(!setting.enabled)}
                       className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                         setting.enabled
-                          ? 'bg-blue-600'
+                          ? 'bg-[var(--color-accent)]'
                           : 'bg-gray-200 dark:bg-gray-700'
                       }`}
                     >
@@ -135,6 +138,26 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
               </div>
             </div>
           ))}
+
+          {/* Appearance */}
+          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+            <div className="flex items-center space-x-3 mb-4">
+              <Palette className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Color Scheme
+              </h2>
+            </div>
+            <div className="flex space-x-4">
+              {(Object.keys(colorSchemes) as ColorScheme[]).map((key) => (
+                <button
+                  key={key}
+                  onClick={() => setScheme(key)}
+                  className={`w-8 h-8 rounded-full border-2 ${scheme === key ? 'border-[var(--color-accent)]' : 'border-transparent'}`}
+                  style={{ background: `linear-gradient(to right, ${colorSchemes[key].start}, ${colorSchemes[key].end})` }}
+                />
+              ))}
+            </div>
+          </div>
 
           {/* Data & Privacy */}
           <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -9,7 +9,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variants = {
-  primary: 'bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-lg hover:shadow-xl',
+  primary: 'bg-gradient-to-r from-[var(--color-primary-start)] to-[var(--color-primary-end)] text-white shadow-lg hover:shadow-xl',
   secondary: 'bg-gray-100 hover:bg-gray-200 text-gray-900 border border-gray-300',
   ghost: 'hover:bg-gray-100 text-gray-700 hover:text-gray-900',
   danger: 'bg-red-600 hover:bg-red-700 text-white shadow-lg hover:shadow-xl',
@@ -37,7 +37,7 @@ export function Button({
         font-medium rounded-lg
         transition-all duration-200
         disabled:opacity-50 disabled:cursor-not-allowed
-        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+        focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-2
         ${variants[variant]}
         ${sizes[size]}
         ${className}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -22,7 +22,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             w-full px-3 py-2 
             border border-gray-300 rounded-lg
             placeholder-gray-400
-            focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+            focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-transparent
             transition-all duration-200
             ${error ? 'border-red-500 focus:ring-red-500' : ''}
             ${className}

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+export type ColorScheme = 'indigo' | 'teal' | 'rose'
+
+interface ThemeContextValue {
+  scheme: ColorScheme
+  setScheme: (scheme: ColorScheme) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export const colorSchemes: Record<ColorScheme, { start: string; end: string }> = {
+  indigo: { start: '#6366f1', end: '#8b5cf6' },
+  teal: { start: '#14b8a6', end: '#10b981' },
+  rose: { start: '#f43f5e', end: '#d946ef' },
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [scheme, setScheme] = useState<ColorScheme>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('colorScheme') as ColorScheme) || 'indigo'
+    }
+    return 'indigo'
+  })
+
+  useEffect(() => {
+    document.documentElement.dataset.scheme = scheme
+    localStorage.setItem('colorScheme', scheme)
+  }, [scheme])
+
+  return (
+    <ThemeContext.Provider value={{ scheme, setScheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5,9 +5,34 @@
 @layer base {
   :root {
     color-scheme: light;
+    --color-primary-start: #6366f1;
+    --color-primary-end: #8b5cf6;
+    --color-accent: #6366f1;
+    --color-accent-light: #eef2ff;
   }
 
   .dark {
     color-scheme: dark;
   }
+}
+
+:root[data-scheme='indigo'] {
+  --color-primary-start: #6366f1;
+  --color-primary-end: #8b5cf6;
+  --color-accent: #6366f1;
+  --color-accent-light: #eef2ff;
+}
+
+:root[data-scheme='teal'] {
+  --color-primary-start: #14b8a6;
+  --color-primary-end: #10b981;
+  --color-accent: #14b8a6;
+  --color-accent-light: #ccfbf1;
+}
+
+:root[data-scheme='rose'] {
+  --color-primary-start: #f43f5e;
+  --color-primary-end: #d946ef;
+  --color-accent: #e11d48;
+  --color-accent-light: #fdf2f8;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { AuthProvider } from './hooks/useAuth';
+import { ThemeProvider } from './hooks/useTheme';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </AuthProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- introduce `useTheme` hook and provider
- define modern color scheme variables
- update layout and UI components to use scheme variables
- add color scheme selector in settings

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f225e36088327aa98dbe6dc19a77e