### PR TITLE
Add realtime reset helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ GitHub Actions pipeline:
 Run lint, type-check, and test on pull request
 Deploy to Netlify or Vercel on merge to main
 Optional: Slack/Discord webhook alerts
+
+--- ## Troubleshooting Realtime Connections
+
+If realtime channels stop updating after a manual session refresh, call the `resetRealtimeConnection` helper to re-authenticate the websocket:
+
+```ts
+import { resetRealtimeConnection } from './src/lib/supabase'
+
+await resetRealtimeConnection()
+```
+
+This disconnects the realtime client, reconnects it and sets the auth token
+from the current session.
+
 --- ## Future Features
 Push notifications (web + mobile)
 Offline drafts and local caching (message history cached on load)

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -12,6 +12,7 @@ import {
   supabase,
   ensureSession,
   refreshSessionLocked,
+  resetRealtimeConnection,
   getStoredRefreshToken,
   localStorageKey,
   SUPABASE_URL,
@@ -183,7 +184,8 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     }
 
     // Force a session refresh to ensure tokens are valid
-    await ensureSession(true)
+    const valid = await ensureSession(true)
+    if (valid) await resetRealtimeConnection()
   }
 
   const handleFocusRefresh = async () => {
@@ -256,7 +258,8 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     }
 
     // Force a session refresh to ensure tokens are valid
-    await ensureSession(true)
+    const valid = await ensureSession(true)
+    if (valid) await resetRealtimeConnection()
   }
 
   useVisibilityRefresh(handleFocusRefresh)

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -167,6 +167,23 @@ export const forceRefreshSession = async () => {
   return refreshSessionLocked()
 }
 
+export const resetRealtimeConnection = async () => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  supabase.realtime.setAuth(session?.access_token || '')
+  try {
+    supabase.realtime.disconnect()
+  } catch (err) {
+    if (DEBUG) console.error('realtime.disconnect error', err)
+  }
+  try {
+    supabase.realtime.connect()
+  } catch (err) {
+    if (DEBUG) console.error('realtime.connect error', err)
+  }
+}
+
 export const VOICE_BUCKET = 'message-media'
 export const UPLOADS_BUCKET = 'chat-uploads'
 

--- a/tests/resetRealtimeConnection.test.ts
+++ b/tests/resetRealtimeConnection.test.ts
@@ -1,0 +1,23 @@
+import { resetRealtimeConnection, supabase } from '../src/lib/supabase'
+
+beforeEach(() => {
+  // @ts-ignore
+  supabase.auth.getSession = jest.fn().mockResolvedValue({
+    data: { session: { access_token: 'tok' } },
+    error: null,
+  })
+  // @ts-ignore
+  supabase.realtime.disconnect = jest.fn()
+  // @ts-ignore
+  supabase.realtime.connect = jest.fn()
+  // @ts-ignore
+  supabase.realtime.setAuth = jest.fn()
+})
+
+test('updates realtime auth and reconnects', async () => {
+  await resetRealtimeConnection()
+  expect(supabase.auth.getSession).toHaveBeenCalled()
+  expect(supabase.realtime.setAuth).toHaveBeenCalledWith('tok')
+  expect(supabase.realtime.disconnect).toHaveBeenCalled()
+  expect(supabase.realtime.connect).toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- expose `resetRealtimeConnection` utility to restart the websocket with a fresh token
- invoke helper after manual session refreshes
- document reconnection steps in the troubleshooting section
- test the new helper

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68645287c69483278310d23cf3baf2a8