### PR TITLE
Handle offline scenario on session refresh

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -73,6 +73,10 @@ let refreshSessionPromise: Promise<{ data: any; error: any }> | null = null
 
 export const refreshSessionLocked = async () => {
   if (!refreshSessionPromise) {
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      return Promise.reject(new Error('Offline: cannot refresh session'))
+    }
+
     const refresh = supabase.auth.refreshSession()
     const timeout = new Promise<never>((_, reject) =>
       setTimeout(


### PR DESCRIPTION
## Summary
- detect offline state before attempting `supabase.auth.refreshSession`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864244ad8108327847493511362d62c