### PR TITLE
fix: keep message actions menu open

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -220,7 +220,6 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
           <AnimatePresence>
             {showActions && (
               <div
-                onMouseLeave={() => setShowActions(false)}
                 className="absolute right-0 top-full mt-1 p-2 -m-2"
               >
                 <motion.div


### PR DESCRIPTION
## Summary
- keep message actions menu from closing on mouse leave

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686043b533348327825d42fad883fe4a