### PR TITLE
Fix message grouping avatar bug

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -64,9 +64,13 @@ export function groupMessagesByDate(messages: ChatMessage[]) {
 
 export function shouldGroupMessage(current: ChatMessage, previous?: ChatMessage) {
   if (!previous) return false
-  
+
+  // Determine ids for chat or DM messages
+  const currentId = (current as any).user_id ?? (current as any).sender_id
+  const previousId = (previous as any).user_id ?? (previous as any).sender_id
+
   // Don't group if different users
-  if (current.user_id !== previous.user_id && current.sender_id !== previous.sender_id) return false
+  if (currentId !== previousId) return false
   
   // Don't group if more than 5 minutes apart
   const currentTime = new Date(current.created_at).getTime()

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,29 @@
+import { shouldGroupMessage } from '../src/lib/utils';
+
+describe('shouldGroupMessage', () => {
+  const baseTime = '2020-01-01T00:00:00Z';
+
+  it('returns false for different users', () => {
+    const prev = { id: '1', user_id: 'u1', created_at: baseTime } as any;
+    const current = { id: '2', user_id: 'u2', created_at: '2020-01-01T00:01:00Z' } as any;
+    expect(shouldGroupMessage(current, prev)).toBe(false);
+  });
+
+  it('returns true for same user within 5 minutes', () => {
+    const prev = { id: '1', user_id: 'u1', created_at: baseTime } as any;
+    const current = { id: '2', user_id: 'u1', created_at: '2020-01-01T00:04:00Z' } as any;
+    expect(shouldGroupMessage(current, prev)).toBe(true);
+  });
+
+  it('returns false when more than 5 minutes apart', () => {
+    const prev = { id: '1', user_id: 'u1', created_at: baseTime } as any;
+    const current = { id: '2', user_id: 'u1', created_at: '2020-01-01T00:06:00Z' } as any;
+    expect(shouldGroupMessage(current, prev)).toBe(false);
+  });
+
+  it('handles DM messages', () => {
+    const prev = { id: '1', sender_id: 'u1', created_at: baseTime } as any;
+    const current = { id: '2', sender_id: 'u1', created_at: '2020-01-01T00:01:00Z' } as any;
+    expect(shouldGroupMessage(current, prev)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- fix logic of shouldGroupMessage to compare message owners correctly
- add unit tests for shouldGroupMessage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860440ff080832792095869e81a5f7f