### PR TITLE
Add message types and apply across components

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -14,12 +14,12 @@ import {
 import { Avatar } from '../ui/Avatar'
 import { Button } from '../ui/Button'
 import { formatTime, shouldGroupMessage } from '../../lib/utils'
-import { toggleReaction } from '../../lib/supabase'
+import { toggleReaction, type Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 
 interface MessageItemProps {
-  message: any
-  previousMessage?: any
+  message: Message
+  previousMessage?: Message
   onReply?: (messageId: string, content: string) => void
   onEdit: (messageId: string, content: string) => Promise<void>
   onDelete: (messageId: string) => Promise<void>
@@ -210,17 +210,17 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
 
 MessageItem.displayName = 'MessageItem'
 
-const MessageReactions: React.FC<{ message: any; onReact: (emoji: string) => void }> = ({ message, onReact }) => {
+const MessageReactions: React.FC<{ message: Message; onReact: (emoji: string) => void }> = ({ message, onReact }) => {
   const { profile } = useAuth()
-  const reactions = message.reactions || {}
+  const reactions: Record<string, { count: number; users: string[] }> = message.reactions || {}
   const hasReactions = Object.keys(reactions).length > 0
 
   if (!hasReactions) return null
 
   return (
     <div className="flex flex-wrap gap-1 mt-2">
-      {Object.entries(reactions).map(([emoji, data]: [string, any]) => {
-        const isReacted = data.users?.includes(profile?.id)
+      {Object.entries(reactions).map(([emoji, data]: [string, { count: number; users: string[] }]) => {
+        const isReacted = data.users?.includes(profile?.id ?? '')
         return (
           <motion.button
             key={emoji}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -116,6 +116,8 @@ export interface DMMessage {
   sender?: User
 }
 
+export type ChatMessage = Message | DMMessage
+
 export interface UserSession {
   id: string
   user_id: string

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import type { ChatMessage } from './supabase'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -35,10 +36,10 @@ export function isToday(date: string | Date) {
   return d.toDateString() === today.toDateString()
 }
 
-export function groupMessagesByDate(messages: any[]) {
-  const groups: { date: string; messages: any[] }[] = []
+export function groupMessagesByDate(messages: ChatMessage[]) {
+  const groups: { date: string; messages: ChatMessage[] }[] = []
   let currentDate = ''
-  let currentGroup: any[] = []
+  let currentGroup: ChatMessage[] = []
 
   messages.forEach(message => {
     const messageDate = formatDate(message.created_at)
@@ -61,7 +62,7 @@ export function groupMessagesByDate(messages: any[]) {
   return groups
 }
 
-export function shouldGroupMessage(current: any, previous: any) {
+export function shouldGroupMessage(current: ChatMessage, previous?: ChatMessage) {
   if (!previous) return false
   
   // Don't group if different users


### PR DESCRIPTION
## Summary
- define `ChatMessage` union for chat and DM messages
- update utilities to accept `ChatMessage` rather than `any`
- type message props in `MessageItem`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2268882883278c076bb00ecdfe66