### PR TITLE
Improve mobile chat input

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -75,7 +75,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
       <div className="hidden md:block">
         <MessageInput
           onSendMessage={handleSendMessage}
-          placeholder="Type a message in #general..."
+          placeholder="Type a message"
         />
       </div>
 
@@ -86,7 +86,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
       >
         <MessageInput
           onSendMessage={handleSendMessage}
-          placeholder="Type a message in #general..."
+          placeholder="Type a message"
           className="border-t"
         />
       </MobileChatFooter>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -17,7 +17,7 @@ interface MessageInputProps {
 
 export const MessageInput: React.FC<MessageInputProps> = ({
   onSendMessage,
-  placeholder = 'Type a message...',
+  placeholder = 'Type a message',
   disabled = false,
   className = ''
 }) => {
@@ -256,6 +256,26 @@ export const MessageInput: React.FC<MessageInputProps> = ({
               >
                 File
               </button>
+              <button
+                type="button"
+                onClick={() => {
+                  handleRecordClick()
+                  setShowAttachmentMenu(false)
+                }}
+                className="md:hidden block w-full px-3 py-1.5 text-sm text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Voice
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowEmojiPicker(true)
+                  setShowAttachmentMenu(false)
+                }}
+                className="md:hidden block w-full px-3 py-1.5 text-sm text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Emoji
+              </button>
             </div>
           )}
           <input
@@ -291,7 +311,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleRecordClick}
-          className="h-12 w-12 p-0 rounded-xl"
+          className="hidden md:inline-flex h-12 w-12 p-0 rounded-xl"
           aria-label="Record audio"
         >
           <Mic className={`w-4 h-4 ${recording ? 'text-red-600' : ''}`} />
@@ -302,7 +322,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           variant="ghost"
           size="sm"
           onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-          className="h-12 w-12 p-0 rounded-xl text-[var(--color-accent)]"
+          className="hidden md:inline-flex h-12 w-12 p-0 rounded-xl text-[var(--color-accent)]"
           aria-label="Insert emoji"
         >
           <Smile className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- move emoji picker and voice recording actions inside attachment menu on small screens
- hide emoji and mic buttons on mobile
- shorten chat input placeholder text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b88bda48832798cdd799dfa89632