### PR TITLE
Clean up dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.4.1",
-        "react-router-dom": "^6.11.0",
         "react-window": "^1.8.8",
         "tailwind-merge": "^2.2.0"
       },
@@ -9368,23 +9367,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-window": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
     "clsx": "^2.0.0",
-    "clsx": "^2.0.0",
     "emoji-picker-react": "^4.7.15",
     "framer-motion": "^10.16.16",
     "lucide-react": "^0.344.0",
@@ -21,7 +20,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
-    "react-router-dom": "^6.11.0",
     "tailwind-merge": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove duplicate `clsx` entry
- drop `react-router-dom` from dependencies and lockfile

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/shadowChat1.0/node_modules/@eslint/js/index.js' imported from /workspace/shadowChat1.0/eslint.config.js)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603ceeb3708327aef0dd8b350265f0