### PR TITLE
Fix profile stats by validating session

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -332,6 +332,12 @@ export interface UserStats {
 }
 
 export const fetchUserStats = async (userId: string): Promise<UserStats> => {
+  const sessionValid = await ensureSession()
+
+  if (!sessionValid) {
+    return { messages: 0, reactions: 0, friends: 0 }
+  }
+
   const [messagesRes, reactionsRes, friendsRes] = await Promise.all([
     supabase
       .from('messages')


### PR DESCRIPTION
## Summary
- ensure auth session is valid before fetching profile stats so data populates properly

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*


------
https://chatgpt.com/codex/tasks/task_e_68634c1d29d08327ac323fc96a96ce73