### PR TITLE
Remove padding changes when showing reactions

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -98,7 +98,6 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       return () => document.removeEventListener('mousedown', handleClick)
     }, [showReactionPicker])
 
-    const hasReactions = !!message.reactions && Object.keys(message.reactions).length > 0
 
     return (
       <motion.div
@@ -165,14 +164,13 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
               <div className="relative group/message inline-block max-w-full">
                 <div
                   className={cn(
-                    'relative bg-gray-100 dark:bg-gray-700 rounded-xl px-3 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors break-words',
-                    hasReactions ? 'pt-5 pb-2' : 'py-2'
+                    'relative bg-gray-100 dark:bg-gray-700 rounded-xl px-3 py-2 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors break-words space-y-1'
                   )}
                 >
                   <MessageReactions
                     message={message}
                     onReact={handleReaction}
-                    className="absolute top-1 left-2 text-[0.65rem]"
+                    className="text-[0.65rem]"
                   />
                   {message.content}
                 </div>

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -47,10 +47,6 @@ const MessageListRow: React.FC<MessageListRowProps> = ({ index, style, data }) =
     }
   }, [item, index, setSize])
 
-  const hasReactions =
-    item.type === 'message' &&
-    item.message?.reactions &&
-    Object.keys(item.message.reactions).length > 0
 
   if (item.type === 'header') {
     return (
@@ -72,7 +68,7 @@ const MessageListRow: React.FC<MessageListRowProps> = ({ index, style, data }) =
     <div
       ref={rowRef}
       style={style}
-      className={cn('py-1', hasReactions && 'pb-6')}
+      className="py-1"
     >
       <MessageItem
         message={item.message as ChatMessage}

--- a/src/components/chat/PinnedMessageItem.tsx
+++ b/src/components/chat/PinnedMessageItem.tsx
@@ -44,21 +44,14 @@ export const PinnedMessageItem: React.FC<PinnedMessageItemProps> = ({
     setShowPicker(false)
   }
 
-  const hasReactions = !!message.reactions && Object.keys(message.reactions).length > 0
-
   return (
-    <div
-      className={cn(
-        'relative p-2 rounded-md bg-yellow-100/60 dark:bg-yellow-800/40 flex items-start',
-        hasReactions && 'pt-6'
-      )}
-    >
-      <MessageReactions
-        message={message}
-        onReact={handleReaction}
-        className="absolute top-1 left-2 text-[0.65rem]"
-      />
-      <div className="flex-1 min-w-0">
+    <div className="relative p-2 rounded-md bg-yellow-100/60 dark:bg-yellow-800/40 flex items-start">
+      <div className="flex-1 min-w-0 space-y-1">
+        <MessageReactions
+          message={message}
+          onReact={handleReaction}
+          className="text-[0.65rem]"
+        />
         <div className="text-sm text-yellow-800 dark:text-yellow-200 break-words">
           <strong>{message.user?.display_name}:</strong> {message.content}
         </div>


### PR DESCRIPTION
## Summary
- render message reactions inline inside the bubble
- remove conditional padding from messages and pinned messages
- keep message list rows at a constant height

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68604b66a52c832788870b8e969d11ec