### PR TITLE
Add session refresh on page focus

### DIFF
--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -7,6 +7,7 @@ import {
   getOrCreateDMConversation,
   markDMMessagesRead,
   fetchDMConversations,
+  refreshSessionLocked,
 } from '../lib/supabase';
 import { MESSAGE_FETCH_LIMIT } from '../config';
 import { useAuth } from './useAuth';
@@ -334,7 +335,7 @@ export function useConversationMessages(conversationId: string | null) {
       let finalError = error;
       if (finalError) {
         if (finalError.status === 401 || /jwt|token|expired/i.test(finalError.message)) {
-          const { error: refreshError } = await supabase.auth.refreshSession();
+          const { error: refreshError } = await refreshSessionLocked();
           if (!refreshError) {
             const retry = await supabase
               .from('dm_messages')

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -6,7 +6,7 @@ import React, {
   useCallback,
   useRef
 } from 'react';
-import { supabase, Message, ensureSession, DEBUG } from '../lib/supabase';
+import { supabase, Message, ensureSession, DEBUG, refreshSessionLocked } from '../lib/supabase';
 import { MESSAGE_FETCH_LIMIT } from '../config';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import { useAuth } from './useAuth';
@@ -69,7 +69,7 @@ export const refreshSessionAndRetry = async (messageData: {
   file_url?: string;
   audio_url?: string;
 }) => {
-  const refreshPromise = supabase.auth.refreshSession();
+  const refreshPromise = refreshSessionLocked();
   const refreshTimeout = new Promise((_, reject) =>
     setTimeout(
       () => reject(new Error('Session refresh timeout after 5 seconds')),


### PR DESCRIPTION
## Summary
- implement refreshSessionLocked in `supabase.ts` to prevent concurrent refreshes
- use locked refresh in `ensureSession` and message hooks
- refresh session when page regains focus and show ConsoleModal logs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640a00f0d8832792dd56d0dcde99be