### PR TITLE
Handle realtime auth on session refresh

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -122,6 +122,15 @@ export const refreshSessionLocked = async () => {
         if (DEBUG) {
           console.log('[refreshSessionLocked] refresh result', res)
         }
+        if (res.data?.session) {
+          supabase.realtime.setAuth(res.data.session?.access_token || '')
+          // Reconnect websocket in case it was closed on token expiry
+          try {
+            supabase.realtime.connect()
+          } catch (err) {
+            if (DEBUG) console.error('realtime.connect error', err)
+          }
+        }
         return res
       })
       .catch((err) => {

--- a/tests/refreshSessionLocked.test.ts
+++ b/tests/refreshSessionLocked.test.ts
@@ -1,0 +1,19 @@
+import { refreshSessionLocked, supabase } from '../src/lib/supabase';
+
+beforeEach(() => {
+  // @ts-ignore
+  supabase.auth.getSession = jest.fn().mockResolvedValue({ data: { session: { refresh_token: 't', expires_at: 0 } }, error: null });
+  // @ts-ignore
+  supabase.auth.refreshSession = jest.fn().mockResolvedValue({ data: { session: { access_token: 'new-token' } }, error: null });
+  // @ts-ignore
+  supabase.realtime.setAuth = jest.fn();
+  // @ts-ignore
+  supabase.realtime.connect = jest.fn();
+});
+
+test('sets realtime auth token after refresh', async () => {
+  const result = await refreshSessionLocked();
+  expect(supabase.auth.refreshSession).toHaveBeenCalled();
+  expect(supabase.realtime.setAuth).toHaveBeenCalledWith('new-token');
+  expect(result).toEqual({ data: { session: { access_token: 'new-token' } }, error: null });
+});


### PR DESCRIPTION
## Summary
- update `refreshSessionLocked` to sync realtime auth token
- test that refreshing the session updates realtime auth

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686451724e6883278645bc3b143241dc