### PR TITLE
Add UserStatus type and remove any cast

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -7,8 +7,9 @@ import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { LoadingSpinner } from '../ui/LoadingSpinner'
 import toast from 'react-hot-toast'
+import type { UserStatus } from '../../types'
 
-const statusOptions = [
+const statusOptions: { value: UserStatus; label: string; color: string }[] = [
   { value: 'online', label: 'Online', color: 'bg-green-500' },
   { value: 'away', label: 'Away', color: 'bg-yellow-500' },
   { value: 'busy', label: 'Busy', color: 'bg-red-500' },
@@ -24,11 +25,18 @@ interface ProfileViewProps {
   onToggleSidebar: () => void
 }
 
+interface ProfileFormData {
+  display_name: string
+  status_message: string
+  status: UserStatus
+  color: string
+}
+
 export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => {
   const { profile, updateProfile } = useAuth()
   const [isEditing, setIsEditing] = useState(false)
   const [loading, setLoading] = useState(false)
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<ProfileFormData>({
     display_name: profile?.display_name || '',
     status_message: profile?.status_message || '',
     status: profile?.status || 'online',
@@ -148,7 +156,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => 
                       {statusOptions.map((option) => (
                         <button
                           key={option.value}
-                          onClick={() => setFormData(prev => ({ ...prev, status: option.value as any }))}
+                          onClick={() => setFormData(prev => ({ ...prev, status: option.value }))}
                           className={`p-3 rounded-lg border-2 transition-colors ${
                             formData.status === option.value
                               ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -66,6 +66,8 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
 })
 
 // Database types matching the actual schema
+import type { UserStatus } from '../types'
+
 export interface User {
   id: string
   email: string
@@ -73,7 +75,7 @@ export interface User {
   display_name: string
   avatar_url?: string
   banner_url?: string
-  status: 'online' | 'away' | 'busy' | 'offline'
+  status: UserStatus
   status_message: string
   color: string
   last_active: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type UserStatus = 'online' | 'away' | 'busy' | 'offline';


### PR DESCRIPTION
## Summary
- define a `UserStatus` union type
- use `UserStatus` for profile state and Supabase `User`
- remove `as any` cast in profile status buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602b7cb900832786a4558ed75b95d4