### PR TITLE
Fix message list flicker

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -103,7 +103,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
   }
 
 
-  const Row = ({ index, style }: { index: number; style: React.CSSProperties }) => {
+  const Row = useCallback(({ index, style }: { index: number; style: React.CSSProperties }) => {
     const item = items[index]
     const rowRef = useRef<HTMLDivElement | null>(null)
 
@@ -147,7 +147,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
         />
       </div>
     )
-  }
+  }, [items, onReply, handleEdit, handleDelete, togglePin])
 
   return (
     <div
@@ -179,6 +179,11 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
           width="100%"
           itemCount={items.length}
           itemSize={getSize}
+          itemKey={(index) =>
+            items[index].type === 'header'
+              ? `header-${items[index].date}`
+              : (items[index].message as ChatMessage).id
+          }
           overscanCount={10}
         >
           {Row}


### PR DESCRIPTION
## Summary
- memoize row renderer in `MessageList`
- add `itemKey` to react-window list for stable identity

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603bb8489c8327a637ca7214975560