### PR TITLE
Fix mobile nav spacing

### DIFF
--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -15,7 +15,7 @@ export function MobileNav({ currentView, onViewChange }: MobileNavProps) {
   ]
 
   return (
-    <nav className="md:hidden fixed bottom-0 inset-x-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 z-50">
+    <nav className="md:hidden fixed bottom-0 inset-x-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 h-16 z-50">
       <ul className="flex justify-around">
         {navItems.map(item => (
           <li key={item.id}>


### PR DESCRIPTION
## Summary
- explicitly set height on `MobileNav` so its size matches the page padding

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860406aa5808327aa36068b9ba694fa