### PR TITLE
Add aborting to user search

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -254,8 +254,15 @@ export const markDMMessagesRead = async (conversationId: string) => {
   if (error) console.error('Error marking messages as read:', error)
 }
 
-export const searchUsers = async (term: string) => {
-  const { data, error } = await supabase.rpc('search_users', { term })
+export const searchUsers = async (
+  term: string,
+  options?: { signal?: AbortSignal }
+) => {
+  const { data, error } = await supabase.rpc(
+    'search_users',
+    { term },
+    options
+  )
   if (error) {
     console.error('Error searching users:', error)
     return [] as BasicUser[]

--- a/tests/useUserSearch.test.tsx
+++ b/tests/useUserSearch.test.tsx
@@ -25,7 +25,7 @@ test('searches users by term', async () => {
     await Promise.resolve()
   })
 
-  expect(searchMock).toHaveBeenCalledWith('bob')
+  expect(searchMock).toHaveBeenCalledWith('bob', { signal: expect.anything() })
   expect(result.current.results).toEqual([
     { id: 'u1', username: 'bob', display_name: 'Bob', avatar_url: null, color: '#fff', status: 'online' },
   ])


### PR DESCRIPTION
## Summary
- allow cancelling requests in `useUserSearch` by using an `AbortController`
- forward abort signal to `searchUsers`
- update tests for new call signature

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686341a85ddc8327bcbba64a1b78ecf2