### PR TITLE
Adjust spacing for reacted messages

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -118,7 +118,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className={cn('group flex space-x-3', hasReactions ? 'mt-3' : 'mt-1')}
+        className={cn('group flex space-x-3', hasReactions ? 'mt-4' : 'mt-2')}
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -139,7 +139,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
       <div
         ref={rowRef}
         style={style}
-        className={cn(hasReactions ? 'py-2 pb-6' : 'py-0.5')}
+        className={cn(hasReactions ? 'py-3 pb-8' : 'py-1')}
       >
         <MessageItem
           message={item.message as ChatMessage}


### PR DESCRIPTION
## Summary
- add a bit more padding under messages that have reactions
- bump up margin on MessageItem when reactions are present

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603f2596748327bfc12bc944613c8f