### PR TITLE
Add timeout for session refresh

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -73,11 +73,19 @@ let refreshSessionPromise: Promise<{ data: any; error: any }> | null = null
 
 export const refreshSessionLocked = async () => {
   if (!refreshSessionPromise) {
-    refreshSessionPromise = supabase.auth
-      .refreshSession()
-      .finally(() => {
-        refreshSessionPromise = null
-      })
+    const refresh = supabase.auth.refreshSession()
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error('Session refresh timeout after 10 seconds')),
+        10000
+      )
+    )
+    refreshSessionPromise = (Promise.race([refresh, timeout]) as Promise<{
+      data: any
+      error: any
+    }>).finally(() => {
+      refreshSessionPromise = null
+    })
   }
   return refreshSessionPromise
 }


### PR DESCRIPTION
## Summary
- avoid indefinite hang in `refreshSessionLocked` by racing the Supabase call against a 10s timeout

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641372942c83279d8e92d85eab07b9