### PR TITLE
Update session refresh to avoid page reload

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -66,6 +66,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     appendLog('Calling supabase.auth.refreshSession()')
 
     const { data, error } = await supabase.auth.refreshSession()
+    const { session, user } = data
 
     if (error) {
       console.error('Forced session restore failed:', error.message)
@@ -74,9 +75,9 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     }
 
     appendLog('Session refresh successful ✅')
-    appendLog(`New session expires at: ${data.session?.expires_at}`)
-    appendLog('Reloading page to establish new session...')
-    window.location.reload()
+    appendLog(`New session expires at: ${session?.expires_at}`)
+    appendLog(`User id: ${user?.id}`)
+    appendLog(`Full response: ${JSON.stringify(data, null, 2)}`)
   }
 
   const handleSendMessage = async (


### PR DESCRIPTION
## Summary
- remove page reload from `ChatView` refresh handler
- log session refresh details to popup console

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634fffce388327bd94c01507a00720