### PR TITLE
Adjust message spacing based on reactions

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -115,7 +115,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="group flex space-x-3 mt-2"
+        className={cn('group flex space-x-3', hasReactions ? 'mt-3' : 'mt-1')}
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -136,7 +136,11 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     }
 
     return (
-      <div ref={rowRef} style={style} className={cn('py-1', hasReactions && 'pb-6')}>
+      <div
+        ref={rowRef}
+        style={style}
+        className={cn(hasReactions ? 'py-2 pb-6' : 'py-0.5')}
+      >
         <MessageItem
           message={item.message as ChatMessage}
           previousMessage={item.prev}


### PR DESCRIPTION
## Summary
- tighten `MessageItem` spacing when no reactions are present
- add extra padding in `MessageList` rows only when reactions exist

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603dcdc4e883278b2c22c630bd0dec