### PR TITLE
Fix mobile chat entry overlapping footer

### DIFF
--- a/src/components/layout/MobileChatFooter.tsx
+++ b/src/components/layout/MobileChatFooter.tsx
@@ -12,7 +12,11 @@ export function MobileChatFooter({ currentView, onViewChange, children }: Mobile
     <div className="md:hidden fixed bottom-0 inset-x-0 bg-white dark:bg-gray-800 z-50 flex flex-col">
       {children}
       <div className="border-t border-gray-200 dark:border-gray-700" />
-      <MobileNav currentView={currentView} onViewChange={onViewChange} className="" />
+      <MobileNav
+        currentView={currentView}
+        onViewChange={onViewChange}
+        className="static"
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- update `MobileChatFooter` so the bottom nav isn't fixed when inside the footer

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6860487b47f48327adcd3797a4912ebb