### PR TITLE
Fix visibility refresh test

### DIFF
--- a/tests/useVisibilityRefresh.test.tsx
+++ b/tests/useVisibilityRefresh.test.tsx
@@ -1,16 +1,10 @@
 import { renderHook } from '@testing-library/react'
 import { useVisibilityRefresh } from '../src/hooks/useVisibilityRefresh'
 
-Object.defineProperty(window, 'location', {
-  value: { reload: jest.fn() },
-  writable: true,
-})
-
-test('reloads page and runs callback on visibility change', () => {
+test('runs callback on visibility change when document becomes visible', () => {
   const cb = jest.fn()
   renderHook(() => useVisibilityRefresh(cb))
   Object.defineProperty(document, 'hidden', { value: false, configurable: true })
   document.dispatchEvent(new Event('visibilitychange'))
-  expect(window.location.reload).toHaveBeenCalled()
   expect(cb).toHaveBeenCalled()
 })


### PR DESCRIPTION
## Summary
- remove reload check from `useVisibilityRefresh` test
- test that provided callback runs when document becomes visible

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864515f53ac8327ab0906561536ea79