### PR TITLE
Refine message grouping logic

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -69,15 +69,8 @@ export function shouldGroupMessage(current: ChatMessage, previous?: ChatMessage)
   const currentId = (current as any).user_id ?? (current as any).sender_id
   const previousId = (previous as any).user_id ?? (previous as any).sender_id
 
-  // Don't group if different users
-  if (currentId !== previousId) return false
-  
-  // Don't group if more than 5 minutes apart
-  const currentTime = new Date(current.created_at).getTime()
-  const previousTime = new Date(previous.created_at).getTime()
-  const timeDiff = currentTime - previousTime
-  
-  return timeDiff < 5 * 60 * 1000 // 5 minutes
+  // Group messages whenever they are from the same sender
+  return currentId === previousId
 }
 
 // Slash command processor

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -15,10 +15,10 @@ describe('shouldGroupMessage', () => {
     expect(shouldGroupMessage(current, prev)).toBe(true);
   });
 
-  it('returns false when more than 5 minutes apart', () => {
+  it('returns true for same user even when time gap is large', () => {
     const prev = { id: '1', user_id: 'u1', created_at: baseTime } as any;
-    const current = { id: '2', user_id: 'u1', created_at: '2020-01-01T00:06:00Z' } as any;
-    expect(shouldGroupMessage(current, prev)).toBe(false);
+    const current = { id: '2', user_id: 'u1', created_at: '2020-01-02T00:00:00Z' } as any;
+    expect(shouldGroupMessage(current, prev)).toBe(true);
   });
 
   it('handles DM messages', () => {


### PR DESCRIPTION
## Summary
- simplify `shouldGroupMessage` to group solely by sender
- adjust unit tests for new grouping behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a15611248327b0860da31c4b021c