### PR TITLE
Fix reaction un-toggle

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -15,7 +15,7 @@ import {
 import { Avatar } from '../ui/Avatar'
 import { Button } from '../ui/Button'
 import { formatTime, shouldGroupMessage } from '../../lib/utils'
-import { toggleReaction, type Message } from '../../lib/supabase'
+import type { Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 
 const QUICK_REACTIONS = ['👍', '❤️', '😂', '🎉', '🙏']
@@ -27,10 +27,11 @@ interface MessageItemProps {
   onEdit: (messageId: string, content: string) => Promise<void>
   onDelete: (messageId: string) => Promise<void>
   onTogglePin: (messageId: string) => Promise<void>
+  onToggleReaction: (messageId: string, emoji: string) => Promise<void>
 }
 
 export const MessageItem: React.FC<MessageItemProps> = React.memo(
-  ({ message, previousMessage, onReply, onEdit, onDelete, onTogglePin }) => {
+  ({ message, previousMessage, onReply, onEdit, onDelete, onTogglePin, onToggleReaction }) => {
     const { profile } = useAuth()
     const [isEditing, setIsEditing] = useState(false)
     const [editContent, setEditContent] = useState(message.content)
@@ -50,7 +51,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     }
 
     const handleReaction = async (emoji: string) => {
-      await toggleReaction(message.id, emoji, false)
+      await onToggleReaction(message.id, emoji)
     }
 
     const handleReactionSelect = (emojiData: any) => {

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -21,7 +21,7 @@ interface MessageListProps {
 }
 
 export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
-  const { messages, loading, editMessage, deleteMessage, togglePin } = useMessages()
+  const { messages, loading, editMessage, deleteMessage, togglePin, toggleReaction } = useMessages()
   const { typingUsers } = useTyping('general')
   
   
@@ -132,6 +132,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
           onEdit={handleEdit}
           onDelete={handleDelete}
           onTogglePin={togglePin}
+          onToggleReaction={toggleReaction}
         />
       </div>
     )

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -528,6 +528,23 @@ function useProvideMessages(): MessagesContextValue {
         throw error;
       }
 
+      // Optimistically update local state
+      setMessages(prev =>
+        prev.map(msg => {
+          if (msg.id !== messageId) return msg;
+          const reactions = { ...(msg.reactions || {}) } as Record<string, { count: number; users: string[] }>;
+          const data = reactions[emoji] || { count: 0, users: [] };
+          const reacted = data.users.includes(user.id);
+          const users = reacted ? data.users.filter(u => u !== user.id) : [...data.users, user.id];
+          if (users.length === 0) {
+            delete reactions[emoji];
+          } else {
+            reactions[emoji] = { count: users.length, users };
+          }
+          return { ...msg, reactions } as Message;
+        })
+      );
+
     } catch (error) {
       // console.error('❌ Exception toggling reaction:', error);
       throw error;


### PR DESCRIPTION
## Summary
- wire MessageItem to call a passed `onToggleReaction`
- expose `toggleReaction` from `useMessages` and pass to MessageItem
- update `toggleReaction` to update local state optimistically

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860337129b883278e4f2d4e71ce6cd0