### PR TITLE
Store audio messages via dedicated field

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -198,7 +198,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                     className="text-[0.65rem]"
                   />
                   {message.message_type === 'audio' ? (
-                    <audio controls src={message.content} className="mt-1 max-w-full" />
+                    <audio controls src={message.audio_url} className="mt-1 max-w-full" />
                   ) : message.message_type === 'image' && message.file_url ? (
                     <img
                       src={message.file_url}

--- a/src/components/chat/PinnedMessageItem.tsx
+++ b/src/components/chat/PinnedMessageItem.tsx
@@ -55,7 +55,7 @@ export const PinnedMessageItem: React.FC<PinnedMessageItemProps> = ({
         <div className="text-sm text-yellow-800 dark:text-yellow-200 break-words">
           <strong>{message.user?.display_name}:</strong>{' '}
           {message.message_type === 'audio' ? (
-            <audio controls src={message.content} className="mt-1 max-w-full" />
+            <audio controls src={message.audio_url} className="mt-1 max-w-full" />
           ) : (
             message.content
           )}

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -20,9 +20,10 @@ export const prepareMessageData = (
   fileUrl?: string
 ) => ({
   user_id: userId,
-  content: content.trim(),
+  content: messageType === 'audio' ? '' : content.trim(),
   message_type: messageType,
   file_url: fileUrl,
+  ...(messageType === 'audio' ? { audio_url: content.trim() } : {}),
 });
 
 export const insertMessage = async (messageData: {
@@ -30,6 +31,7 @@ export const insertMessage = async (messageData: {
   content: string;
   message_type: 'text' | 'command' | 'audio' | 'image';
   file_url?: string;
+  audio_url?: string;
 }) => {
   const start = performance.now();
   const insertPromise = supabase
@@ -63,6 +65,7 @@ export const refreshSessionAndRetry = async (messageData: {
   content: string;
   message_type: 'text' | 'command' | 'audio' | 'image';
   file_url?: string;
+  audio_url?: string;
 }) => {
   const refreshPromise = supabase.auth.refreshSession();
   const refreshTimeout = new Promise((_, reject) =>

--- a/supabase/migrations/20250630224600_move_audio_to_audio_url.sql
+++ b/supabase/migrations/20250630224600_move_audio_to_audio_url.sql
@@ -1,0 +1,15 @@
+-- Migrate existing audio message content to audio_url
+
+-- For messages table
+UPDATE messages
+SET audio_url = content,
+    content = ''
+WHERE message_type = 'audio'
+  AND audio_url IS NULL;
+
+-- For dm_messages table
+UPDATE dm_messages
+SET audio_url = content,
+    content = ''
+WHERE message_type = 'audio'
+  AND audio_url IS NULL;

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -41,3 +41,24 @@ test('renders image message', () => {
   const img = screen.getByAltText(/uploaded image/i)
   expect(img).toHaveAttribute('src', baseMessage.file_url)
 })
+
+test('renders audio message', () => {
+  const audioMessage = {
+    ...baseMessage,
+    message_type: 'audio',
+    audio_url: 'https://example.com/test.webm',
+  } as Message
+
+  const { container } = render(
+    <MessageItem
+      message={audioMessage}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+    />
+  )
+
+  const audio = container.querySelector('audio')
+  expect(audio).toHaveAttribute('src', audioMessage.audio_url)
+})

--- a/tests/useMessages.test.tsx
+++ b/tests/useMessages.test.tsx
@@ -133,8 +133,9 @@ describe('sendMessage', () => {
 
     expect(insertFn).toHaveBeenCalledWith({
       user_id: user.id,
-      content: 'https://example.com/audio.webm',
+      content: '',
       message_type: 'audio',
+      audio_url: 'https://example.com/audio.webm',
     });
   });
 


### PR DESCRIPTION
## Summary
- store audio URL in `audio_url` when preparing a new chat message
- display audio messages using `audio_url`
- migrate existing audio messages into the new column
- test storing and rendering of audio messages via `audio_url`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633502a34083278e9676660fb36d6d