### PR TITLE
Add ErrorBoundary component

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ReactNode, ErrorInfo } from 'react';
+import { Button } from './ui/Button';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  private handleReset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="h-screen flex flex-col items-center justify-center space-y-4">
+          <p className="text-lg">Something went wrong.</p>
+          <Button onClick={this.handleReset}>Try again</Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
 import { AuthProvider } from './hooks/useAuth';
 import { ThemeProvider } from './hooks/useTheme';
@@ -9,7 +10,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
       <ThemeProvider>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
       </ThemeProvider>
     </AuthProvider>
   </StrictMode>

--- a/tests/ErrorBoundary.test.tsx
+++ b/tests/ErrorBoundary.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import ErrorBoundary from '../src/components/ErrorBoundary';
+
+test('displays fallback when child throws', () => {
+  const Bomb = () => {
+    throw new Error('Boom');
+  };
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  render(
+    <ErrorBoundary>
+      <Bomb />
+    </ErrorBoundary>
+  );
+
+  expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+  (console.error as jest.Mock).mockRestore();
+});
+
+test('renders children after retry', () => {
+  const Bomb = ({ shouldThrow }: { shouldThrow: boolean }) => {
+    if (shouldThrow) throw new Error('Boom');
+    return <div>Child</div>;
+  };
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  const { rerender } = render(
+    <ErrorBoundary>
+      <Bomb shouldThrow={true} />
+    </ErrorBoundary>
+  );
+
+  expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+  rerender(
+    <ErrorBoundary>
+      <Bomb shouldThrow={false} />
+    </ErrorBoundary>
+  );
+
+  expect(screen.getByText('Child')).toBeInTheDocument();
+  (console.error as jest.Mock).mockRestore();
+});


### PR DESCRIPTION
## Summary
- create `ErrorBoundary` component that logs errors and displays a fallback with a retry button
- wrap `<App />` with the new boundary in `src/main.tsx`
- add tests verifying that errors from children are caught

## Testing
- `./setup.sh` *(fails: internet is disabled)*
- `npm test` *(fails: jest not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6860458457588327bed625226ab23a75