### PR TITLE
Fix reaction updates

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -15,7 +15,7 @@ import {
 import { Avatar } from '../ui/Avatar'
 import { Button } from '../ui/Button'
 import { formatTime, shouldGroupMessage, cn } from '../../lib/utils'
-import { toggleReaction, type Message } from '../../lib/supabase'
+import type { Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import toast from 'react-hot-toast'
 import type { EmojiPickerProps, EmojiClickData } from '../../types'
@@ -29,10 +29,11 @@ interface MessageItemProps {
   onEdit: (messageId: string, content: string) => Promise<void>
   onDelete: (messageId: string) => Promise<void>
   onTogglePin: (messageId: string) => Promise<void>
+  onToggleReaction: (messageId: string, emoji: string) => Promise<void>
 }
 
 export const MessageItem: React.FC<MessageItemProps> = React.memo(
-  ({ message, previousMessage, onReply, onEdit, onDelete, onTogglePin }) => {
+  ({ message, previousMessage, onReply, onEdit, onDelete, onTogglePin, onToggleReaction }) => {
     const { profile } = useAuth()
     const [isEditing, setIsEditing] = useState(false)
     const [editContent, setEditContent] = useState(message.content)
@@ -54,7 +55,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     }
 
     const handleReaction = async (emoji: string) => {
-      await toggleReaction(message.id, emoji, false)
+      await onToggleReaction(message.id, emoji)
     }
 
     const handleReactionSelect = (emojiData: EmojiClickData) => {

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -21,7 +21,7 @@ interface MessageListProps {
 }
 
 export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
-  const { messages, loading, editMessage, deleteMessage, togglePin } = useMessages()
+  const { messages, loading, editMessage, deleteMessage, togglePin, toggleReaction } = useMessages()
   const { typingUsers } = useTyping('general')
   
   
@@ -148,10 +148,11 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
           onEdit={handleEdit}
           onDelete={handleDelete}
           onTogglePin={togglePin}
+          onToggleReaction={toggleReaction}
         />
       </div>
     )
-  }, [items, onReply, handleEdit, handleDelete, togglePin])
+  }, [items, onReply, handleEdit, handleDelete, togglePin, toggleReaction])
 
   return (
     <div


### PR DESCRIPTION
## Summary
- update reactions in `useMessages` optimistically
- pass `onToggleReaction` through `MessageList` to `MessageItem`
- call the new handler from `MessageItem`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603f39913c832792a432c55298ae1e