### PR TITLE
Fix message row sizing

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -42,12 +42,25 @@ const MessageListRow: React.FC<MessageListRowProps> = ({ index, style, data }) =
   const rowRef = useRef<HTMLDivElement | null>(null)
 
   useLayoutEffect(() => {
-    if (rowRef.current) {
-      const height = rowRef.current.getBoundingClientRect().height
-      setSize(index, height)
-      if (index === items.length - 1) {
-        scrollToBottom()
+    if (!rowRef.current) return
+
+    const updateSize = () => {
+      if (rowRef.current) {
+        const height = rowRef.current.getBoundingClientRect().height
+        setSize(index, height)
+        if (index === items.length - 1) {
+          scrollToBottom()
+        }
       }
+    }
+
+    updateSize()
+
+    const observer = new ResizeObserver(updateSize)
+    observer.observe(rowRef.current)
+
+    return () => {
+      observer.disconnect()
     }
   }, [item, index, setSize, scrollToBottom])
 


### PR DESCRIPTION
## Summary
- watch message list rows with `ResizeObserver` to update row heights dynamically

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605a5416b88327b945dd23496acf13