### PR TITLE
Shift chat messages slightly to the right

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -182,7 +182,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
   return (
     <div
       ref={containerRef}
-      className="relative flex-1 overflow-y-hidden overflow-x-visible p-4 pb-8"
+      className="relative flex-1 overflow-y-hidden overflow-x-visible p-4 pb-8 pl-6"
     >
       {messages.some(m => m.pinned) && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -269,7 +269,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             </div>
 
             {/* Messages */}
-            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+            <div className="flex-1 overflow-y-auto p-4 pl-6 space-y-3">
               {messages.map((message, index) => {
                 const previousMessage = messages[index - 1]
                 const isGrouped = shouldGroupMessage(message, previousMessage)


### PR DESCRIPTION
## Summary
- add extra left padding in chat view
- indent direct messages

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604bb656108327810c2972a3b30dc4