### PR TITLE
Add aria-labels and tests for icon-only buttons

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -224,6 +224,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                     onClick={() => setShowReactionPicker(!showReactionPicker)}
                     className="text-base hover:scale-110 transition-transform"
                     type="button"
+                    aria-label="Add reaction"
                   >
                     <Plus className="w-4 h-4" />
                   </button>

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -62,3 +62,18 @@ test('renders audio message', () => {
   const audio = container.querySelector('audio')
   expect(audio).toHaveAttribute('src', audioMessage.audio_url)
 })
+
+test('icon buttons have aria-labels', () => {
+  render(
+    <MessageItem
+      message={baseMessage}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+    />
+  )
+
+  const addReaction = screen.getByRole('button', { name: /add reaction/i })
+  expect(addReaction).toBeInTheDocument()
+})

--- a/tests/PinnedMessageItem.test.tsx
+++ b/tests/PinnedMessageItem.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { PinnedMessageItem } from '../src/components/chat/PinnedMessageItem'
+import type { Message } from '../src/lib/supabase'
+
+const message = {
+  id: 'm1',
+  user_id: 'u1',
+  content: 'hi',
+  message_type: 'text',
+  reactions: {},
+  pinned: true,
+  created_at: '2020-01-01',
+  updated_at: '2020-01-01',
+  user: {
+    id: 'u1',
+    email: '',
+    username: 'alice',
+    display_name: 'Alice',
+    status: 'online',
+    status_message: '',
+    color: 'red',
+    last_active: '',
+    created_at: '',
+    updated_at: ''
+  }
+} as unknown as Message
+
+it('icon buttons have aria-labels', () => {
+  render(
+    <PinnedMessageItem
+      message={message}
+      onUnpin={async () => {}}
+      onToggleReaction={async () => {}}
+    />
+  )
+
+  expect(screen.getByRole('button', { name: /add reaction/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /unpin message/i })).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- label the reaction button in `MessageItem`
- check icon button labels in `MessageItem.test`
- add tests for `PinnedMessageItem` icon labels

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686336d756908327858a058699b44142