### PR TITLE
Fix chat area scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,7 @@ function App() {
   return (
     <AuthGuard>
       <MessagesProvider>
-        <div className="h-screen flex flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
+        <div className="h-screen overflow-hidden flex flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
           <Sidebar
             currentView={currentView}
             onViewChange={setCurrentView}
@@ -114,11 +114,7 @@ function App() {
             />
           )}
 
-          <main
-            className={`flex-1 flex flex-col min-w-0 ${
-              currentView === 'chat' || currentView === 'dms' ? 'pb-32' : 'pb-16'
-            } md:pb-0`}
-          >
+          <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
             {renderCurrentView()}
           </main>
 

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -178,7 +178,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
   return (
     <div
       ref={containerRef}
-      className="relative flex-1 overflow-y-hidden overflow-x-visible p-4 pb-24"
+      className="relative flex-1 overflow-y-hidden overflow-x-visible p-4 pb-32"
     >
       {messages.some(m => m.pinned) && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -269,7 +269,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             </div>
 
             {/* Messages */}
-            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+            <div className="flex-1 overflow-y-auto p-4 space-y-3 pb-32">
               {messages.map((message, index) => {
                 const previousMessage = messages[index - 1]
                 const isGrouped = shouldGroupMessage(message, previousMessage)

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -80,7 +80,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => 
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900"
+      className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 pb-16"
     >
       <div className="max-w-2xl mx-auto p-6">
         <button

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -77,7 +77,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900"
+      className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 pb-16"
     >
       <div className="max-w-2xl mx-auto p-6">
         <button


### PR DESCRIPTION
## Summary
- make root app container not scroll
- make main area overflow hidden
- add bottom padding to message lists
- keep profile/settings padded for bottom nav

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686050f8ce40832789c235ef23a78b8e