### PR TITLE
Fix async error in message submission

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -108,7 +108,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }, [message])
 
-  const handleSubmit = (
+  const handleSubmit = async (
     e: React.FormEvent<HTMLFormElement> | React.KeyboardEvent<HTMLTextAreaElement>
   ) => {
     if (DEBUG) console.log('📝 [MESSAGE_INPUT] handleSubmit: Starting...', {


### PR DESCRIPTION
## Summary
- fix the MessageInput `handleSubmit` function to be async

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js` package)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674da9b1d08327a4de22bf5c416213