### PR TITLE
Implement single pinned message behavior

### DIFF
--- a/tests/useMessages.test.tsx
+++ b/tests/useMessages.test.tsx
@@ -268,6 +268,8 @@ describe('message actions', () => {
 
   it('toggles pin state', async () => {
     const selectEq = jest.fn().mockReturnThis();
+    const unpinEq = jest.fn().mockReturnThis();
+    const unpinUpdateFn = jest.fn().mockReturnThis();
     const updateEq = jest.fn().mockReturnThis();
     const updateFn = jest.fn().mockReturnThis();
 
@@ -289,6 +291,17 @@ describe('message actions', () => {
         single: jest.fn().mockResolvedValue({ data: [], error: null }),
         order: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
+        update: unpinUpdateFn,
+        delete: jest.fn().mockReturnThis(),
+        eq: unpinEq,
+        rpc: jest.fn().mockReturnThis(),
+      } as any)
+      .mockReturnValueOnce({
+        insert: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: [], error: null }),
+        order: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
         update: updateFn,
         delete: jest.fn().mockReturnThis(),
         eq: updateEq,
@@ -301,6 +314,8 @@ describe('message actions', () => {
       await result.current.togglePin('m1');
     });
 
+    expect(unpinUpdateFn).toHaveBeenCalledWith({ pinned: false, pinned_by: null, pinned_at: null });
+    expect(unpinEq).toHaveBeenCalledWith('pinned', true);
     expect(updateFn).toHaveBeenCalledWith(expect.objectContaining({ pinned: true, pinned_by: user.id, pinned_at: expect.any(String) }));
     expect(selectEq).toHaveBeenCalledWith('id', 'm1');
     expect(updateEq).toHaveBeenCalledWith('id', 'm1');


### PR DESCRIPTION
## Summary
- unpin existing messages before pinning a new one
- adjust local state updates accordingly
- update tests for new unpin behavior

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686055172ba483278729ab6da66b0b87