### PR TITLE
Remove unused messagesEndRef

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -25,7 +25,6 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
   const { typingUsers } = useTyping('general')
   
   
-  const messagesEndRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<List>(null)
   const [listHeight, setListHeight] = useState(0)
@@ -190,7 +189,6 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
           </motion.div>
         )}
       </AnimatePresence>
-      <div ref={messagesEndRef} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove the `messagesEndRef` reference and its `<div>` from `MessageList`

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: cannot access npm registry)*
- `npm run lint` *(fails: cannot find ESLint deps)*

------
https://chatgpt.com/codex/tasks/task_e_686032d135088327bd31135b46fe6d66