### PR TITLE
Improve chat virtualization layout

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react'
 import { Avatar } from '../ui/Avatar'
 import { Button } from '../ui/Button'
-import { formatTime, shouldGroupMessage } from '../../lib/utils'
+import { formatTime, shouldGroupMessage, cn } from '../../lib/utils'
 import { toggleReaction, type Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 
@@ -95,11 +95,17 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       return () => document.removeEventListener('mousedown', handleClick)
     }, [showReactionPicker])
 
+    const hasReactions = !!message.reactions && Object.keys(message.reactions).length > 0
+
     return (
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className={`group flex space-x-3 ${isGrouped ? 'mt-1' : 'mt-4'}`}
+        className={cn(
+          'group flex space-x-3',
+          isGrouped ? 'mt-1' : 'mt-4',
+          hasReactions && 'mb-6'
+        )}
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -54,12 +54,12 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     return arr
   }, [groupedMessages])
 
-  // Auto-scroll to bottom
+  // Auto-scroll to bottom whenever items change or list resizes
   useEffect(() => {
     if (listRef.current) {
-      listRef.current.scrollToItem(items.length - 1)
+      listRef.current.scrollToItem(items.length - 1, 'end')
     }
-  }, [items.length])
+  }, [items.length, listHeight])
 
   const sizeMap = useRef<Record<number, number>>({})
 
@@ -115,10 +115,16 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
 
     if (item.type === 'header') {
       return (
-        <div ref={refCallback} style={style} className="sticky top-0 z-10 flex justify-center">
-          <div className="bg-gray-100 dark:bg-gray-800 px-3 py-1 rounded-full text-xs font-medium text-gray-500 dark:text-gray-400">
+        <div
+          ref={refCallback}
+          style={style}
+          className="sticky top-0 z-10 flex items-center my-2"
+        >
+          <hr className="flex-grow border-t border-gray-300 dark:border-gray-700" />
+          <span className="mx-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
             {item.date}
-          </div>
+          </span>
+          <hr className="flex-grow border-t border-gray-300 dark:border-gray-700" />
         </div>
       )
     }


### PR DESCRIPTION
## Summary
- auto-scroll List component to newest message using `align: 'end'`
- restyle date dividers as thin lines across the message view
- add bottom space when messages contain reactions to avoid overlap

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603285a1cc83278ade872af29d449a