### PR TITLE
Improve session refresh logs

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -135,6 +135,9 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     } else {
       appendLog(after.session ? 'Session valid ✅' : 'Session invalid ❌')
     }
+
+    // Force a session refresh to ensure tokens are valid
+    await ensureSession(true)
   }
 
   const handleFocusRefresh = async () => {
@@ -204,6 +207,9 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     } else {
       appendLog(after.session ? 'Session valid ✅' : 'Session invalid ❌')
     }
+
+    // Force a session refresh to ensure tokens are valid
+    await ensureSession(true)
   }
 
   useVisibilityRefresh(handleFocusRefresh)


### PR DESCRIPTION
## Summary
- add detailed logging for `refreshSessionLocked`
- allow forcing session refresh through `ensureSession(true)` and new `forceRefreshSession`
- call forced refresh in `ChatView` for troubleshooting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642ce776388327be1011e392142485