### PR TITLE
Allow pin/unpin by any user

### DIFF
--- a/supabase/migrations/20250630210000_toggle_message_pin.sql
+++ b/supabase/migrations/20250630210000_toggle_message_pin.sql
@@ -1,0 +1,47 @@
+/*
+  # Allow any authenticated user to pin or unpin messages
+
+  Adds `toggle_message_pin(message_id uuid)` which toggles the pinned
+  state of a message. When pinning a new message the function unpins any
+  currently pinned message so that only one message remains pinned. The
+  pinning user is recorded in `pinned_by` and the timestamp stored in
+  `pinned_at`.
+*/
+
+CREATE OR REPLACE FUNCTION toggle_message_pin(message_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  is_pinned boolean;
+BEGIN
+  SELECT pinned INTO is_pinned FROM messages WHERE id = message_id;
+
+  IF is_pinned IS NULL THEN
+    RAISE EXCEPTION 'Message not found';
+  END IF;
+
+  IF is_pinned THEN
+    UPDATE messages
+    SET pinned = false,
+        pinned_by = NULL,
+        pinned_at = NULL
+    WHERE id = message_id;
+  ELSE
+    UPDATE messages
+    SET pinned = false,
+        pinned_by = NULL,
+        pinned_at = NULL
+    WHERE pinned = true;
+
+    UPDATE messages
+    SET pinned = true,
+        pinned_by = auth.uid(),
+        pinned_at = NOW()
+    WHERE id = message_id;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION toggle_message_pin(uuid) TO authenticated;

--- a/tests/useMessages.test.tsx
+++ b/tests/useMessages.test.tsx
@@ -267,46 +267,8 @@ describe('message actions', () => {
   });
 
   it('toggles pin state', async () => {
-    const selectEq = jest.fn().mockReturnThis();
-    const unpinEq = jest.fn().mockReturnThis();
-    const unpinUpdateFn = jest.fn().mockReturnThis();
-    const updateEq = jest.fn().mockReturnThis();
-    const updateFn = jest.fn().mockReturnThis();
-
-    (supabase.from as jest.Mock)
-      .mockReturnValueOnce({
-        insert: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        single: jest.fn().mockResolvedValue({ data: { pinned: false }, error: null }),
-        order: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        update: jest.fn().mockReturnThis(),
-        delete: jest.fn().mockReturnThis(),
-        eq: selectEq,
-        rpc: jest.fn().mockReturnThis(),
-      } as any)
-      .mockReturnValueOnce({
-        insert: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        single: jest.fn().mockResolvedValue({ data: [], error: null }),
-        order: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        update: unpinUpdateFn,
-        delete: jest.fn().mockReturnThis(),
-        eq: unpinEq,
-        rpc: jest.fn().mockReturnThis(),
-      } as any)
-      .mockReturnValueOnce({
-        insert: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        single: jest.fn().mockResolvedValue({ data: [], error: null }),
-        order: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        update: updateFn,
-        delete: jest.fn().mockReturnThis(),
-        eq: updateEq,
-        rpc: jest.fn().mockReturnThis(),
-      } as any);
+    const rpcFn = jest.fn().mockResolvedValue({ data: null, error: null });
+    (supabase.rpc as jest.Mock).mockImplementationOnce(rpcFn);
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
 
@@ -314,10 +276,6 @@ describe('message actions', () => {
       await result.current.togglePin('m1');
     });
 
-    expect(unpinUpdateFn).toHaveBeenCalledWith({ pinned: false, pinned_by: null, pinned_at: null });
-    expect(unpinEq).toHaveBeenCalledWith('pinned', true);
-    expect(updateFn).toHaveBeenCalledWith(expect.objectContaining({ pinned: true, pinned_by: user.id, pinned_at: expect.any(String) }));
-    expect(selectEq).toHaveBeenCalledWith('id', 'm1');
-    expect(updateEq).toHaveBeenCalledWith('id', 'm1');
+    expect(rpcFn).toHaveBeenCalledWith('toggle_message_pin', { message_id: 'm1' });
   });
 });


### PR DESCRIPTION
## Summary
- add `toggle_message_pin` DB function so any user can pin or unpin a message
- use the new RPC in `useMessages` hook
- update tests for pinning behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686057a5e788832782c617fa03193dfc