### PR TITLE
Fix message avatar clipping

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -143,7 +143,10 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
   }
 
   return (
-    <div ref={containerRef} className="flex-1 overflow-hidden p-4">
+    <div
+      ref={containerRef}
+      className="flex-1 overflow-y-hidden overflow-x-visible p-4"
+    >
       {messages.some(m => m.pinned) && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">
           <div className="flex items-center space-x-2 mb-2">


### PR DESCRIPTION
## Summary
- avoid clipping message avatars beside the sidebar by allowing horizontal overflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686036ae08e48327b0117222505a87d6