### PR TITLE
Improve accessibility for icon-only controls

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -135,6 +135,7 @@ export function LoginForm() {
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
                 className="absolute right-3 top-8 text-gray-400 hover:text-gray-600"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
               >
                 {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
               </button>

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -35,6 +35,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar }) => {
             <button
               onClick={onToggleSidebar}
               className="md:hidden p-2 -ml-2"
+              aria-label="Toggle sidebar"
             >
               <Menu className="w-5 h-5" />
             </button>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -180,6 +180,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
               size="sm"
               onClick={() => setShowEmojiPicker(!showEmojiPicker)}
               className="h-8 w-8 p-0"
+              aria-label="Insert emoji"
             >
               <Smile className="w-4 h-4" />
             </Button>
@@ -189,6 +190,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
               variant="ghost"
               size="sm"
               className="h-8 w-8 p-0"
+              aria-label="Attach file"
             >
               <Paperclip className="w-4 h-4" />
             </Button>
@@ -199,6 +201,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           type="submit"
           disabled={!message.trim() || disabled}
           className="h-12 w-12 p-0 rounded-xl"
+          aria-label="Send message"
         >
           <Send className="w-5 h-5" />
         </Button>

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -157,6 +157,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
             size="sm"
             onClick={() => setShowActions(!showActions)}
             className="opacity-70 group-hover:opacity-100 transition-opacity"
+            aria-label="Message actions"
           >
             <MoreHorizontal className="w-4 h-4" />
           </Button>

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -86,7 +86,11 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center">
-              <button onClick={onToggleSidebar} className="md:hidden p-2 -ml-2 mr-2">
+              <button
+                onClick={onToggleSidebar}
+                className="md:hidden p-2 -ml-2 mr-2"
+                aria-label="Toggle sidebar"
+              >
                 <Menu className="w-5 h-5" />
               </button>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
@@ -97,6 +101,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
               size="sm"
               onClick={() => setShowNewConversation(true)}
               className="p-2"
+              aria-label="Start new conversation"
             >
               <Plus className="w-4 h-4" />
             </Button>
@@ -223,7 +228,11 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             {/* Header */}
             <div className="flex-shrink-0 px-6 py-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center space-x-3">
-                <button onClick={onToggleSidebar} className="md:hidden p-2 -ml-2">
+                <button
+                  onClick={onToggleSidebar}
+                  className="md:hidden p-2 -ml-2"
+                  aria-label="Toggle sidebar"
+                >
                   <Menu className="w-5 h-5" />
                 </button>
                 <Button
@@ -231,6 +240,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                   size="sm"
                   onClick={() => setCurrentConversation(null)}
                   className="lg:hidden"
+                  aria-label="Back"
                 >
                   <ArrowLeft className="w-4 h-4" />
                 </Button>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -64,6 +64,7 @@ export function Sidebar({
       <button
         onClick={onClose}
         className="absolute top-2 right-2 p-2 rounded-md text-gray-500 hover:text-gray-700 md:hidden"
+        aria-label="Close sidebar"
       >
         <X className="w-4 h-4" />
       </button>
@@ -115,6 +116,7 @@ export function Sidebar({
               <button
                 onClick={onNewDM}
                 className="p-1 text-gray-400 hover:text-gray-600 rounded"
+                aria-label="Start new conversation"
               >
                 <Plus className="w-4 h-4" />
               </button>
@@ -178,6 +180,7 @@ export function Sidebar({
           <button
             onClick={onToggleDarkMode}
             className="p-2 text-gray-500 hover:text-gray-700"
+            aria-label="Toggle dark mode"
           >
             {isDarkMode ? (
               <Sun className="w-4 h-4" />

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -75,14 +75,21 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => 
       className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900"
     >
       <div className="max-w-2xl mx-auto p-6">
-        <button onClick={onToggleSidebar} className="md:hidden p-2 -ml-2 mb-2">
+        <button
+          onClick={onToggleSidebar}
+          className="md:hidden p-2 -ml-2 mb-2"
+          aria-label="Toggle sidebar"
+        >
           <Menu className="w-5 h-5" />
         </button>
         {/* Header */}
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
           {/* Banner */}
           <div className="h-32 bg-gradient-to-r from-blue-500 to-purple-600 relative">
-            <button className="absolute top-4 right-4 p-2 bg-black bg-opacity-20 rounded-lg text-white hover:bg-opacity-30 transition-colors">
+            <button
+              className="absolute top-4 right-4 p-2 bg-black bg-opacity-20 rounded-lg text-white hover:bg-opacity-30 transition-colors"
+              aria-label="Change banner image"
+            >
               <Camera className="w-4 h-4" />
             </button>
           </div>
@@ -98,7 +105,10 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => 
                   color={profile.color}
                   className="border-4 border-white dark:border-gray-800"
                 />
-                <button className="absolute bottom-0 right-0 p-1.5 bg-blue-600 text-white rounded-full hover:bg-blue-700 transition-colors">
+                <button
+                  className="absolute bottom-0 right-0 p-1.5 bg-blue-600 text-white rounded-full hover:bg-blue-700 transition-colors"
+                  aria-label="Change avatar"
+                >
                   <Camera className="w-3 h-3" />
                 </button>
               </div>

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -80,7 +80,11 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
       className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900"
     >
       <div className="max-w-2xl mx-auto p-6">
-        <button onClick={onToggleSidebar} className="md:hidden p-2 -ml-2 mb-2">
+        <button
+          onClick={onToggleSidebar}
+          className="md:hidden p-2 -ml-2 mb-2"
+          aria-label="Toggle sidebar"
+        >
           <Menu className="w-5 h-5" />
         </button>
         {/* Header */}
@@ -126,6 +130,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
                           ? 'bg-[var(--color-accent)]'
                           : 'bg-gray-200 dark:bg-gray-700'
                       }`}
+                      aria-label={`Toggle ${setting.label}`}
                     >
                       <span
                         className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
@@ -154,6 +159,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
                   onClick={() => setScheme(key)}
                   className={`w-8 h-8 rounded-full border-2 ${scheme === key ? 'border-[var(--color-accent)]' : 'border-transparent'}`}
                   style={{ background: `linear-gradient(to right, ${colorSchemes[key].start}, ${colorSchemes[key].end})` }}
+                  aria-label={`Select ${key} color scheme`}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- add `aria-label` text for menu button in `ChatView`
- provide screen reader text for close, new conversation and dark-mode buttons in `Sidebar`
- update `DirectMessagesView` icon buttons with aria labels
- add labels for edit controls in `ProfileView`
- annotate menu button, toggles and color scheme buttons in `SettingsView`
- label password visibility control in `LoginForm`
- label icons in `MessageInput` and `MessageItem`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602c025e488327a4fbc160e2fbb5b8