### PR TITLE
Implement forced session refresh helper

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -8,7 +8,7 @@ import { MobileChatFooter } from '../layout/MobileChatFooter'
 import toast from 'react-hot-toast'
 import { Button } from '../ui/Button'
 import { ConsoleModal } from '../ui/ConsoleModal'
-import { supabase, ensureSession } from '../../lib/supabase'
+import { supabase, ensureSession, refreshAuthSession } from '../../lib/supabase'
 
 interface ChatViewProps {
   onToggleSidebar: () => void
@@ -64,7 +64,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
   const handleRefreshSession = async () => {
     appendLog('Refreshing session...')
 
-    const { data, error } = await supabase.auth.refreshSession()
+    const { data, error } = await refreshAuthSession()
 
     if (error) {
       console.error('Forced session restore failed:', error.message)

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -7,6 +7,7 @@ import {
   getOrCreateDMConversation,
   markDMMessagesRead,
   fetchDMConversations,
+  refreshAuthSession,
 } from '../lib/supabase';
 import { MESSAGE_FETCH_LIMIT } from '../config';
 import { useAuth } from './useAuth';
@@ -334,7 +335,7 @@ export function useConversationMessages(conversationId: string | null) {
       let finalError = error;
       if (finalError) {
         if (finalError.status === 401 || /jwt|token|expired/i.test(finalError.message)) {
-          const { error: refreshError } = await supabase.auth.refreshSession();
+          const { error: refreshError } = await refreshAuthSession();
           if (!refreshError) {
             const retry = await supabase
               .from('dm_messages')

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -6,7 +6,7 @@ import React, {
   useCallback,
   useRef
 } from 'react';
-import { supabase, Message, ensureSession, DEBUG } from '../lib/supabase';
+import { supabase, Message, ensureSession, DEBUG, refreshAuthSession } from '../lib/supabase';
 import { MESSAGE_FETCH_LIMIT } from '../config';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import { useAuth } from './useAuth';
@@ -69,7 +69,7 @@ export const refreshSessionAndRetry = async (messageData: {
   file_url?: string;
   audio_url?: string;
 }) => {
-  const refreshPromise = supabase.auth.refreshSession();
+  const refreshPromise = refreshAuthSession();
   const refreshTimeout = new Promise((_, reject) =>
     setTimeout(
       () => reject(new Error('Session refresh timeout after 5 seconds')),

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -68,6 +68,15 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
 export const VOICE_BUCKET = 'message-media'
 export const UPLOADS_BUCKET = 'chat-uploads'
 
+// Force refresh auth session and update realtime connection token
+export const refreshAuthSession = async () => {
+  const result = await supabase.auth.refreshSession()
+  if (result.data?.session?.access_token) {
+    supabase.realtime.setAuth(result.data.session.access_token)
+  }
+  return result
+}
+
 export const uploadVoiceMessage = async (blob: Blob) => {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) throw new Error('Not authenticated')
@@ -298,7 +307,7 @@ export const ensureSession = async () => {
     const fiveMinutes = 5 * 60
     
     if (expiresAt && (expiresAt - now) < fiveMinutes) {
-      const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession()
+      const { data: refreshData, error: refreshError } = await refreshAuthSession()
 
       if (refreshError) {
         console.error('Error refreshing session:', refreshError)

--- a/tests/useDirectMessages.test.tsx
+++ b/tests/useDirectMessages.test.tsx
@@ -18,6 +18,7 @@ jest.mock('../src/lib/supabase', () => {
     fetchDMConversations: jest.fn().mockResolvedValue([]),
     getOrCreateDMConversation: jest.fn(),
     markDMMessagesRead: jest.fn(),
+    refreshAuthSession: jest.fn(),
   };
 });
 

--- a/tests/useMessages.test.tsx
+++ b/tests/useMessages.test.tsx
@@ -20,6 +20,7 @@ jest.mock('../src/lib/supabase', () => {
       rpc: jest.fn(),
       auth: { getSession: jest.fn(), refreshSession: jest.fn() },
     },
+    refreshAuthSession: jest.fn(),
     ensureSession: jest.fn(),
   };
 });


### PR DESCRIPTION
## Summary
- add `refreshAuthSession` helper to refresh the auth session and update realtime token
- use the new helper in messages, DMs, and ChatView
- update tests to mock the new helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863493da3a08327bab2633c20b33777