### PR TITLE
Add explicit types for emoji picker and typing hook

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -5,6 +5,7 @@ import { useTyping } from '../../hooks/useTyping'
 import { Button } from '../ui/Button'
 import { processSlashCommand, slashCommands } from '../../lib/utils'
 import toast from 'react-hot-toast'
+import type { EmojiPickerProps, EmojiClickData } from '../../types'
 
 interface MessageInputProps {
   onSendMessage: (content: string) => void
@@ -19,7 +20,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
 }) => {
   const [message, setMessage] = useState('')
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
-  const [EmojiPicker, setEmojiPicker] = useState<React.ComponentType<any> | null>(null)
+  const [EmojiPicker, setEmojiPicker] = useState<
+    React.ComponentType<EmojiPickerProps> | null
+  >(null)
   const [showSlashCommands, setShowSlashCommands] = useState(false)
   const { startTyping, stopTyping } = useTyping('general')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -112,7 +115,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }
 
-  const insertEmoji = (emojiData: any) => {
+  const insertEmoji = (emojiData: EmojiClickData) => {
     const emoji = emojiData.emoji
     setMessage(prev => prev + emoji)
     setShowEmojiPicker(false)

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -18,6 +18,7 @@ import { formatTime, shouldGroupMessage, cn } from '../../lib/utils'
 import { toggleReaction, type Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import toast from 'react-hot-toast'
+import type { EmojiPickerProps, EmojiClickData } from '../../types'
 
 const QUICK_REACTIONS = ['👍', '❤️', '😂', '🎉', '🙏']
 
@@ -37,7 +38,9 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     const [editContent, setEditContent] = useState(message.content)
     const [showActions, setShowActions] = useState(false)
     const [showReactionPicker, setShowReactionPicker] = useState(false)
-    const [EmojiPicker, setEmojiPicker] = useState<React.ComponentType<any> | null>(null)
+    const [EmojiPicker, setEmojiPicker] = useState<
+      React.ComponentType<EmojiPickerProps> | null
+    >(null)
     const reactionPickerRef = useRef<HTMLDivElement>(null)
     const actionsRef = useRef<HTMLDivElement>(null)
 
@@ -54,7 +57,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       await toggleReaction(message.id, emoji, false)
     }
 
-    const handleReactionSelect = (emojiData: any) => {
+    const handleReactionSelect = (emojiData: EmojiClickData) => {
       const emoji = emojiData.emoji
       handleReaction(emoji)
       setShowReactionPicker(false)

--- a/src/hooks/useTyping.ts
+++ b/src/hooks/useTyping.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { supabase } from '../lib/supabase'
 import { useAuth } from './useAuth'
+import type { RealtimeChannel } from '@supabase/supabase-js'
 
 interface TypingUser {
   id: string
@@ -13,7 +14,7 @@ export const useTyping = (channelName: string = 'general') => {
   const [typingUsers, setTypingUsers] = useState<TypingUser[]>([])
   const [isTyping, setIsTyping] = useState(false)
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
-  const channelRef = useRef<any>()
+  const channelRef = useRef<RealtimeChannel | null>(null)
 
   useEffect(() => {
     const channel = supabase.channel(`typing:${channelName}`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,21 @@
 export type UserStatus = 'online' | 'away' | 'busy' | 'offline';
+
+/**
+ * Minimal representation of the emoji data returned by the
+ * `emoji-picker-react` component when an emoji is selected.
+ */
+export interface EmojiClickData {
+  /** The actual emoji character. */
+  emoji: string;
+}
+
+/**
+ * Props used by the `emoji-picker-react` component. Only the subset of
+ * properties that are required within this project are defined here.
+ */
+export interface EmojiPickerProps {
+  onEmojiClick: (emoji: EmojiClickData, event: MouseEvent) => void;
+  width?: number;
+  height?: number;
+  theme?: 'auto' | 'dark' | 'light' | string;
+}


### PR DESCRIPTION
## Summary
- create `EmojiClickData` and `EmojiPickerProps` interfaces
- use these interfaces in `MessageInput` and `MessageItem`
- type the realtime channel in `useTyping`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68603c566c488327a3caa8fc1fc07df4