### PR TITLE
Add back arrow to DM list on mobile

### DIFF
--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -38,6 +38,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   
   const [showNewConversation, setShowNewConversation] = useState(false)
   const [searchUsername, setSearchUsername] = useState('')
+  const [lastConversation, setLastConversation] = useState<string | null>(null)
 
   const handleUserSelect = async (user: { username: string }) => {
     try {
@@ -66,6 +67,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   }
 
   const handleConversationSelect = (conversationId: string) => {
+    setLastConversation(conversationId)
     setCurrentConversation(conversationId)
     markAsRead(conversationId)
   }
@@ -86,6 +88,17 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center">
+              {!isDesktop && lastConversation && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setCurrentConversation(lastConversation)}
+                  className="mr-2"
+                  aria-label="Back"
+                >
+                  <ArrowLeft className="w-4 h-4" />
+                </Button>
+              )}
               {isDesktop && (
                 <button
                   onClick={onToggleSidebar}


### PR DESCRIPTION
## Summary
- improve mobile conversation list usability
- remember last opened conversation and show back button when the list is open

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68633cbd751083279d09f2f1f7b6909b