### PR TITLE
Improve manual session refresh

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -64,27 +64,15 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
   const handleRefreshSession = async () => {
     appendLog('Refreshing session...')
 
-    const {
-      data: { session },
-      error: getSessionError,
-    } = await supabase.auth.getSession()
+    const { data, error } = await supabase.auth.refreshSession()
 
-    if (!session?.refresh_token) {
-      appendLog('No refresh token found ❌')
-      return
-    }
-
-    const { data, error } = await supabase.auth.setSession({
-      access_token: '', // force fallback
-      refresh_token: session.refresh_token,
-    })
     if (error) {
       console.error('Forced session restore failed:', error.message)
       appendLog(`Refresh failed: ${error.message}`)
-    } else {
-      console.log('Session re-established:', data.session)
-      appendLog(`Session refreshed: ${JSON.stringify(data.session)}`)
+      return
     }
+
+    appendLog(`New session expires at: ${data.session?.expires_at}`)
   }
 
   const handleSendMessage = async (


### PR DESCRIPTION
## Summary
- call `supabase.auth.refreshSession()` in ChatView refresh handler
- log result so the console shows new expiry time

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863427f0ec48327bf6eb5ccbda5d07a