### PR TITLE
Refactor message limits and presence interval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,8 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 # Optional: Presence update interval in milliseconds (default: 30000)
 VITE_PRESENCE_INTERVAL_MS=30000
 
+# Optional: Number of messages to fetch per request (default: 100)
+VITE_MESSAGE_FETCH_LIMIT=100
+
 # Optional: Enable verbose logging for Supabase requests (true/false)
 VITE_DEBUG_LOGS=false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { SettingsView } from './components/settings/SettingsView'
 import { useAuth } from './hooks/useAuth'
 import { MessagesProvider } from './hooks/useMessages'
 import { updateUserPresence } from './lib/supabase'
+import { PRESENCE_INTERVAL_MS } from './config'
 import { MobileNav } from './components/layout/MobileNav'
 
 type View = 'chat' | 'dms' | 'profile' | 'settings'
@@ -45,7 +46,7 @@ function App() {
     // Set up periodic presence updates
     const interval = setInterval(() => {
       updateUserPresence()
-    }, parseInt(import.meta.env.VITE_PRESENCE_INTERVAL_MS || '30000'))
+    }, PRESENCE_INTERVAL_MS)
 
     return () => clearInterval(interval)
   }, [user])

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,6 @@
+export const MESSAGE_FETCH_LIMIT = parseInt(
+  import.meta.env.VITE_MESSAGE_FETCH_LIMIT || '100'
+)
+export const PRESENCE_INTERVAL_MS = parseInt(
+  import.meta.env.VITE_PRESENCE_INTERVAL_MS || '30000'
+)

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { supabase, User, updateUserPresence } from '../lib/supabase';
+import { PRESENCE_INTERVAL_MS } from '../config';
 import { signIn as authSignIn, signUp as authSignUp, signOut as authSignOut, getCurrentUser, updateUserProfile } from '../lib/auth';
 
 interface AuthContextValue {
@@ -147,8 +148,8 @@ function useProvideAuth() {
     // Update immediately
     updatePresence();
     
-    // Update every 30 seconds
-    const interval = setInterval(updatePresence, 30000);
+    // Update at configured interval
+    const interval = setInterval(updatePresence, PRESENCE_INTERVAL_MS);
     
     // Update on page visibility change
     const handleVisibilityChange = () => {

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -8,6 +8,7 @@ import {
   markDMMessagesRead,
   fetchDMConversations,
 } from '../lib/supabase';
+import { MESSAGE_FETCH_LIMIT } from '../config';
 import { useAuth } from './useAuth';
 
 export function useDirectMessages() {
@@ -172,7 +173,7 @@ export function useConversationMessages(conversationId: string | null) {
         `)
         .eq('conversation_id', conversationId)
         .order('created_at', { ascending: true })
-        .limit(100);
+        .limit(MESSAGE_FETCH_LIMIT);
 
       if (error) {
         console.error('Error fetching DM messages:', error);

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef
 } from 'react';
 import { supabase, Message, ensureSession, DEBUG } from '../lib/supabase';
+import { MESSAGE_FETCH_LIMIT } from '../config';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import { useAuth } from './useAuth';
 
@@ -39,7 +40,7 @@ function useProvideMessages(): MessagesContextValue {
           user:users!user_id(*)
         `)
         .order('created_at', { ascending: true })
-        .limit(100);
+        .limit(MESSAGE_FETCH_LIMIT);
 
       if (error) {
         // console.error('❌ Error fetching messages:', error);


### PR DESCRIPTION
## Summary
- centralize configuration for intervals and limits
- use `MESSAGE_FETCH_LIMIT` instead of magic numbers
- use `PRESENCE_INTERVAL_MS` across the app
- document new env variable

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68602c3bacec832796d604c487b9f4b3