### PR TITLE
Fix mobile chat scroll area

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -81,7 +81,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className="relative flex-1 overflow-y-auto overflow-x-visible p-4 pb-48 md:pb-40"
+      className="relative flex-1 overflow-y-auto overflow-x-visible p-4 pb-60 md:pb-52"
     >
       {messages.some(m => m.pinned) && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -307,7 +307,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             <div
               ref={messagesRef}
               onScroll={handleScroll}
-              className="flex-1 overflow-y-auto p-4 space-y-3 pb-48 md:pb-40"
+              className="flex-1 overflow-y-auto p-4 space-y-3 pb-60 md:pb-52"
             >
               {messages.map((message, index) => {
                 const previousMessage = messages[index - 1]


### PR DESCRIPTION
## Summary
- increase padding at bottom of message lists so last message isn't hidden on mobile

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681e55f77483278aa78c96dc40ae39