### PR TITLE
Fix sidebar for mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { MessagesProvider } from './hooks/useMessages'
 import { updateUserPresence } from './lib/supabase'
 import { PRESENCE_INTERVAL_MS } from './config'
 import { MobileNav } from './components/layout/MobileNav'
+import { useIsDesktop } from './hooks/useIsDesktop'
 
 type View = 'chat' | 'dms' | 'profile' | 'settings'
 
@@ -18,6 +19,7 @@ function App() {
   const { user } = useAuth()
   const [currentView, setCurrentView] = useState<View>('chat')
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const isDesktop = useIsDesktop()
   const [isDarkMode, setIsDarkMode] = useState(() => {
     if (typeof window !== 'undefined') {
       return localStorage.getItem('darkMode') === 'true' ||
@@ -98,16 +100,18 @@ function App() {
     <AuthGuard>
       <MessagesProvider>
         <div className="h-screen overflow-hidden flex flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
-          <Sidebar
-            currentView={currentView}
-            onViewChange={setCurrentView}
-            isDarkMode={isDarkMode}
-            onToggleDarkMode={toggleDarkMode}
-            isOpen={sidebarOpen}
-            onClose={closeSidebar}
-          />
+          {isDesktop && (
+            <Sidebar
+              currentView={currentView}
+              onViewChange={setCurrentView}
+              isDarkMode={isDarkMode}
+              onToggleDarkMode={toggleDarkMode}
+              isOpen={sidebarOpen}
+              onClose={closeSidebar}
+            />
+          )}
 
-          {sidebarOpen && (
+          {isDesktop && sidebarOpen && (
             <div
               className="fixed inset-0 bg-black/40 md:hidden"
               onClick={closeSidebar}

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -14,6 +14,7 @@ import { UserSearchSelect } from './UserSearchSelect'
 import { MessageInput } from '../chat/MessageInput'
 import { MobileChatFooter } from '../layout/MobileChatFooter'
 import { formatTime, shouldGroupMessage } from '../../lib/utils'
+import { useIsDesktop } from '../../hooks/useIsDesktop'
 import toast from 'react-hot-toast'
 
 interface DirectMessagesViewProps {
@@ -24,6 +25,7 @@ interface DirectMessagesViewProps {
 
 export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggleSidebar, currentView, onViewChange }) => {
   const { profile } = useAuth()
+  const isDesktop = useIsDesktop()
   const {
     conversations,
     currentConversation,
@@ -84,13 +86,15 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center">
-              <button
-                onClick={onToggleSidebar}
-                className="md:hidden p-2 -ml-2 mr-2"
-                aria-label="Toggle sidebar"
-              >
-                <Menu className="w-5 h-5" />
-              </button>
+              {isDesktop && (
+                <button
+                  onClick={onToggleSidebar}
+                  className="p-2 -ml-2 mr-2"
+                  aria-label="Toggle sidebar"
+                >
+                  <Menu className="w-5 h-5" />
+                </button>
+              )}
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
               Direct Messages
               </h2>
@@ -215,13 +219,15 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             {/* Header */}
             <div className="flex-shrink-0 px-6 py-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center space-x-3">
-                <button
-                  onClick={onToggleSidebar}
-                  className="md:hidden p-2 -ml-2"
-                  aria-label="Toggle sidebar"
-                >
-                  <Menu className="w-5 h-5" />
-                </button>
+                {isDesktop && (
+                  <button
+                    onClick={onToggleSidebar}
+                    className="p-2 -ml-2"
+                    aria-label="Toggle sidebar"
+                  >
+                    <Menu className="w-5 h-5" />
+                  </button>
+                )}
                 <Button
                   variant="ghost"
                   size="sm"

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Camera, Edit3, Save, X, Upload, Menu } from 'lucide-react'
+import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { useAuth } from '../../hooks/useAuth'
 import { Avatar } from '../ui/Avatar'
 import { Button } from '../ui/Button'
@@ -34,6 +35,7 @@ interface ProfileFormData {
 
 export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => {
   const { profile, updateProfile, uploadAvatar, uploadBanner } = useAuth()
+  const isDesktop = useIsDesktop()
   const [isEditing, setIsEditing] = useState(false)
   const [loading, setLoading] = useState(false)
   const [uploadingAvatar, setUploadingAvatar] = useState(false)
@@ -117,13 +119,15 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ onToggleSidebar }) => 
       className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 pb-16"
     >
       <div className="max-w-2xl mx-auto p-6">
-        <button
-          onClick={onToggleSidebar}
-          className="md:hidden p-2 -ml-2 mb-2"
-          aria-label="Toggle sidebar"
-        >
-          <Menu className="w-5 h-5" />
-        </button>
+        {isDesktop && (
+          <button
+            onClick={onToggleSidebar}
+            className="p-2 -ml-2 mb-2"
+            aria-label="Toggle sidebar"
+          >
+            <Menu className="w-5 h-5" />
+          </button>
+        )}
         {/* Header */}
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
           {/* Banner */}

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -18,6 +18,7 @@ import { Button } from '../ui/Button'
 import { signOut } from '../../lib/auth'
 import toast from 'react-hot-toast'
 import { useTheme, colorSchemes, ColorScheme } from '../../hooks/useTheme'
+import { useIsDesktop } from '../../hooks/useIsDesktop'
 
 interface SettingsViewProps {
   onToggleSidebar: () => void
@@ -28,6 +29,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
   const [sounds, setSounds] = useState(true)
   const [showDangerZone, setShowDangerZone] = useState(false)
   const { scheme, setScheme } = useTheme()
+  const isDesktop = useIsDesktop()
 
   const handleExportData = () => {
     toast.success('Data export started - you will receive an email when ready')
@@ -80,13 +82,15 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
       className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 pb-16"
     >
       <div className="max-w-2xl mx-auto p-6">
-        <button
-          onClick={onToggleSidebar}
-          className="md:hidden p-2 -ml-2 mb-2"
-          aria-label="Toggle sidebar"
-        >
-          <Menu className="w-5 h-5" />
-        </button>
+        {isDesktop && (
+          <button
+            onClick={onToggleSidebar}
+            className="p-2 -ml-2 mb-2"
+            aria-label="Toggle sidebar"
+          >
+            <Menu className="w-5 h-5" />
+          </button>
+        )}
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">

--- a/src/hooks/useIsDesktop.ts
+++ b/src/hooks/useIsDesktop.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react'
+
+export function useIsDesktop() {
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia('(min-width: 768px)').matches
+    }
+    return false
+  })
+
+  useEffect(() => {
+    const mql = window.matchMedia('(min-width: 768px)')
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  return isDesktop
+}


### PR DESCRIPTION
## Summary
- add `useIsDesktop` hook to detect desktop viewport
- hide sidebar and overlay on mobile screens
- show sidebar toggle button only when on desktop

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633977b5648327972bc8303df8304b