### PR TITLE
Fix bottom spacing for chat lists and settings

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -81,7 +81,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className="relative flex-1 overflow-y-auto overflow-x-visible p-4 pb-[calc(env(safe-area-inset-bottom)_+_15rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_13rem)]"
+      className="relative flex-1 overflow-y-auto overflow-x-visible p-4 pb-[calc(env(safe-area-inset-bottom)_+_16rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_14rem)]"
     >
       {messages.some(m => m.pinned) && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -307,7 +307,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             <div
               ref={messagesRef}
               onScroll={handleScroll}
-              className="flex-1 overflow-y-auto p-4 space-y-3 pb-[calc(env(safe-area-inset-bottom)_+_15rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_13rem)]"
+              className="flex-1 overflow-y-auto p-4 space-y-3 pb-[calc(env(safe-area-inset-bottom)_+_16rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_14rem)]"
             >
               {messages.map((message, index) => {
                 const previousMessage = messages[index - 1]

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -79,7 +79,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 pb-16"
+      className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 pb-[calc(env(safe-area-inset-bottom)_+_5rem)]"
     >
       <div className="max-w-2xl mx-auto p-6">
         {isDesktop && (


### PR DESCRIPTION
## Summary
- increase bottom padding in chat and DM message lists
- tweak bottom padding on settings page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682102aac483278f0fb2ba46f4a351