### PR TITLE
Add tests for useTheme hook

### DIFF
--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -25,6 +25,8 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   useEffect(() => {
     document.documentElement.dataset.scheme = scheme
+    document.documentElement.classList.remove('indigo', 'teal', 'rose')
+    document.documentElement.classList.add(scheme)
     localStorage.setItem('colorScheme', scheme)
   }, [scheme])
 

--- a/tests/useTheme.test.tsx
+++ b/tests/useTheme.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook, act } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../src/hooks/useTheme';
+
+beforeEach(() => {
+  document.documentElement.className = '';
+  document.documentElement.dataset.scheme = '';
+  localStorage.clear();
+});
+
+test('defaults to indigo scheme', () => {
+  const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+  expect(result.current.scheme).toBe('indigo');
+  expect(document.documentElement.classList.contains('indigo')).toBe(true);
+});
+
+test('changing scheme updates document.classList', () => {
+  const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+
+  act(() => {
+    result.current.setScheme('teal');
+  });
+
+  expect(document.documentElement.classList.contains('teal')).toBe(true);
+  expect(document.documentElement.classList.contains('indigo')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add tests verifying theme defaults and classlist updates
- update useTheme to manipulate classList when scheme changes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604588a7188327bdef8e784425c123