### PR TITLE
Reload page on focus

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -154,10 +154,8 @@ function useProvideAuth() {
     // Update on page visibility change
     const handleVisibilityChange = () => {
       if (!document.hidden) {
-        // Refresh the auth session when the page comes back into focus
-        supabase.auth.refreshSession().catch((err) => {
-          console.error('Error refreshing session on visibility change:', err)
-        })
+        // Reload the page when it comes back into focus
+        window.location.reload();
         updatePresence();
       }
     };

--- a/src/hooks/useVisibilityRefresh.ts
+++ b/src/hooks/useVisibilityRefresh.ts
@@ -1,13 +1,10 @@
 import { useEffect } from 'react'
-import { supabase } from '../lib/supabase'
 
 export function useVisibilityRefresh(onVisible?: () => void) {
   useEffect(() => {
     const handler = () => {
       if (!document.hidden) {
-        supabase.auth.refreshSession().catch(err => {
-          console.error('Error refreshing session on visibility change:', err)
-        })
+        window.location.reload()
         onVisible?.()
       }
     }

--- a/tests/useVisibilityRefresh.test.tsx
+++ b/tests/useVisibilityRefresh.test.tsx
@@ -1,16 +1,16 @@
 import { renderHook } from '@testing-library/react'
 import { useVisibilityRefresh } from '../src/hooks/useVisibilityRefresh'
-import { supabase } from '../src/lib/supabase'
 
-jest.mock('../src/lib/supabase', () => ({
-  supabase: { auth: { refreshSession: jest.fn() } }
-}))
+Object.defineProperty(window, 'location', {
+  value: { reload: jest.fn() },
+  writable: true,
+})
 
-test('refreshes session and runs callback on visibility change', () => {
+test('reloads page and runs callback on visibility change', () => {
   const cb = jest.fn()
   renderHook(() => useVisibilityRefresh(cb))
   Object.defineProperty(document, 'hidden', { value: false, configurable: true })
   document.dispatchEvent(new Event('visibilitychange'))
-  expect(supabase.auth.refreshSession).toHaveBeenCalled()
+  expect(window.location.reload).toHaveBeenCalled()
   expect(cb).toHaveBeenCalled()
 })


### PR DESCRIPTION
## Summary
- reload the page instead of refreshing Supabase session when tab returns to focus
- update visibility hook tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605b756f0883278129591cc44f38de