### PR TITLE
Fix emoji picker z-index

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -181,7 +181,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                 {showReactionPicker && EmojiPicker && (
                   <div
                     ref={reactionPickerRef}
-                    className="absolute -top-48 left-1/2 -translate-x-1/2 z-20"
+                    className="absolute -top-48 left-1/2 -translate-x-1/2 z-50"
                   >
                     <EmojiPicker
                       onEmojiClick={handleReactionSelect}


### PR DESCRIPTION
## Summary
- bump z-index for emoji picker so it's always in front of the sidebar

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603072d6d4832789988d70b6ad0715