### PR TITLE
Add image attachment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,5 @@ VITE_MESSAGE_FETCH_LIMIT=100
 
 # Optional: Enable verbose logging for Supabase requests (true/false)
 VITE_DEBUG_LOGS=false
+
+# Ensure a `chat-uploads` bucket exists for uploading message images

--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ npm test
 # Apply Supabase migrations
 npx supabase db push
 
-# This will also create the `avatars`, `banners`, and `message-media` storage buckets
+# This will also create the `avatars`, `banners`, `message-media`, and `chat-uploads` storage buckets
 # along with the row-level security policies needed for uploads.
+# Run the same command in production to ensure the bucket exists
 
 # Start the dev server
 npm run dev

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -18,10 +18,11 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
 
   const handleSendMessage = async (
     content: string,
-    type?: 'text' | 'command' | 'audio'
+    type?: 'text' | 'command' | 'audio' | 'image',
+    fileUrl?: string
   ) => {
     try {
-      await sendMessage(content, type)
+      await sendMessage(content, type, fileUrl)
     } catch (error) {
       console.error('❌ ChatView: Failed to send message:', error)
       toast.error('Failed to send message')

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -4,12 +4,16 @@ import { Send, Smile, Command, Plus, Mic } from 'lucide-react'
 import { useTyping } from '../../hooks/useTyping'
 import { Button } from '../ui/Button'
 import { processSlashCommand, slashCommands } from '../../lib/utils'
-import { uploadVoiceMessage } from '../../lib/supabase'
+import { uploadVoiceMessage, uploadChatFile } from '../../lib/supabase'
 import type { EmojiPickerProps, EmojiClickData } from '../../types'
 import { useEmojiPicker } from '../../hooks/useEmojiPicker'
 
 interface MessageInputProps {
-  onSendMessage: (content: string, type?: 'text' | 'command' | 'audio') => void
+  onSendMessage: (
+    content: string,
+    type?: 'text' | 'command' | 'audio' | 'image',
+    fileUrl?: string
+  ) => void
   placeholder?: string
   disabled?: boolean
   className?: string
@@ -136,7 +140,11 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
-      console.log('Selected image:', file)
+      uploadChatFile(file)
+        .then(url => {
+          onSendMessage('', 'image', url)
+        })
+        .catch(err => console.error('Failed to upload image', err))
     }
   }
 

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -199,6 +199,12 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                   />
                   {message.message_type === 'audio' ? (
                     <audio controls src={message.content} className="mt-1 max-w-full" />
+                  ) : message.message_type === 'image' && message.file_url ? (
+                    <img
+                      src={message.file_url}
+                      alt="uploaded image"
+                      className="mt-1 max-w-full rounded"
+                    />
                   ) : (
                     message.content
                   )}

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -53,10 +53,11 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
 
   const handleSendMessage = async (
     content: string,
-    type?: 'text' | 'command' | 'audio'
+    type?: 'text' | 'command' | 'audio' | 'image',
+    fileUrl?: string
   ) => {
     try {
-      await sendMessage(content, type)
+      await sendMessage(content, type, fileUrl)
     } catch (error) {
       toast.error('Failed to send message')
     }

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -303,7 +303,12 @@ export function useConversationMessages(conversationId: string | null) {
     };
   }, [conversationId, user]);
 
-  const sendMessage = useCallback(async (content: string, messageType: 'text' | 'command' | 'audio' = 'text') => {
+  const sendMessage = useCallback(
+    async (
+      content: string,
+      messageType: 'text' | 'command' | 'audio' | 'image' = 'text',
+      fileUrl?: string
+    ) => {
     if (!user || !conversationId || !content.trim()) return;
 
     setSending(true);
@@ -315,6 +320,7 @@ export function useConversationMessages(conversationId: string | null) {
           sender_id: user.id,
           content: content.trim(),
           message_type: messageType,
+          file_url: fileUrl,
         })
         .select(`
           *,
@@ -335,6 +341,7 @@ export function useConversationMessages(conversationId: string | null) {
                 sender_id: user.id,
                 content: content.trim(),
                 message_type: messageType,
+                file_url: fileUrl,
               })
               .select(`
                 *,

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -16,17 +16,20 @@ import { useVisibilityRefresh } from './useVisibilityRefresh';
 export const prepareMessageData = (
   userId: string,
   content: string,
-  messageType: 'text' | 'command' | 'audio'
+  messageType: 'text' | 'command' | 'audio' | 'image',
+  fileUrl?: string
 ) => ({
   user_id: userId,
   content: content.trim(),
   message_type: messageType,
+  file_url: fileUrl,
 });
 
 export const insertMessage = async (messageData: {
   user_id: string;
   content: string;
-  message_type: 'text' | 'command' | 'audio';
+  message_type: 'text' | 'command' | 'audio' | 'image';
+  file_url?: string;
 }) => {
   const start = performance.now();
   const insertPromise = supabase
@@ -58,7 +61,8 @@ export const insertMessage = async (messageData: {
 export const refreshSessionAndRetry = async (messageData: {
   user_id: string;
   content: string;
-  message_type: 'text' | 'command' | 'audio';
+  message_type: 'text' | 'command' | 'audio' | 'image';
+  file_url?: string;
 }) => {
   const refreshPromise = supabase.auth.refreshSession();
   const refreshTimeout = new Promise((_, reject) =>
@@ -94,7 +98,11 @@ interface MessagesContextValue {
   messages: Message[];
   loading: boolean;
   sending: boolean;
-  sendMessage: (content: string, type?: 'text' | 'command' | 'audio') => Promise<void>;
+  sendMessage: (
+    content: string,
+    type?: 'text' | 'command' | 'audio' | 'image',
+    fileUrl?: string
+  ) => Promise<void>;
   editMessage: (id: string, content: string) => Promise<void>;
   deleteMessage: (id: string) => Promise<void>;
   toggleReaction: (id: string, emoji: string) => Promise<void>;
@@ -402,7 +410,11 @@ function useProvideMessages(): MessagesContextValue {
     };
   }, [user, fetchMessages]);
 
-  const sendMessage = useCallback(async (content: string, messageType: 'text' | 'command' | 'audio' = 'text') => {
+  const sendMessage = useCallback(async (
+    content: string,
+    messageType: 'text' | 'command' | 'audio' | 'image' = 'text',
+    fileUrl?: string
+  ) => {
     const timestamp = new Date().toISOString();
     const logPrefix = `🚀 [${timestamp}] MESSAGE_SEND`;
 
@@ -457,7 +469,7 @@ function useProvideMessages(): MessagesContextValue {
 
     try {
       // Step 1: Prepare message data
-      const messageData = prepareMessageData(user.id, content, messageType);
+      const messageData = prepareMessageData(user.id, content, messageType, fileUrl);
       if (DEBUG) {
         console.log(`${logPrefix}: Prepared message data`, messageData);
       }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -66,6 +66,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
 })
 
 export const VOICE_BUCKET = 'message-media'
+export const UPLOADS_BUCKET = 'chat-uploads'
 
 export const uploadVoiceMessage = async (blob: Blob) => {
   const { data: { user } } = await supabase.auth.getUser()
@@ -74,6 +75,16 @@ export const uploadVoiceMessage = async (blob: Blob) => {
   const { error } = await supabase.storage.from(VOICE_BUCKET).upload(filePath, blob)
   if (error) throw error
   const { data } = supabase.storage.from(VOICE_BUCKET).getPublicUrl(filePath)
+  return data.publicUrl
+}
+
+export const uploadChatFile = async (file: File) => {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+  const filePath = `${user.id}/${Date.now()}_${file.name}`
+  const { error } = await supabase.storage.from(UPLOADS_BUCKET).upload(filePath, file)
+  if (error) throw error
+  const { data } = supabase.storage.from(UPLOADS_BUCKET).getPublicUrl(filePath)
   return data.publicUrl
 }
 
@@ -101,6 +112,7 @@ export interface Message {
   content: string
   audio_url?: string
   audio_duration?: number
+  file_url?: string
   reactions: Record<string, { count: number; users: string[] }>
   pinned: boolean
   edited_at?: string
@@ -127,6 +139,7 @@ export interface DMMessage {
   content: string
   audio_url?: string
   audio_duration?: number
+  file_url?: string
   read_at?: string
   reactions: Record<string, { count: number; users: string[] }>
   edited_at?: string

--- a/supabase/migrations/20250630224500_file_url.sql
+++ b/supabase/migrations/20250630224500_file_url.sql
@@ -1,0 +1,27 @@
+/*
+  # Add File URL support
+
+  Adds optional `file_url` column to `messages` and `dm_messages` tables for storing image attachments.
+*/
+
+-- Add column to messages table
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'messages' AND column_name = 'file_url'
+  ) THEN
+    ALTER TABLE messages ADD COLUMN file_url text;
+  END IF;
+END $$;
+
+-- Add column to dm_messages table
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'dm_messages' AND column_name = 'file_url'
+  ) THEN
+    ALTER TABLE dm_messages ADD COLUMN file_url text;
+  END IF;
+END $$;

--- a/supabase/migrations/20250630225000_chat_uploads_bucket.sql
+++ b/supabase/migrations/20250630225000_chat_uploads_bucket.sql
@@ -1,0 +1,38 @@
+/*
+  # Create chat-uploads bucket
+
+  Adds a `chat-uploads` storage bucket for message attachments and configures
+  RLS policies so authenticated users can read and manage their own files.
+*/
+
+-- Create the bucket if it doesn't exist
+INSERT INTO storage.buckets (id, name, public)
+  VALUES ('chat-uploads', 'chat-uploads', false)
+  ON CONFLICT (id) DO NOTHING;
+
+-- Ensure RLS is enabled
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to read objects they own
+CREATE POLICY IF NOT EXISTS "Users can read own chat uploads"
+  ON storage.objects FOR SELECT USING (
+    bucket_id = 'chat-uploads' AND auth.uid() = owner
+  );
+
+-- Allow users to upload new objects
+CREATE POLICY IF NOT EXISTS "Users can insert chat uploads"
+  ON storage.objects FOR INSERT WITH CHECK (
+    bucket_id = 'chat-uploads' AND auth.uid() = owner
+  );
+
+-- Allow users to update their objects
+CREATE POLICY IF NOT EXISTS "Users can update own chat uploads"
+  ON storage.objects FOR UPDATE USING (
+    bucket_id = 'chat-uploads' AND auth.uid() = owner
+  );
+
+-- Allow users to delete their objects
+CREATE POLICY IF NOT EXISTS "Users can delete own chat uploads"
+  ON storage.objects FOR DELETE USING (
+    bucket_id = 'chat-uploads' AND auth.uid() = owner
+  );

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { MessageItem } from '../src/components/chat/MessageItem'
+import type { Message } from '../src/lib/supabase'
+
+const baseMessage = {
+  id: 'm1',
+  user_id: 'u1',
+  content: '',
+  message_type: 'image',
+  file_url: 'https://example.com/test.png',
+  reactions: {},
+  pinned: false,
+  created_at: '2020-01-01',
+  updated_at: '2020-01-01',
+  user: {
+    id: 'u1',
+    email: '',
+    username: 'alice',
+    display_name: 'Alice',
+    status: 'online',
+    status_message: '',
+    color: 'red',
+    last_active: '',
+    created_at: '',
+    updated_at: ''
+  }
+} as unknown as Message
+
+test('renders image message', () => {
+  render(
+    <MessageItem
+      message={baseMessage}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+    />
+  )
+
+  const img = screen.getByAltText(/uploaded image/i)
+  expect(img).toHaveAttribute('src', baseMessage.file_url)
+})


### PR DESCRIPTION
## Summary
- support optional `file_url` in messages and DMs
- create migrations for new column and `chat-uploads` bucket with RLS
- allow uploading files from message input and render image messages
- update supabase typings and helper functions
- document new bucket and add example test for image messages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b98b00648327b30c0f9344073d3a