### PR TITLE
Update typing timeout ref

### DIFF
--- a/src/hooks/useTyping.ts
+++ b/src/hooks/useTyping.ts
@@ -12,7 +12,7 @@ export const useTyping = (channelName: string = 'general') => {
   const { user } = useAuth()
   const [typingUsers, setTypingUsers] = useState<TypingUser[]>([])
   const [isTyping, setIsTyping] = useState(false)
-  const typingTimeoutRef = useRef<NodeJS.Timeout>()
+  const typingTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
   const channelRef = useRef<any>()
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- use `ReturnType<typeof setTimeout>` for typing timeout ref

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686032b804388327a1efa34dc383d9f7