### PR TITLE
Fix intermittent message posting

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -437,17 +437,23 @@ function useProvideMessages(): MessagesContextValue {
           return updated
         })
         
-        const broadcastResult = channelRef.current?.send({
-          type: 'broadcast',
-          event: 'new_message',
-          payload: data
-        });
+        let broadcastResult: unknown = null
+        if (channelRef.current?.state === 'joined') {
+          broadcastResult = channelRef.current.send({
+            type: 'broadcast',
+            event: 'new_message',
+            payload: data,
+          })
+        }
         if (DEBUG) {
           console.log(`${logPrefix}: Broadcast result`, {
             result: broadcastResult,
             channelState: channelRef.current?.state,
-          });
+          })
         }
+
+        // Ensure we didn't miss any messages due to timing issues
+        fetchMessages()
       }
       
       


### PR DESCRIPTION
## Summary
- broadcast messages only when channel is ready
- fetch from server after sending to fill any gaps

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603b7cd67c8327955019fcd2afe88d