### PR TITLE
Fix message spacing with reactions

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -104,7 +104,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className={cn('group flex space-x-3', hasReactions ? 'mt-4' : 'mt-2')}
+        className="group flex space-x-3 mt-2"
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -139,7 +139,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
       <div
         ref={rowRef}
         style={style}
-        className={cn(hasReactions ? 'py-3 pb-8' : 'py-1')}
+        className={cn('py-1', hasReactions && 'pb-6')}
       >
         <MessageItem
           message={item.message as ChatMessage}


### PR DESCRIPTION
## Summary
- normalize MessageItem spacing
- reduce padding when showing reactions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860423ff750832798cc63f49ecfb1b4