### PR TITLE
Fix duplicate DM messages

### DIFF
--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -253,7 +253,9 @@ export function useConversationMessages(conversationId: string | null) {
               .single();
 
             if (data) {
-              setMessages(prev => [...prev, data]);
+              setMessages(prev => {
+                return prev.some(m => m.id === data.id) ? prev : [...prev, data];
+              });
 
               // Mark as read if not sent by current user
               if (user && data.sender_id !== user.id) {


### PR DESCRIPTION
## Summary
- deduplicate messages in realtime insert handler to avoid duplicates appearing on senders end

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68633dc203808327969f78f08b3e060f