### PR TITLE
Add useEmojiPicker hook

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -4,8 +4,8 @@ import { Send, Smile, Paperclip, Command } from 'lucide-react'
 import { useTyping } from '../../hooks/useTyping'
 import { Button } from '../ui/Button'
 import { processSlashCommand, slashCommands } from '../../lib/utils'
-import toast from 'react-hot-toast'
 import type { EmojiPickerProps, EmojiClickData } from '../../types'
+import { useEmojiPicker } from '../../hooks/useEmojiPicker'
 
 interface MessageInputProps {
   onSendMessage: (content: string) => void
@@ -20,9 +20,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
 }) => {
   const [message, setMessage] = useState('')
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
-  const [EmojiPicker, setEmojiPicker] = useState<
-    React.ComponentType<EmojiPickerProps> | null
-  >(null)
+  const EmojiPicker = useEmojiPicker(showEmojiPicker)
   const [showSlashCommands, setShowSlashCommands] = useState(false)
   const { startTyping, stopTyping } = useTyping('general')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -49,20 +47,6 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  useEffect(() => {
-    const loadPicker = async () => {
-      try {
-        const mod = await import('emoji-picker-react')
-        setEmojiPicker(() => mod.default)
-      } catch (error) {
-        console.error('❌ MessageInput: Failed to load emoji picker:', error)
-        toast.error('Failed to load emoji picker')
-      }
-    }
-    if (showEmojiPicker && !EmojiPicker) {
-      loadPicker()
-    }
-  }, [showEmojiPicker, EmojiPicker])
 
   // Auto-resize textarea
   useEffect(() => {

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -18,7 +18,8 @@ import { formatTime, shouldGroupMessage, cn } from '../../lib/utils'
 import { toggleReaction, type Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import toast from 'react-hot-toast'
-import type { EmojiPickerProps, EmojiClickData } from '../../types'
+import type { EmojiClickData } from '../../types'
+import { useEmojiPicker } from '../../hooks/useEmojiPicker'
 
 const QUICK_REACTIONS = ['👍', '❤️', '😂', '🎉', '🙏']
 
@@ -38,9 +39,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     const [editContent, setEditContent] = useState(message.content)
     const [showActions, setShowActions] = useState(false)
     const [showReactionPicker, setShowReactionPicker] = useState(false)
-    const [EmojiPicker, setEmojiPicker] = useState<
-      React.ComponentType<EmojiPickerProps> | null
-    >(null)
+    const EmojiPicker = useEmojiPicker(showReactionPicker)
     const reactionPickerRef = useRef<HTMLDivElement>(null)
     const actionsRef = useRef<HTMLDivElement>(null)
 
@@ -83,20 +82,6 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       return () => document.removeEventListener('mousedown', handleClick)
     }, [])
 
-    useEffect(() => {
-      const loadPicker = async () => {
-        try {
-          const mod = await import('emoji-picker-react')
-          setEmojiPicker(() => mod.default)
-        } catch (error) {
-          console.error('❌ MessageItem: Failed to load emoji picker:', error)
-          toast.error('Failed to load emoji picker')
-        }
-      }
-      if (showReactionPicker && !EmojiPicker) {
-        loadPicker()
-      }
-    }, [showReactionPicker, EmojiPicker])
 
     useEffect(() => {
       if (!showReactionPicker) return

--- a/src/hooks/useEmojiPicker.ts
+++ b/src/hooks/useEmojiPicker.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
+import type { EmojiPickerProps } from '../types'
+
+/**
+ * Lazily load the `emoji-picker-react` component.
+ *
+ * @param load When true, start importing the picker library.
+ * @returns The loaded picker component or `null` while loading.
+ */
+export const useEmojiPicker = (
+  load: boolean
+): React.ComponentType<EmojiPickerProps> | null => {
+  const [Picker, setPicker] = useState<React.ComponentType<EmojiPickerProps> | null>(null)
+
+  useEffect(() => {
+    if (!load || Picker) return
+    const loadPicker = async () => {
+      try {
+        const mod = await import('emoji-picker-react')
+        setPicker(() => mod.default)
+      } catch (error) {
+        console.error('❌ useEmojiPicker: Failed to load emoji picker:', error)
+        toast.error('Failed to load emoji picker')
+      }
+    }
+    loadPicker()
+  }, [load, Picker])
+
+  return Picker
+}


### PR DESCRIPTION
## Summary
- add `useEmojiPicker` hook for lazy loading of emoji-picker-react
- simplify emoji picker loading in `MessageInput` and `MessageItem`
- clean up unused types and imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603e57c6808327867afc95084d0191