### PR TITLE
Fix grouped message spacing

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -127,7 +127,10 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="group flex space-x-3 mt-2 ml-2"
+        className={cn(
+          'group flex space-x-3 ml-2',
+          isGrouped ? 'mt-1' : 'mt-4'
+        )}
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">


### PR DESCRIPTION
## Summary
- adjust message spacing for grouped chat messages so consecutive messages appear evenly spaced

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605ccee9ec8327a71c2e8bdcfb03dc