### PR TITLE
Fix unsent chat drafts lost on refresh

### DIFF
--- a/src/hooks/useDraft.tsx
+++ b/src/hooks/useDraft.tsx
@@ -11,6 +11,16 @@ export function useDraft(key: string) {
     }
   })
 
+  // Load new draft when the key changes
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return
+    try {
+      setDraft(localStorage.getItem(storageKey) || '')
+    } catch {
+      setDraft('')
+    }
+  }, [storageKey])
+
   useEffect(() => {
     try {
       if (draft) {

--- a/tests/useDraft.test.tsx
+++ b/tests/useDraft.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook, act } from '@testing-library/react'
+import { useDraft } from '../src/hooks/useDraft'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+test('persists draft across mounts', () => {
+  const { result, unmount } = renderHook(() => useDraft('general'))
+  act(() => {
+    result.current.setDraft('hello')
+  })
+  unmount()
+  const { result: result2 } = renderHook(() => useDraft('general'))
+  expect(result2.current.draft).toBe('hello')
+})
+
+test('updates draft when key changes', () => {
+  localStorage.setItem('draft-other', 'world')
+  const { result, rerender } = renderHook((props: {key: string}) => useDraft(props.key), {
+    initialProps: { key: 'general' }
+  })
+  act(() => {
+    result.current.setDraft('hello')
+  })
+  rerender({ key: 'other' })
+  expect(result.current.draft).toBe('world')
+})


### PR DESCRIPTION
## Summary
- update `useDraft` hook so stored text reloads if the cache key changes
- add tests covering draft persistence and key switching

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674a6def048327bf9ddff57a470b67