### PR TITLE
Add reusable emoji picker hook

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -2,9 +2,10 @@ import React, { useState, useRef, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { Send, Smile, Paperclip, Command } from 'lucide-react'
 import { useTyping } from '../../hooks/useTyping'
+import { useEmojiPicker } from '../../hooks/useEmojiPicker'
+import type { EmojiClickData } from 'emoji-picker-react'
 import { Button } from '../ui/Button'
 import { processSlashCommand, slashCommands } from '../../lib/utils'
-import toast from 'react-hot-toast'
 
 interface MessageInputProps {
   onSendMessage: (content: string) => void
@@ -19,7 +20,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
 }) => {
   const [message, setMessage] = useState('')
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
-  const [EmojiPicker, setEmojiPicker] = useState<React.ComponentType<any> | null>(null)
+  const EmojiPicker = useEmojiPicker(showEmojiPicker)
   const [showSlashCommands, setShowSlashCommands] = useState(false)
   const { startTyping, stopTyping } = useTyping('general')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -46,20 +47,6 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  useEffect(() => {
-    const loadPicker = async () => {
-      try {
-        const mod = await import('emoji-picker-react')
-        setEmojiPicker(() => mod.default)
-      } catch (error) {
-        console.error('❌ MessageInput: Failed to load emoji picker:', error)
-        toast.error('Failed to load emoji picker')
-      }
-    }
-    if (showEmojiPicker && !EmojiPicker) {
-      loadPicker()
-    }
-  }, [showEmojiPicker, EmojiPicker])
 
   // Auto-resize textarea
   useEffect(() => {
@@ -112,7 +99,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }
 
-  const insertEmoji = (emojiData: any) => {
+  const insertEmoji = (emojiData: EmojiClickData) => {
     const emoji = emojiData.emoji
     setMessage(prev => prev + emoji)
     setShowEmojiPicker(false)

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -14,10 +14,11 @@ import {
 } from 'lucide-react'
 import { Avatar } from '../ui/Avatar'
 import { Button } from '../ui/Button'
+import { useEmojiPicker } from '../../hooks/useEmojiPicker'
 import { formatTime, shouldGroupMessage, cn } from '../../lib/utils'
 import { toggleReaction, type Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
-import toast from 'react-hot-toast'
+import type { EmojiClickData } from 'emoji-picker-react'
 
 const QUICK_REACTIONS = ['👍', '❤️', '😂', '🎉', '🙏']
 
@@ -37,7 +38,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     const [editContent, setEditContent] = useState(message.content)
     const [showActions, setShowActions] = useState(false)
     const [showReactionPicker, setShowReactionPicker] = useState(false)
-    const [EmojiPicker, setEmojiPicker] = useState<React.ComponentType<any> | null>(null)
+    const EmojiPicker = useEmojiPicker(showReactionPicker)
     const reactionPickerRef = useRef<HTMLDivElement>(null)
     const actionsRef = useRef<HTMLDivElement>(null)
 
@@ -54,7 +55,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       await toggleReaction(message.id, emoji, false)
     }
 
-    const handleReactionSelect = (emojiData: any) => {
+    const handleReactionSelect = (emojiData: EmojiClickData) => {
       const emoji = emojiData.emoji
       handleReaction(emoji)
       setShowReactionPicker(false)
@@ -74,20 +75,6 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       return () => document.removeEventListener('mousedown', handleClick)
     }, [])
 
-    useEffect(() => {
-      const loadPicker = async () => {
-        try {
-          const mod = await import('emoji-picker-react')
-          setEmojiPicker(() => mod.default)
-        } catch (error) {
-          console.error('❌ MessageItem: Failed to load emoji picker:', error)
-          toast.error('Failed to load emoji picker')
-        }
-      }
-      if (showReactionPicker && !EmojiPicker) {
-        loadPicker()
-      }
-    }, [showReactionPicker, EmojiPicker])
 
     useEffect(() => {
       if (!showReactionPicker) return

--- a/src/hooks/useEmojiPicker.ts
+++ b/src/hooks/useEmojiPicker.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import type { EmojiPickerProps } from 'emoji-picker-react'
+
+export type EmojiPickerComponent = React.ComponentType<EmojiPickerProps>
+
+export function useEmojiPicker(shouldLoad: boolean): EmojiPickerComponent | null {
+  const [EmojiPicker, setEmojiPicker] = useState<EmojiPickerComponent | null>(null)
+
+  useEffect(() => {
+    if (!shouldLoad || EmojiPicker) return
+
+    let mounted = true
+    import('emoji-picker-react')
+      .then(mod => {
+        if (mounted) {
+          setEmojiPicker(() => mod.default)
+        }
+      })
+      .catch(error => {
+        console.error('Failed to load emoji picker:', error)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [shouldLoad, EmojiPicker])
+
+  return EmojiPicker
+}


### PR DESCRIPTION
## Summary
- add `useEmojiPicker` for lazy loading emoji picker
- simplify emoji picker logic in `MessageInput` and `MessageItem`
- use `EmojiClickData` type in handlers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603cee338883279ecb120050b21504