### PR TITLE
Add avatar and banner update support

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -33,15 +33,49 @@ interface ProfileFormData {
 }
 
 export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => {
-  const { profile, updateProfile } = useAuth()
+  const { profile, updateProfile, uploadAvatar, uploadBanner } = useAuth()
   const [isEditing, setIsEditing] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [uploadingAvatar, setUploadingAvatar] = useState(false)
+  const [uploadingBanner, setUploadingBanner] = useState(false)
+  const avatarInputRef = React.useRef<HTMLInputElement>(null)
+  const bannerInputRef = React.useRef<HTMLInputElement>(null)
   const [formData, setFormData] = useState<ProfileFormData>({
     display_name: profile?.display_name || '',
     status_message: profile?.status_message || '',
     status: profile?.status || 'online',
     color: profile?.color || '#3B82F6'
   })
+
+  const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploadingAvatar(true)
+    try {
+      await uploadAvatar(file)
+      toast.success('Avatar updated!')
+    } catch {
+      toast.error('Failed to upload avatar')
+    } finally {
+      setUploadingAvatar(false)
+      e.target.value = ''
+    }
+  }
+
+  const handleBannerChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploadingBanner(true)
+    try {
+      await uploadBanner(file)
+      toast.success('Banner updated!')
+    } catch {
+      toast.error('Failed to upload banner')
+    } finally {
+      setUploadingBanner(false)
+      e.target.value = ''
+    }
+  }
 
   const handleSave = async () => {
     if (!profile) return
@@ -93,13 +127,26 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => 
         {/* Header */}
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
           {/* Banner */}
-          <div className="h-32 bg-gradient-to-r from-blue-500 to-purple-600 relative">
+          <div className="h-32 relative">
+            {profile.banner_url ? (
+              <img src={profile.banner_url} alt="Banner" className="w-full h-full object-cover" />
+            ) : (
+              <div className="w-full h-full bg-gradient-to-r from-blue-500 to-purple-600" />
+            )}
             <button
               className="absolute top-4 right-4 p-2 bg-black bg-opacity-20 rounded-lg text-white hover:bg-opacity-30 transition-colors"
               aria-label="Change banner image"
+              onClick={() => bannerInputRef.current?.click()}
             >
-              <Camera className="w-4 h-4" />
+              {uploadingBanner ? <LoadingSpinner size="sm" /> : <Camera className="w-4 h-4" />}
             </button>
+            <input
+              type="file"
+              accept="image/*"
+              ref={bannerInputRef}
+              onChange={handleBannerChange}
+              className="hidden"
+            />
           </div>
 
           {/* Profile Info */}
@@ -116,9 +163,17 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => 
                 <button
                   className="absolute bottom-0 right-0 p-1.5 bg-blue-600 text-white rounded-full hover:bg-blue-700 transition-colors"
                   aria-label="Change avatar"
+                  onClick={() => avatarInputRef.current?.click()}
                 >
-                  <Camera className="w-3 h-3" />
+                  {uploadingAvatar ? <LoadingSpinner size="sm" /> : <Camera className="w-3 h-3" />}
                 </button>
+                <input
+                  type="file"
+                  accept="image/*"
+                  ref={avatarInputRef}
+                  onChange={handleAvatarChange}
+                  className="hidden"
+                />
               </div>
 
               <Button

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,7 +1,15 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { supabase, User, updateUserPresence } from '../lib/supabase';
 import { PRESENCE_INTERVAL_MS } from '../config';
-import { signIn as authSignIn, signUp as authSignUp, signOut as authSignOut, getCurrentUser, updateUserProfile } from '../lib/auth';
+import {
+  signIn as authSignIn,
+  signUp as authSignUp,
+  signOut as authSignOut,
+  getCurrentUser,
+  updateUserProfile,
+  uploadUserAvatar,
+  uploadUserBanner,
+} from '../lib/auth';
 
 interface AuthContextValue {
   user: User | null;
@@ -16,6 +24,8 @@ interface AuthContextValue {
   ) => Promise<any>;
   signOut: () => Promise<void>;
   updateProfile: (updates: Partial<User>) => Promise<User | void>;
+  uploadAvatar: (file: File) => Promise<string | void>;
+  uploadBanner: (file: File) => Promise<string | void>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -229,13 +239,37 @@ function useProvideAuth() {
 
   const updateProfile = async (updates: Partial<User>) => {
     if (!user) return;
-    
+
     try {
       const updatedUser = await updateUserProfile(updates);
       setUser(updatedUser);
       return updatedUser;
     } catch (error) {
       setError(error instanceof Error ? error.message : 'Profile update failed');
+      throw error;
+    }
+  };
+
+  const uploadAvatar = async (file: File) => {
+    if (!user) return;
+    try {
+      const url = await uploadUserAvatar(file);
+      setUser(prev => (prev ? { ...prev, avatar_url: url } : prev));
+      return url;
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Avatar upload failed');
+      throw error;
+    }
+  };
+
+  const uploadBanner = async (file: File) => {
+    if (!user) return;
+    try {
+      const url = await uploadUserBanner(file);
+      setUser(prev => (prev ? { ...prev, banner_url: url } : prev));
+      return url;
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Banner upload failed');
       throw error;
     }
   };
@@ -249,6 +283,8 @@ function useProvideAuth() {
     signUp,
     signOut,
     updateProfile,
+    uploadAvatar,
+    uploadBanner,
   };
 }
 

--- a/tests/useAuth.test.tsx
+++ b/tests/useAuth.test.tsx
@@ -92,3 +92,27 @@ test('signOut calls auth.signOut', async () => {
 
   expect(authModule.signOut).toHaveBeenCalled();
 });
+
+test('uploadAvatar calls auth.uploadUserAvatar', async () => {
+  authModule.uploadUserAvatar.mockResolvedValue('url');
+
+  const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await act(async () => {
+    await result.current.uploadAvatar(new File(['x'], 'a.png', { type: 'image/png' }));
+  });
+
+  expect(authModule.uploadUserAvatar).toHaveBeenCalled();
+});
+
+test('uploadBanner calls auth.uploadUserBanner', async () => {
+  authModule.uploadUserBanner.mockResolvedValue('url');
+
+  const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await act(async () => {
+    await result.current.uploadBanner(new File(['x'], 'b.png', { type: 'image/png' }));
+  });
+
+  expect(authModule.uploadUserBanner).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- allow profile avatar and banner uploads via Supabase storage
- add Upload methods in auth hook and lib
- enable avatar & banner update UI in ProfileView
- test new upload functions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a516b104832788973cba6ebd2aa5