### PR TITLE
Fix mobile chat padding

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -56,7 +56,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
   }
 
   return (
-    <div ref={containerRef} className="relative flex-1 overflow-y-auto overflow-x-visible p-4 pb-32">
+    <div ref={containerRef} className="relative flex-1 overflow-y-auto overflow-x-visible p-4 pb-40 md:pb-32">
       {messages.some(m => m.pinned) && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">
           <div className="flex items-center space-x-2 mb-2">

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -269,7 +269,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             </div>
 
             {/* Messages */}
-            <div className="flex-1 overflow-y-auto p-4 space-y-3 pb-32">
+            <div className="flex-1 overflow-y-auto p-4 space-y-3 pb-40 md:pb-32">
               {messages.map((message, index) => {
                 const previousMessage = messages[index - 1]
                 const isGrouped = shouldGroupMessage(message, previousMessage)


### PR DESCRIPTION
## Summary
- make extra room for mobile chat history in chat and DMs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6861a634a3a8832780eb2a7c0f532c34