### PR TITLE
Fix message row spacing measurement

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -127,10 +127,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className={cn(
-          'group flex space-x-3 ml-2',
-          isGrouped ? 'mt-1' : 'mt-4'
-        )}
+        className={cn('group flex space-x-3 ml-2')}
       >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -11,7 +11,7 @@ import { Pin } from 'lucide-react'
 import { VariableSizeList as List } from 'react-window'
 import { useMessages } from '../../hooks/useMessages'
 import { useTyping } from '../../hooks/useTyping'
-import { groupMessagesByDate, cn } from '../../lib/utils'
+import { groupMessagesByDate, cn, shouldGroupMessage } from '../../lib/utils'
 import { MessageItem } from './MessageItem'
 import { PinnedMessageItem } from './PinnedMessageItem'
 import type { Message as ChatMessage } from '../../lib/supabase'
@@ -40,6 +40,8 @@ const MessageListRow: React.FC<MessageListRowProps> = ({ index, style, data }) =
   const { items, setSize, scrollToBottom, onReply, handleEdit, handleDelete, togglePin, toggleReaction } = data
   const item = items[index]
   const rowRef = useRef<HTMLDivElement | null>(null)
+  const isGrouped =
+    item.type === 'message' && shouldGroupMessage(item.message as ChatMessage, item.prev)
 
   useLayoutEffect(() => {
     if (!rowRef.current) return
@@ -85,7 +87,7 @@ const MessageListRow: React.FC<MessageListRowProps> = ({ index, style, data }) =
     <div
       ref={rowRef}
       style={style}
-      className="py-1"
+      className={cn(isGrouped ? 'pt-1 pb-1' : 'pt-4 pb-1')}
     >
       <MessageItem
         message={item.message as ChatMessage}


### PR DESCRIPTION
## Summary
- remove margin calculation from `MessageItem`
- move spacing logic into `MessageListRow` and use `shouldGroupMessage`
- keep bottom padding for consistent gaps

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619f27bc208327ae9e2fa0ee5258f5