### PR TITLE
Fix ambiguous search_users function

### DIFF
--- a/supabase/migrations/20250630223000_search_users_function.sql
+++ b/supabase/migrations/20250630223000_search_users_function.sql
@@ -13,10 +13,10 @@ SECURITY DEFINER
 AS $$
 BEGIN
   RETURN QUERY
-  SELECT id, username, display_name, avatar_url, color, status
-  FROM users
-  WHERE username ILIKE '%' || term || '%'
-     OR display_name ILIKE '%' || term || '%';
+  SELECT u.id, u.username, u.display_name, u.avatar_url, u.color, u.status
+  FROM users u
+  WHERE u.username ILIKE '%' || term || '%'
+     OR u.display_name ILIKE '%' || term || '%';
 END;
 $$;
 


### PR DESCRIPTION
## Summary
- fix `search_users` RPC by prefixing table columns to avoid ambiguity

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c4e4f5008327aeee7b3b74155dfa