### PR TITLE
Shift messages slightly right

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -104,7 +104,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="group flex space-x-3 mt-2"
+        className="group flex space-x-3 mt-2 ml-2"
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">

--- a/src/components/chat/PinnedMessageItem.tsx
+++ b/src/components/chat/PinnedMessageItem.tsx
@@ -49,7 +49,7 @@ export const PinnedMessageItem: React.FC<PinnedMessageItemProps> = ({
   return (
     <div
       className={cn(
-        'relative p-2 rounded-md bg-yellow-100/60 dark:bg-yellow-800/40 flex items-start',
+        'relative p-2 rounded-md bg-yellow-100/60 dark:bg-yellow-800/40 flex items-start ml-2',
         hasReactions && 'pt-6'
       )}
     >


### PR DESCRIPTION
## Summary
- shift `MessageItem` container right with `ml-2`
- shift pinned message rows right as well

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604c792ed88327b78807d185bb03e1