### PR TITLE
Add time-based grouping limit

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -69,8 +69,15 @@ export function shouldGroupMessage(current: ChatMessage, previous?: ChatMessage)
   const currentId = (current as any).user_id ?? (current as any).sender_id
   const previousId = (previous as any).user_id ?? (previous as any).sender_id
 
-  // Group messages whenever they are from the same sender
-  return currentId === previousId
+  // Only group messages if they are from the same sender and sent within a
+  // short time window (default: 5 minutes)
+  if (currentId !== previousId) return false
+
+  const currentTime = new Date(current.created_at).getTime()
+  const previousTime = new Date(previous.created_at).getTime()
+  const FIVE_MINUTES = 5 * 60 * 1000
+
+  return Math.abs(currentTime - previousTime) < FIVE_MINUTES
 }
 
 // Slash command processor

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -15,15 +15,21 @@ describe('shouldGroupMessage', () => {
     expect(shouldGroupMessage(current, prev)).toBe(true);
   });
 
-  it('returns true for same user even when time gap is large', () => {
+  it('returns false for same user when time gap is large', () => {
     const prev = { id: '1', user_id: 'u1', created_at: baseTime } as any;
     const current = { id: '2', user_id: 'u1', created_at: '2020-01-02T00:00:00Z' } as any;
-    expect(shouldGroupMessage(current, prev)).toBe(true);
+    expect(shouldGroupMessage(current, prev)).toBe(false);
   });
 
   it('handles DM messages', () => {
     const prev = { id: '1', sender_id: 'u1', created_at: baseTime } as any;
     const current = { id: '2', sender_id: 'u1', created_at: '2020-01-01T00:01:00Z' } as any;
     expect(shouldGroupMessage(current, prev)).toBe(true);
+  });
+
+  it('returns false for DM messages when time gap is large', () => {
+    const prev = { id: '1', sender_id: 'u1', created_at: baseTime } as any;
+    const current = { id: '2', sender_id: 'u1', created_at: '2020-01-02T00:00:00Z' } as any;
+    expect(shouldGroupMessage(current, prev)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- set a 5 minute window for grouping messages by sender
- update unit tests for new grouping logic

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633c11fa5c83278c9edfdb918a630a