### PR TITLE
Fix initial message history loading

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -111,23 +111,6 @@ function useProvideMessages(): MessagesContextValue {
   const channelRef = useRef<RealtimeChannel | null>(null);
   const subscribeRef = useRef<() => RealtimeChannel>();
 
-  const handleVisible = useCallback(() => {
-    const channel = channelRef.current;
-    if (channel && channel.state !== 'joined') {
-      if (DEBUG) {
-        console.log('🌀 Resubscribing channel due to state', channel.state)
-      }
-      supabase.removeChannel(channel)
-      const newChannel = subscribeRef.current?.()
-      if (newChannel) {
-        channelRef.current = newChannel
-      }
-    }
-    fetchMessages()
-  }, [fetchMessages])
-
-  useVisibilityRefresh(handleVisible)
-
   const fetchMessages = useCallback(async () => {
     try {
       const { data, error } = await supabase
@@ -157,6 +140,23 @@ function useProvideMessages(): MessagesContextValue {
       setLoading(false);
     }
   }, []);
+
+  const handleVisible = useCallback(() => {
+    const channel = channelRef.current;
+    if (channel && channel.state !== 'joined') {
+      if (DEBUG) {
+        console.log('🌀 Resubscribing channel due to state', channel.state)
+      }
+      supabase.removeChannel(channel)
+      const newChannel = subscribeRef.current?.()
+      if (newChannel) {
+        channelRef.current = newChannel
+      }
+    }
+    fetchMessages()
+  }, [fetchMessages])
+
+  useVisibilityRefresh(handleVisible)
 
   // Fetch initial messages
   useEffect(() => {


### PR DESCRIPTION
## Summary
- define `fetchMessages` before it's first used

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860477f571c8327ba48d1f0f11a871a