### PR TITLE
Improve copy message feedback

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -60,8 +60,14 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       setShowReactionPicker(false)
     }
 
-    const handleCopyMessage = () => {
-      navigator.clipboard.writeText(message.content)
+    const handleCopyMessage = async () => {
+      try {
+        await navigator.clipboard.writeText(message.content)
+        toast.success('Message copied')
+      } catch (error) {
+        console.error('❌ MessageItem: Failed to copy message:', error)
+        toast.error('Failed to copy message')
+      }
     }
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- handle copy errors in MessageItem
- provide toast feedback when copying a message succeeds or fails

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68603ce3a9848327a700fc8620b8e07f