### PR TITLE
Add Supabase debug info to connection popup

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { Hash, Users, Pin } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
@@ -14,6 +14,8 @@ import {
   refreshSessionLocked,
   getStoredRefreshToken,
   localStorageKey,
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
 } from '../../lib/supabase'
 import { useVisibilityRefresh } from '../../hooks/useVisibilityRefresh'
 
@@ -32,9 +34,21 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
   const appendLog = (msg: string) =>
     setLogs((l) => [...l, `${new Date().toLocaleTimeString()} ${msg}`])
 
+  const appendSupabaseInfo = () => {
+    appendLog(`Supabase URL: ${SUPABASE_URL}`)
+    appendLog(`Supabase Key: ${SUPABASE_ANON_KEY}`)
+  }
+
+  useEffect(() => {
+    setConsoleOpen(true)
+    setLogs([])
+    appendSupabaseInfo()
+  }, [])
+
   const handleCheckAuth = async () => {
     setConsoleOpen(true)
     setLogs([])
+    appendSupabaseInfo()
 
     appendLog('Testing Supabase connectivity...')
     try {
@@ -108,6 +122,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
   }
 
   const handleRefreshSession = async () => {
+    appendSupabaseInfo()
     appendLog('Starting forced session refresh...')
     const { data: before } = await supabase.auth.getSession()
     appendLog(
@@ -174,6 +189,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
   const handleFocusRefresh = async () => {
     setConsoleOpen(true)
     setLogs([])
+    appendSupabaseInfo()
     appendLog('Page became visible - refreshing session')
     const { data: before } = await supabase.auth.getSession()
     appendLog(

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -42,8 +42,11 @@ const loggingFetch: typeof fetch = async (input, init) => {
   }
 }
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
+export const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+const supabaseUrl = SUPABASE_URL
+const supabaseAnonKey = SUPABASE_ANON_KEY
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables')


### PR DESCRIPTION
## Summary
- export Supabase credentials for debugging
- display Supabase URL and key whenever the console modal opens
- automatically show the console on page load

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68644b8e71f48327ba164303994b149a