### PR TITLE
Add DM user search tests

### DIFF
--- a/tests/useUserSearch.test.tsx
+++ b/tests/useUserSearch.test.tsx
@@ -33,3 +33,20 @@ test('searches users by term', async () => {
   expect(result.current.results).toEqual([{ id: 'u1' }])
   expect(result.current.error).toBeNull()
 })
+
+test('returns error when no users found', async () => {
+  const orMock = jest.fn().mockResolvedValue({ data: [], error: null })
+  const sb = supabase as SupabaseMock
+  ;(sb.from as jest.Mock).mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    or: orMock,
+  } as any)
+
+  const { result } = renderHook(() => useUserSearch('missing'))
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  expect(result.current.results).toEqual([])
+  expect(result.current.error).toBe('User not found')
+})


### PR DESCRIPTION
## Summary
- test DirectMessagesView integration with user search
- test user search hook for not found case

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861aad21b2c8327bec1718d56077103