### PR TITLE
Reduce chat font for more messages

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -430,7 +430,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="flex flex-col h-full bg-gray-50 dark:bg-gray-900"
+      className="flex flex-col h-full bg-gray-50 dark:bg-gray-900 text-sm"
     >
       {/* Header */}
       <div className="hidden md:block flex-shrink-0 px-6 py-5 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- make chat window text a bit smaller so more content fits on screen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868214b28f883278112db7a4767b323