### PR TITLE
Fix session refresh when returning to tab

### DIFF
--- a/src/hooks/useVisibilityRefresh.ts
+++ b/src/hooks/useVisibilityRefresh.ts
@@ -1,12 +1,19 @@
 import { useEffect } from 'react'
+import { supabase } from '../lib/supabase'
 
 export function useVisibilityRefresh(onVisible?: () => void) {
   useEffect(() => {
-    const handler = () => {
+    const handler = async () => {
       if (!document.hidden) {
+        try {
+          await supabase.auth.refreshSession()
+        } catch (err) {
+          console.error('Error refreshing session on visibility change:', err)
+        }
         onVisible?.()
       }
     }
+
     document.addEventListener('visibilitychange', handler)
     return () => document.removeEventListener('visibilitychange', handler)
   }, [onVisible])

--- a/tests/useVisibilityRefresh.test.tsx
+++ b/tests/useVisibilityRefresh.test.tsx
@@ -1,16 +1,16 @@
 import { renderHook } from '@testing-library/react'
 import { useVisibilityRefresh } from '../src/hooks/useVisibilityRefresh'
+import { supabase } from '../src/lib/supabase'
 
-Object.defineProperty(window, 'location', {
-  value: { reload: jest.fn() },
-  writable: true,
-})
+jest.mock('../src/lib/supabase', () => ({
+  supabase: { auth: { refreshSession: jest.fn() } }
+}))
 
-test('reloads page and runs callback on visibility change', () => {
+test('refreshes session and runs callback on visibility change', () => {
   const cb = jest.fn()
   renderHook(() => useVisibilityRefresh(cb))
   Object.defineProperty(document, 'hidden', { value: false, configurable: true })
   document.dispatchEvent(new Event('visibilitychange'))
-  expect(window.location.reload).toHaveBeenCalled()
+  expect(supabase.auth.refreshSession).toHaveBeenCalled()
   expect(cb).toHaveBeenCalled()
 })


### PR DESCRIPTION
## Summary
- refresh Supabase session on visibility change
- update tests for visibility refresh hook

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686351c82d9483279556ebf46923fef8