### PR TITLE
Remove unused createConversation

### DIFF
--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -110,21 +110,6 @@ export function useDirectMessages() {
     };
   }, [user]);
 
-  const createConversation = useCallback(async (otherUserId: string) => {
-    if (!user) return null;
-
-    try {
-      const { data, error } = await supabase.rpc('create_dm_conversation', {
-        other_user_id: otherUserId,
-      });
-
-      if (error) throw error;
-      return data;
-    } catch (error) {
-      console.error('Error creating conversation:', error);
-      throw error;
-    }
-  }, [user]);
   const {
     messages,
     sendMessage,
@@ -174,7 +159,6 @@ export function useDirectMessages() {
     startConversation,
     sendMessage,
     markAsRead,
-    createConversation,
   };
 }
 


### PR DESCRIPTION
## Summary
- delete the unused `createConversation` callback and its export from `useDirectMessages`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686032c3d26c83278a01930fc65e833f