### PR TITLE
Show typing indicator below last message

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -13,18 +13,25 @@ interface MessageListProps {
 }
 
 export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
-  const { messages, loading, editMessage, deleteMessage, togglePin, toggleReaction } = useMessages()
+  const {
+    messages,
+    loading,
+    editMessage,
+    deleteMessage,
+    togglePin,
+    toggleReaction
+  } = useMessages()
   const { typingUsers } = useTyping('general')
   const containerRef = useRef<HTMLDivElement>(null)
 
   const groupedMessages = useMemo(() => groupMessagesByDate(messages), [messages])
 
-  // Scroll to bottom when messages change
+  // Scroll to bottom when messages or typing users change
   useEffect(() => {
     if (containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight
     }
-  }, [messages])
+  }, [messages, typingUsers])
 
   const handleEdit = async (messageId: string, content: string) => {
     try {
@@ -111,15 +118,22 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
-            className="absolute left-4 bottom-2 flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400"
+            className="mt-2 flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400"
           >
             <div className="flex space-x-1">
               <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
-              <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }} />
-              <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }} />
+              <div
+                className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"
+                style={{ animationDelay: '0.1s' }}
+              />
+              <div
+                className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"
+                style={{ animationDelay: '0.2s' }}
+              />
             </div>
             <span>
-              {typingUsers.map(u => u.display_name).join(', ')}{typingUsers.length === 1 ? ' is' : ' are'} typing...
+              {typingUsers.map(u => u.display_name).join(', ')}
+              {typingUsers.length === 1 ? ' is' : ' are'} typing...
             </span>
           </motion.div>
         )}


### PR DESCRIPTION
## Summary
- keep scroll position updated when typing indicator appears
- render typing indicator as part of the message list

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861a664ec8083279d940166c275bfbd