### PR TITLE
Cache chat history on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Deploy to Netlify or Vercel on merge to main
 Optional: Slack/Discord webhook alerts
 --- ## Future Features
 Push notifications (web + mobile)
-Offline drafts and local caching
+Offline drafts and local caching (message history cached on load)
 Threaded replies and collapsible chains
 Video or voice rooms using WebRTC
 Third-party plugin support

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -104,8 +104,22 @@ interface MessagesContextValue {
 const MessagesContext = createContext<MessagesContextValue | undefined>(undefined);
 
 function useProvideMessages(): MessagesContextValue {
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [loading, setLoading] = useState(true);
+  const initialMessages = (() => {
+    if (typeof localStorage !== 'undefined') {
+      try {
+        const stored = localStorage.getItem('chatHistory');
+        if (stored) {
+          return JSON.parse(stored) as Message[];
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+    return [] as Message[];
+  })();
+
+  const [messages, setMessages] = useState<Message[]>(initialMessages);
+  const [loading, setLoading] = useState(initialMessages.length === 0);
   const [sending, setSending] = useState(false);
   const { user } = useAuth();
   const channelRef = useRef<RealtimeChannel | null>(null);
@@ -127,10 +141,20 @@ function useProvideMessages(): MessagesContextValue {
       } else if (data) {
         setMessages(prev => {
           if (prev.length === 0) {
+            if (typeof localStorage !== 'undefined') {
+              try {
+                localStorage.setItem('chatHistory', JSON.stringify(data));
+              } catch {}
+            }
             return data as Message[];
           }
           const ids = new Set(prev.map(m => m.id));
           const merged = [...prev, ...data.filter(m => !ids.has(m.id))];
+          if (typeof localStorage !== 'undefined') {
+            try {
+              localStorage.setItem('chatHistory', JSON.stringify(merged));
+            } catch {}
+          }
           return merged;
         });
       }
@@ -162,6 +186,17 @@ function useProvideMessages(): MessagesContextValue {
   useEffect(() => {
     fetchMessages();
   }, [fetchMessages]);
+
+  // Persist messages to localStorage whenever they change
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.setItem('chatHistory', JSON.stringify(messages));
+      } catch {
+        // ignore storage errors
+      }
+    }
+  }, [messages]);
 
   // Subscribe to real-time updates
   useEffect(() => {


### PR DESCRIPTION
## Summary
- persist chat history in `localStorage`
- load cached messages on startup so history appears immediately
- document caching in README

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860491827a88327aa404841cb096cf6