### PR TITLE
Fix action menu hover behavior

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -150,7 +150,6 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
         <div
           className="relative"
           ref={actionsRef}
-          onMouseLeave={() => setShowActions(false)}
         >
           <Button
             variant="ghost"
@@ -167,6 +166,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                 initial={{ opacity: 0, scale: 0.95 }}
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.95 }}
+                onMouseLeave={() => setShowActions(false)}
                 className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-10 min-w-[160px]"
               >
                 <button


### PR DESCRIPTION
## Summary
- keep the message action menu open while hovering over it

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602d3a701083279e7c03c6f43030cb