### PR TITLE
Add error handling for session refresh

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -66,7 +66,16 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     appendLog('Starting forced session refresh...')
     appendLog('Calling supabase.auth.refreshSession()')
 
-    const { data, error } = await refreshSessionLocked()
+    let result
+    try {
+      result = await refreshSessionLocked()
+    } catch (err) {
+      console.error('Forced session restore threw:', err)
+      appendLog(`Refresh threw: ${(err as Error).message}`)
+      return
+    }
+
+    const { data, error } = result
     const { session, user } = data
 
     if (error) {
@@ -87,7 +96,25 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     appendLog('Page became visible - refreshing session')
     appendLog('Calling supabase.auth.refreshSession()')
 
-    const { data, error } = await refreshSessionLocked()
+    let result
+    try {
+      result = await refreshSessionLocked()
+    } catch (err) {
+      console.error('Visibility session refresh threw:', err)
+      appendLog(`Refresh threw: ${(err as Error).message}`)
+      const { data: checkData, error: checkError } =
+        await supabase.auth.getSession()
+      if (checkError) {
+        appendLog(`Session check failed: ${checkError.message}`)
+      } else {
+        appendLog(
+          checkData.session ? 'Session valid ✅' : 'Session invalid ❌'
+        )
+      }
+      return
+    }
+
+    const { data, error } = result
     const { session, user } = data
 
     if (error) {


### PR DESCRIPTION
## Summary
- catch errors from `refreshSessionLocked` and log them
- show session state even when refresh fails

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640fd6e8a483279cb78c660031188a