### PR TITLE
Add extra bottom space for message list

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -182,7 +182,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
   return (
     <div
       ref={containerRef}
-      className="relative flex-1 overflow-y-hidden overflow-x-visible p-4 pb-8"
+      className="relative flex-1 overflow-y-hidden overflow-x-visible p-4 pb-16"
     >
       {messages.some(m => m.pinned) && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">


### PR DESCRIPTION
## Summary
- increase bottom padding in `MessageList` so last chat message isn't flush with the bottom

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604b8db8008327a75feecc41518861