### PR TITLE
Add aria-labels to icon buttons

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -224,6 +224,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                     onClick={() => setShowReactionPicker(!showReactionPicker)}
                     className="text-base hover:scale-110 transition-transform"
                     type="button"
+                    aria-label="Add reaction"
                   >
                     <Plus className="w-4 h-4" />
                   </button>

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -41,3 +41,18 @@ test('renders image message', () => {
   const img = screen.getByAltText(/uploaded image/i)
   expect(img).toHaveAttribute('src', baseMessage.file_url)
 })
+
+test('add reaction button has aria-label', () => {
+  render(
+    <MessageItem
+      message={baseMessage}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+    />
+  )
+
+  const btn = screen.getByLabelText('Add reaction', { hidden: true })
+  expect(btn).toBeInTheDocument()
+})

--- a/tests/PinnedMessageItem.test.tsx
+++ b/tests/PinnedMessageItem.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { PinnedMessageItem } from '../src/components/chat/PinnedMessageItem'
+import type { Message } from '../src/lib/supabase'
+
+const message = {
+  id: 'm1',
+  user_id: 'u1',
+  content: 'Hello',
+  message_type: 'text',
+  reactions: {},
+  pinned: true,
+  created_at: '2020-01-01',
+  updated_at: '2020-01-01',
+  user: { id: 'u1', email: '', username: 'alice', display_name: 'Alice', status: 'online', status_message: '', color: 'red', last_active: '', created_at: '', updated_at: '' }
+} as unknown as Message
+
+it('renders unpin button with label', () => {
+  render(
+    <PinnedMessageItem
+      message={message}
+      onUnpin={async () => {}}
+      onToggleReaction={async () => {}}
+    />
+  )
+
+  const btn = screen.getByLabelText('Unpin message')
+  expect(btn).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- ensure message reaction button has aria-label
- test that reaction button is labelled
- test pinned message unpin button is labelled

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633544740483279c3ed030f2a215a9