### PR TITLE
Add draft persistence and failed message queue

### DIFF
--- a/src/components/chat/FailedMessageItem.tsx
+++ b/src/components/chat/FailedMessageItem.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { FailedMessage } from '../../hooks/useFailedMessages'
+import { Button } from '../ui/Button'
+
+interface Props {
+  message: FailedMessage
+  onResend: (msg: FailedMessage) => void
+}
+
+export const FailedMessageItem: React.FC<Props> = ({ message, onResend }) => {
+  return (
+    <div className="flex space-x-2 items-start ml-12 my-2">
+      <div className="bg-red-100 dark:bg-red-900/40 rounded-xl px-3 py-2">
+        {message.type === 'text' && <div>{message.content}</div>}
+        {message.type === 'image' && message.dataUrl && (
+          <img src={message.dataUrl} alt={message.fileName} className="max-w-xs rounded" />
+        )}
+        {message.type === 'audio' && message.dataUrl && (
+          <audio controls src={message.dataUrl} className="max-w-xs" />
+        )}
+        <div className="text-xs text-red-500 mt-1">Failed to send</div>
+        <Button size="sm" variant="ghost" onClick={() => onResend(message)} className="mt-1">
+          Resend
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -6,13 +6,17 @@ import { useTyping } from '../../hooks/useTyping'
 import { groupMessagesByDate, cn, shouldGroupMessage } from '../../lib/utils'
 import { MessageItem } from './MessageItem'
 import { PinnedMessageItem } from './PinnedMessageItem'
+import type { FailedMessage } from '../../hooks/useFailedMessages'
+import { FailedMessageItem } from './FailedMessageItem'
 import toast from 'react-hot-toast'
 
 interface MessageListProps {
   onReply?: (messageId: string, content: string) => void
+  failedMessages?: FailedMessage[]
+  onResend?: (msg: FailedMessage) => void
 }
 
-export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
+export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessages = [], onResend }) => {
   const {
     messages,
     loading,
@@ -110,6 +114,10 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply }) => {
             )
           })}
         </React.Fragment>
+      ))}
+
+      {failedMessages.map(msg => (
+        <FailedMessageItem key={msg.id} message={msg} onResend={onResend!} />
       ))}
 
       <AnimatePresence>

--- a/src/hooks/useDraft.tsx
+++ b/src/hooks/useDraft.tsx
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+
+export function useDraft(key: string) {
+  const storageKey = `draft-${key}`
+  const [draft, setDraft] = useState(() => {
+    if (typeof localStorage === 'undefined') return ''
+    try {
+      return localStorage.getItem(storageKey) || ''
+    } catch {
+      return ''
+    }
+  })
+
+  useEffect(() => {
+    try {
+      if (draft) {
+        localStorage.setItem(storageKey, draft)
+      } else {
+        localStorage.removeItem(storageKey)
+      }
+    } catch {
+      // ignore
+    }
+  }, [draft, storageKey])
+
+  const clear = () => {
+    setDraft('')
+    try {
+      localStorage.removeItem(storageKey)
+    } catch {
+      // ignore
+    }
+  }
+
+  return { draft, setDraft, clear }
+}

--- a/src/hooks/useFailedMessages.tsx
+++ b/src/hooks/useFailedMessages.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+
+export interface FailedMessage {
+  id: string
+  type: 'text' | 'image' | 'audio'
+  content: string
+  dataUrl?: string
+  fileName?: string
+}
+
+export function useFailedMessages(key: string) {
+  const storageKey = `failed-${key}`
+  const [failed, setFailed] = useState<FailedMessage[]>(() => {
+    if (typeof localStorage === 'undefined') return []
+    try {
+      const raw = localStorage.getItem(storageKey)
+      return raw ? (JSON.parse(raw) as FailedMessage[]) : []
+    } catch {
+      return []
+    }
+  })
+
+  const persist = (list: FailedMessage[]) => {
+    setFailed(list)
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(list))
+    } catch {
+      // ignore
+    }
+  }
+
+  const add = (msg: FailedMessage) => {
+    persist([...failed, msg])
+  }
+
+  const remove = (id: string) => {
+    persist(failed.filter(m => m.id !== id))
+  }
+
+  return { failedMessages: failed, addFailedMessage: add, removeFailedMessage: remove }
+}


### PR DESCRIPTION
## Summary
- preserve unsent text in `MessageInput` via `useDraft`
- keep failed messages using `useFailedMessages`
- show failed message placeholders with resend option

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670af4c5048327a078db46def002b0