### PR TITLE
Combine mobile chat input and nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,15 +64,33 @@ function App() {
   const renderCurrentView = () => {
     switch (currentView) {
       case 'chat':
-        return <ChatView onToggleSidebar={toggleSidebar} />
+        return (
+          <ChatView
+            onToggleSidebar={toggleSidebar}
+            currentView={currentView}
+            onViewChange={setCurrentView}
+          />
+        )
       case 'dms':
-        return <DirectMessagesView onToggleSidebar={toggleSidebar} />
+        return (
+          <DirectMessagesView
+            onToggleSidebar={toggleSidebar}
+            currentView={currentView}
+            onViewChange={setCurrentView}
+          />
+        )
       case 'profile':
         return <ProfileView onToggleSidebar={toggleSidebar} />
       case 'settings':
         return <SettingsView onToggleSidebar={toggleSidebar} />
       default:
-        return <ChatView onToggleSidebar={toggleSidebar} />
+        return (
+          <ChatView
+            onToggleSidebar={toggleSidebar}
+            currentView={currentView}
+            onViewChange={setCurrentView}
+          />
+        )
     }
   }
 
@@ -96,12 +114,18 @@ function App() {
             />
           )}
 
-          <main className="flex-1 flex flex-col min-w-0 pb-16 md:pb-0">
+          <main
+            className={`flex-1 flex flex-col min-w-0 ${
+              currentView === 'chat' || currentView === 'dms' ? 'pb-32' : 'pb-16'
+            } md:pb-0`}
+          >
             {renderCurrentView()}
           </main>
 
           {/* Mobile bottom navigation */}
-          <MobileNav currentView={currentView} onViewChange={setCurrentView} />
+          {currentView !== 'chat' && currentView !== 'dms' && (
+            <MobileNav currentView={currentView} onViewChange={setCurrentView} />
+          )}
 
           <Toaster
             position="top-right"

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -4,13 +4,16 @@ import { Hash, Users, Pin } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
 import { MessageList } from './MessageList'
 import { MessageInput } from './MessageInput'
+import { MobileChatFooter } from '../layout/MobileChatFooter'
 import toast from 'react-hot-toast'
 
 interface ChatViewProps {
   onToggleSidebar: () => void
+  currentView: 'chat' | 'dms' | 'profile' | 'settings'
+  onViewChange: (view: 'chat' | 'dms' | 'profile' | 'settings') => void
 }
 
-export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar }) => {
+export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView, onViewChange }) => {
   const { sendMessage, messages, loading } = useMessages()
 
   const handleSendMessage = async (content: string) => {
@@ -65,11 +68,25 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar }) => {
       {/* Messages */}
       <MessageList />
 
-      {/* Message Input */}
-      <MessageInput
-        onSendMessage={handleSendMessage}
-        placeholder="Type a message in #general..."
-      />
+      {/* Desktop Message Input */}
+      <div className="hidden md:block">
+        <MessageInput
+          onSendMessage={handleSendMessage}
+          placeholder="Type a message in #general..."
+        />
+      </div>
+
+      {/* Mobile Message Input with Navigation */}
+      <MobileChatFooter
+        currentView={currentView}
+        onViewChange={onViewChange}
+      >
+        <MessageInput
+          onSendMessage={handleSendMessage}
+          placeholder="Type a message in #general..."
+          className="border-t"
+        />
+      </MobileChatFooter>
     </motion.div>
   )
 }

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -11,12 +11,14 @@ interface MessageInputProps {
   onSendMessage: (content: string) => void
   placeholder?: string
   disabled?: boolean
+  className?: string
 }
 
 export const MessageInput: React.FC<MessageInputProps> = ({
   onSendMessage,
   placeholder = 'Type a message...',
-  disabled = false
+  disabled = false,
+  className = ''
 }) => {
   const [message, setMessage] = useState('')
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
@@ -115,7 +117,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   }
 
   return (
-    <div className="relative p-4 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+    <div
+      className={`relative p-4 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 ${className}`}
+    >
       {/* Slash Commands Dropdown */}
       {showSlashCommands && (
         <motion.div

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -14,14 +14,17 @@ import { Avatar } from '../ui/Avatar'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { MessageInput } from '../chat/MessageInput'
+import { MobileChatFooter } from '../layout/MobileChatFooter'
 import { formatTime, shouldGroupMessage } from '../../lib/utils'
 import toast from 'react-hot-toast'
 
 interface DirectMessagesViewProps {
   onToggleSidebar: () => void
+  currentView: 'chat' | 'dms' | 'profile' | 'settings'
+  onViewChange: (view: 'chat' | 'dms' | 'profile' | 'settings') => void
 }
 
-export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggleSidebar }) => {
+export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggleSidebar, currentView, onViewChange }) => {
   const { profile } = useAuth()
   const {
     conversations,
@@ -312,11 +315,25 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
               })}
             </div>
 
-            {/* Message Input */}
-            <MessageInput
-              onSendMessage={handleSendMessage}
-              placeholder={`Message @${currentConv.other_user?.username}...`}
-            />
+            {/* Desktop Message Input */}
+            <div className="hidden md:block">
+              <MessageInput
+                onSendMessage={handleSendMessage}
+                placeholder={`Message @${currentConv.other_user?.username}...`}
+              />
+            </div>
+
+            {/* Mobile Message Input with Navigation */}
+            <MobileChatFooter
+              currentView={currentView}
+              onViewChange={onViewChange}
+            >
+              <MessageInput
+                onSendMessage={handleSendMessage}
+                placeholder={`Message @${currentConv.other_user?.username}...`}
+                className="border-t"
+              />
+            </MobileChatFooter>
           </>
         ) : (
           <div className="flex-1 flex items-center justify-center">

--- a/src/components/layout/MobileChatFooter.tsx
+++ b/src/components/layout/MobileChatFooter.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { MobileNav } from './MobileNav'
+
+interface MobileChatFooterProps {
+  currentView: 'chat' | 'dms' | 'profile' | 'settings'
+  onViewChange: (view: 'chat' | 'dms' | 'profile' | 'settings') => void
+  children: React.ReactNode
+}
+
+export function MobileChatFooter({ currentView, onViewChange, children }: MobileChatFooterProps) {
+  return (
+    <div className="md:hidden fixed bottom-0 inset-x-0 bg-white dark:bg-gray-800 z-50 flex flex-col">
+      {children}
+      <div className="border-t border-gray-200 dark:border-gray-700" />
+      <MobileNav currentView={currentView} onViewChange={onViewChange} className="" />
+    </div>
+  )
+}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -4,9 +4,10 @@ import { MessageSquare, Users, User, Settings } from 'lucide-react'
 interface MobileNavProps {
   currentView: 'chat' | 'dms' | 'profile' | 'settings'
   onViewChange: (view: 'chat' | 'dms' | 'profile' | 'settings') => void
+  className?: string
 }
 
-export function MobileNav({ currentView, onViewChange }: MobileNavProps) {
+export function MobileNav({ currentView, onViewChange, className }: MobileNavProps) {
   const navItems = [
     { id: 'chat' as const, icon: MessageSquare, label: 'Chat' },
     { id: 'dms' as const, icon: Users, label: 'DMs' },
@@ -15,7 +16,11 @@ export function MobileNav({ currentView, onViewChange }: MobileNavProps) {
   ]
 
   return (
-    <nav className="md:hidden fixed bottom-0 inset-x-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 h-16 z-50">
+    <nav
+      className={`md:hidden bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 h-16 ${
+        className || 'fixed bottom-0 inset-x-0 z-50'
+      }`}
+    >
       <ul className="flex justify-around">
         {navItems.map(item => (
           <li key={item.id}>


### PR DESCRIPTION
## Summary
- accept optional className prop for `MobileNav`
- accept optional className prop for `MessageInput`
- add `MobileChatFooter` component that holds input and nav
- update chat and DM views to use the combined footer on mobile
- adjust app layout to avoid double footers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604526e114832789aced99ac1c8089