### PR TITLE
Remove unused utilities

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,4 @@
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
 import type { ChatMessage } from './supabase'
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
 
 export function formatTime(date: string | Date) {
   const d = new Date(date)
@@ -114,16 +108,3 @@ export function processSlashCommand(input: string): string | null {
   return slashCommand.handler(args)
 }
 
-export function generateColor(seed: string): string {
-  const colors = [
-    '#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6',
-    '#06B6D4', '#84CC16', '#F97316', '#EC4899', '#6366F1'
-  ]
-  
-  let hash = 0
-  for (let i = 0; i < seed.length; i++) {
-    hash = seed.charCodeAt(i) + ((hash << 5) - hash)
-  }
-  
-  return colors[Math.abs(hash) % colors.length]
-}


### PR DESCRIPTION
## Summary
- delete obsolete `cn` utility function
- remove unused `generateColor` helper

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686032b739f48327acced1b3e916e1e2