### PR TITLE
Fix inconsistent message spacing

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -109,10 +109,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className={cn(
-          'group flex space-x-3',
-          isGrouped ? 'mt-1' : 'mt-4'
-        )}
+        className="group flex space-x-3 mt-2"
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -105,12 +105,14 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
 
   const Row = ({ index, style }: { index: number; style: React.CSSProperties }) => {
     const item = items[index]
-    const refCallback = (el: HTMLDivElement | null) => {
-      if (el) {
-        const height = el.getBoundingClientRect().height
+    const rowRef = useRef<HTMLDivElement | null>(null)
+
+    useLayoutEffect(() => {
+      if (rowRef.current) {
+        const height = rowRef.current.getBoundingClientRect().height
         setSize(index, height)
       }
-    }
+    }, [item, index])
 
     const hasReactions =
       item.type === 'message' &&
@@ -120,7 +122,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     if (item.type === 'header') {
       return (
         <div
-          ref={refCallback}
+          ref={rowRef}
           style={style}
           className="sticky top-0 z-10 flex items-center my-2"
         >
@@ -134,7 +136,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     }
 
     return (
-      <div ref={refCallback} style={style} className={cn('py-1', hasReactions && 'pb-6')}>
+      <div ref={rowRef} style={style} className={cn('py-1', hasReactions && 'pb-6')}>
         <MessageItem
           message={item.message as ChatMessage}
           previousMessage={item.prev}


### PR DESCRIPTION
## Summary
- stabilize the row measurement in `MessageList` so it updates after each render
- use constant spacing for `MessageItem` so messages don't jump around

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603ad441f88327abbdf7b23b606bd1