### PR TITLE
Fix mobile page scroll issue

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -44,3 +44,14 @@
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+html, body, #root {
+  height: 100vh;
+  overflow: hidden;
+}
+
+@supports (height: 100dvh) {
+  html, body, #root {
+    height: 100dvh;
+  }
+}


### PR DESCRIPTION
## Summary
- prevent scrolling on mobile by making the root elements fixed height

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686815e283148327bd29acce98ca2f37