### PR TITLE
Fix mobile header visibility

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -432,7 +432,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
       className="flex flex-col h-full bg-gray-50 dark:bg-gray-900"
     >
       {/* Header */}
-      <div className="flex-shrink-0 px-6 py-5 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+      <div className="hidden md:block flex-shrink-0 px-6 py-5 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             {/* Menu button removed on mobile */}


### PR DESCRIPTION
## Summary
- hide the main chat header on mobile devices

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868168c3c288327977c84109ff84e95