### PR TITLE
Handle emoji picker load failures

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -4,6 +4,7 @@ import { Send, Smile, Paperclip, Command } from 'lucide-react'
 import { useTyping } from '../../hooks/useTyping'
 import { Button } from '../ui/Button'
 import { processSlashCommand, slashCommands } from '../../lib/utils'
+import toast from 'react-hot-toast'
 
 interface MessageInputProps {
   onSendMessage: (content: string) => void
@@ -46,10 +47,17 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   }, [])
 
   useEffect(() => {
-    if (showEmojiPicker && !EmojiPicker) {
-      import('emoji-picker-react').then(mod => {
+    const loadPicker = async () => {
+      try {
+        const mod = await import('emoji-picker-react')
         setEmojiPicker(() => mod.default)
-      })
+      } catch (error) {
+        console.error('❌ MessageInput: Failed to load emoji picker:', error)
+        toast.error('Failed to load emoji picker')
+      }
+    }
+    if (showEmojiPicker && !EmojiPicker) {
+      loadPicker()
     }
   }, [showEmojiPicker, EmojiPicker])
 

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -17,6 +17,7 @@ import { Button } from '../ui/Button'
 import { formatTime, shouldGroupMessage } from '../../lib/utils'
 import { toggleReaction, type Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import toast from 'react-hot-toast'
 
 const QUICK_REACTIONS = ['👍', '❤️', '😂', '🎉', '🙏']
 
@@ -74,10 +75,17 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     }, [])
 
     useEffect(() => {
-      if (showReactionPicker && !EmojiPicker) {
-        import('emoji-picker-react').then(mod => {
+      const loadPicker = async () => {
+        try {
+          const mod = await import('emoji-picker-react')
           setEmojiPicker(() => mod.default)
-        })
+        } catch (error) {
+          console.error('❌ MessageItem: Failed to load emoji picker:', error)
+          toast.error('Failed to load emoji picker')
+        }
+      }
+      if (showReactionPicker && !EmojiPicker) {
+        loadPicker()
       }
     }, [showReactionPicker, EmojiPicker])
 


### PR DESCRIPTION
## Summary
- add toast to message input dynamic import error handling
- add toast to message item dynamic import error handling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686032cad680832792c5173c04c4e54b