### PR TITLE
Fix mobile message overlap

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -113,6 +113,8 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
     const handleResize = () => {
       if (containerRef.current) {
         setListHeight(containerRef.current.clientHeight)
+        sizeMap.current = {}
+        listRef.current?.resetAfterIndex(0, true)
       }
     }
     handleResize()


### PR DESCRIPTION
## Summary
- adjust message list resize handler to reset row sizes when the container width changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605dc995288327a18b0f5f9d8b0324