### PR TITLE
fix reaction spacing

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -111,8 +111,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
         animate={{ opacity: 1, y: 0 }}
         className={cn(
           'group flex space-x-3',
-          isGrouped ? 'mt-1' : 'mt-4',
-          hasReactions && 'mb-6'
+          isGrouped ? 'mt-1' : 'mt-4'
         )}
       >
         {/* Avatar */}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -11,7 +11,7 @@ import { Pin } from 'lucide-react'
 import { VariableSizeList as List } from 'react-window'
 import { useMessages } from '../../hooks/useMessages'
 import { useTyping } from '../../hooks/useTyping'
-import { groupMessagesByDate } from '../../lib/utils'
+import { groupMessagesByDate, cn } from '../../lib/utils'
 import { MessageItem } from './MessageItem'
 import type { Message as ChatMessage } from '../../lib/supabase'
 import toast from 'react-hot-toast'
@@ -112,6 +112,11 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
       }
     }
 
+    const hasReactions =
+      item.type === 'message' &&
+      item.message?.reactions &&
+      Object.keys(item.message.reactions).length > 0
+
     if (item.type === 'header') {
       return (
         <div
@@ -129,7 +134,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     }
 
     return (
-      <div ref={refCallback} style={style} className="py-1">
+      <div ref={refCallback} style={style} className={cn('py-1', hasReactions && 'pb-6')}>
         <MessageItem
           message={item.message as ChatMessage}
           previousMessage={item.prev}


### PR DESCRIPTION
## Summary
- remove margin-bottom from MessageItem root element so virtualization can measure actual height
- apply padding-bottom on message rows when reactions exist

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686036946e9c83278da858006ef10afa