### PR TITLE
Improve chat scrolling behaviour

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Pin } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
@@ -27,15 +27,23 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
   } = useMessages()
   const { typingUsers } = useTyping('general')
   const containerRef = useRef<HTMLDivElement>(null)
+  const [autoScroll, setAutoScroll] = useState(true)
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 20
+    setAutoScroll(atBottom)
+  }, [])
 
   const groupedMessages = useMemo(() => groupMessagesByDate(messages), [messages])
 
   // Scroll to bottom when messages or typing users change
   useEffect(() => {
-    if (containerRef.current) {
+    if (autoScroll && containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight
     }
-  }, [messages, typingUsers])
+  }, [messages, typingUsers, autoScroll])
 
   const handleEdit = async (messageId: string, content: string) => {
     try {
@@ -67,7 +75,11 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
   }
 
   return (
-    <div ref={containerRef} className="relative flex-1 overflow-y-auto overflow-x-visible p-4 pb-40 md:pb-32">
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      className="relative flex-1 overflow-y-auto overflow-x-visible p-4 pb-48 md:pb-40"
+    >
       {messages.some(m => m.pinned) && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">
           <div className="flex items-center space-x-2 mb-2">

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   MessageSquare,
@@ -42,6 +42,8 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   const [showNewConversation, setShowNewConversation] = useState(false)
   const [searchUsername, setSearchUsername] = useState('')
   const [lastConversation, setLastConversation] = useState<string | null>(null)
+  const messagesRef = useRef<HTMLDivElement>(null)
+  const [autoScroll, setAutoScroll] = useState(true)
 
   const handleUserSelect = async (user: { username: string }) => {
     try {
@@ -75,6 +77,23 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
     setCurrentConversation(conversationId)
     markAsRead(conversationId)
   }
+
+  const handleScroll = useCallback(() => {
+    const el = messagesRef.current
+    if (!el) return
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 20
+    setAutoScroll(atBottom)
+  }, [])
+
+  useEffect(() => {
+    if (autoScroll && messagesRef.current) {
+      messagesRef.current.scrollTop = messagesRef.current.scrollHeight
+    }
+  }, [messages, currentConversation, autoScroll])
+
+  useEffect(() => {
+    setAutoScroll(true)
+  }, [currentConversation])
 
   const currentConv = conversations.find(c => c.id === currentConversation)
 
@@ -282,7 +301,11 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             </div>
 
             {/* Messages */}
-            <div className="flex-1 overflow-y-auto p-4 space-y-3 pb-40 md:pb-32">
+            <div
+              ref={messagesRef}
+              onScroll={handleScroll}
+              className="flex-1 overflow-y-auto p-4 space-y-3 pb-48 md:pb-40"
+            >
               {messages.map((message, index) => {
                 const previousMessage = messages[index - 1]
                 const isGrouped = shouldGroupMessage(message, previousMessage)


### PR DESCRIPTION
## Summary
- add automatic scroll management to chat and DM message lists
- allow auto scrolling to be disabled when user scrolls up
- increase bottom padding in message containers so the input isn't covered

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686819f1c014832797472ed842b1267a