### PR TITLE
Fix scrolling for day divider

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -87,7 +87,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
 
       {groupedMessages.map(group => (
         <React.Fragment key={group.date}>
-          <div className="sticky top-0 z-10 flex items-center my-2">
+          <div className="flex items-center my-2">
             <hr className="flex-grow border-t border-gray-300 dark:border-gray-700" />
             <span className="mx-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">{group.date}</span>
             <hr className="flex-grow border-t border-gray-300 dark:border-gray-700" />


### PR DESCRIPTION
## Summary
- allow day divider lines in chat to scroll out of view

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9f01ad0832795962df0630b7f1e