### PR TITLE
Add search_users RPC and hook

### DIFF
--- a/src/components/dms/UserSearchSelect.tsx
+++ b/src/components/dms/UserSearchSelect.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { Avatar } from '../ui/Avatar'
 import { Input } from '../ui/Input'
-import { useUserSearch, BasicUser } from '../../hooks/useUserSearch'
+import { useUserSearch } from '../../hooks/useUserSearch'
+import type { BasicUser } from '../../lib/supabase'
 
 interface UserSearchSelectProps {
   value: string

--- a/src/hooks/useUserSearch.ts
+++ b/src/hooks/useUserSearch.ts
@@ -1,7 +1,5 @@
 import { useState, useEffect } from 'react'
-import { supabase, User } from '../lib/supabase'
-
-export interface BasicUser extends Pick<User, 'id' | 'username' | 'display_name' | 'avatar_url' | 'color' | 'status'> {}
+import { searchUsers, BasicUser } from '../lib/supabase'
 
 export function useUserSearch(term: string) {
   const [results, setResults] = useState<BasicUser[]>([])
@@ -17,19 +15,10 @@ export function useUserSearch(term: string) {
         return
       }
       setLoading(true)
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, username, display_name, avatar_url, color, status')
-        .or(`username.ilike.%${term}%,display_name.ilike.%${term}%`)
+      const users = await searchUsers(term)
       if (!active) return
-      if (error) {
-        console.error('Error searching users:', error)
-        setError('Failed to search users')
-        setResults([])
-      } else {
-        setResults((data ?? []) as BasicUser[])
-        setError(data && data.length > 0 ? null : 'User not found')
-      }
+      setResults(users)
+      setError(users.length > 0 ? null : 'User not found')
       setLoading(false)
     }
     search()

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -118,6 +118,12 @@ export interface DMMessage {
   sender?: User
 }
 
+export interface BasicUser
+  extends Pick<
+    User,
+    'id' | 'username' | 'display_name' | 'avatar_url' | 'color' | 'status'
+  > {}
+
 export type ChatMessage = Message | DMMessage
 
 export interface UserSession {
@@ -168,6 +174,15 @@ export const markDMMessagesRead = async (conversationId: string) => {
     conversation_id: conversationId
   })
   if (error) console.error('Error marking messages as read:', error)
+}
+
+export const searchUsers = async (term: string) => {
+  const { data, error } = await supabase.rpc('search_users', { term })
+  if (error) {
+    console.error('Error searching users:', error)
+    return [] as BasicUser[]
+  }
+  return (data ?? []) as BasicUser[]
 }
 
 // Helper function to ensure valid session before database operations

--- a/supabase/migrations/20250630223000_search_users_function.sql
+++ b/supabase/migrations/20250630223000_search_users_function.sql
@@ -1,0 +1,23 @@
+-- Simple search function for user profiles
+CREATE OR REPLACE FUNCTION search_users(term text)
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  color text,
+  status text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT id, username, display_name, avatar_url, color, status
+  FROM users
+  WHERE username ILIKE '%' || term || '%'
+     OR display_name ILIKE '%' || term || '%';
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_users(text) TO authenticated;


### PR DESCRIPTION
## Summary
- add `search_users` function migration
- expose `searchUsers` and `BasicUser` in `supabase.ts`
- update `useUserSearch` hook to use the RPC
- adjust `UserSearchSelect` and tests to new API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861acc72c008327998ff9b1eefa8879