### PR TITLE
Improve DM conversation retrieval

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -139,6 +139,15 @@ export const toggleReaction = async (messageId: string, emoji: string, isDM = fa
   if (error) console.error('Error toggling reaction:', error)
 }
 
+export const fetchDMConversations = async () => {
+  const { data, error } = await supabase.rpc('get_dm_conversations')
+  if (error) {
+    console.error('Error fetching DM conversations:', error)
+    return [] as DMConversation[]
+  }
+  return (data ?? []) as DMConversation[]
+}
+
 export const getOrCreateDMConversation = async (otherUserId: string) => {
   const { data, error } = await supabase.rpc('get_or_create_dm_conversation', {
     other_user_id: otherUserId

--- a/supabase/migrations/20250627000000_joint_conversations.sql
+++ b/supabase/migrations/20250627000000_joint_conversations.sql
@@ -1,0 +1,58 @@
+/*
+  # Fetch DM conversations with participant info
+
+  Adds function get_dm_conversations() which returns conversations for the
+  authenticated user together with the other participant, the last message
+  and the unread message count.
+*/
+
+CREATE OR REPLACE FUNCTION get_dm_conversations()
+RETURNS TABLE (
+  id uuid,
+  participants uuid[],
+  last_message_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz,
+  other_user jsonb,
+  last_message jsonb,
+  unread_count integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id,
+    c.participants,
+    c.last_message_at,
+    c.created_at,
+    c.updated_at,
+    (
+      SELECT row_to_json(u)
+      FROM users u
+      WHERE u.id <> auth.uid()
+        AND u.id = ANY (c.participants)
+      LIMIT 1
+    ) AS other_user,
+    (
+      SELECT row_to_json(m)
+      FROM dm_messages m
+      WHERE m.conversation_id = c.id
+      ORDER BY m.created_at DESC
+      LIMIT 1
+    ) AS last_message,
+    (
+      SELECT count(*)
+      FROM dm_messages m2
+      WHERE m2.conversation_id = c.id
+        AND m2.sender_id <> auth.uid()
+        AND (m2.read_by IS NULL OR NOT (auth.uid() = ANY(m2.read_by)))
+    ) AS unread_count
+  FROM dm_conversations c
+  WHERE auth.uid() = ANY (c.participants)
+  ORDER BY c.last_message_at DESC;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_dm_conversations() TO authenticated;


### PR DESCRIPTION
## Summary
- create SQL function `get_dm_conversations` to fetch DM conversation data with one query
- add `fetchDMConversations` helper
- refactor `useDirectMessages` to use the new helper and update realtime handling

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f22695c388327bf869dab2329965a