### PR TITLE
Handle Avatar image errors

### DIFF
--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 interface AvatarProps {
   src?: string;
@@ -35,6 +35,7 @@ export function Avatar({
   color,
   showStatus,
 }: AvatarProps) {
+  const [imageError, setImageError] = useState(false);
   const initials = fallback || alt.split(' ').map(n => n[0]).join('').toUpperCase();
   
   return (
@@ -52,14 +53,12 @@ export function Avatar({
       `}
         style={color ? { backgroundColor: color } : undefined}
       >
-        {src ? (
+        {src && !imageError ? (
           <img
             src={src}
             alt={alt}
             className="w-full h-full object-cover"
-            onError={(e) => {
-              e.currentTarget.style.display = 'none';
-            }}
+            onError={() => setImageError(true)}
           />
         ) : (
           <span className="select-none">{initials}</span>


### PR DESCRIPTION
## Summary
- show fallback initials when Avatar image fails to load

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602c15f9608327b49570fc154202da