### PR TITLE
Shift chat rows right

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -103,7 +103,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="group flex space-x-3 mt-2"
+        className="group flex space-x-3 mt-2 ml-2"
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">


### PR DESCRIPTION
## Summary
- nudge each chat message row to the right for a subtle offset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604d53f5688327b44c87fa2c241466