### PR TITLE
Fix menu orientation

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -31,10 +31,11 @@ interface MessageItemProps {
   onDelete: (messageId: string) => Promise<void>
   onTogglePin: (messageId: string) => Promise<void>
   onToggleReaction: (messageId: string, emoji: string) => Promise<void>
+  containerRef?: React.RefObject<HTMLDivElement>
 }
 
 export const MessageItem: React.FC<MessageItemProps> = React.memo(
-  ({ message, previousMessage, onReply, onEdit, onDelete, onTogglePin, onToggleReaction }) => {
+  ({ message, previousMessage, onReply, onEdit, onDelete, onTogglePin, onToggleReaction, containerRef }) => {
     const { profile } = useAuth()
     const [isEditing, setIsEditing] = useState(false)
     const [editContent, setEditContent] = useState(message.content)
@@ -94,18 +95,21 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     useEffect(() => {
       if (!showActions) return
       const btnRect = actionsRef.current?.getBoundingClientRect()
-      const menuEl = menuRef.current
-      if (btnRect && menuEl) {
+      const containerRect = containerRef?.current?.getBoundingClientRect()
+      if (btnRect && containerRect) {
+        const center = containerRect.top + containerRect.height / 2
+        setOpenAbove(btnRect.top > center)
+      } else if (btnRect && menuRef.current) {
         const spaceBelow = window.innerHeight - btnRect.bottom
         const spaceAbove = btnRect.top
-        const menuHeight = menuEl.offsetHeight
+        const menuHeight = menuRef.current.offsetHeight
         if (spaceBelow < menuHeight && spaceAbove > menuHeight) {
           setOpenAbove(true)
         } else {
           setOpenAbove(false)
         }
       }
-    }, [showActions])
+    }, [showActions, containerRef])
 
 
     useEffect(() => {

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -124,6 +124,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
                   onDelete={handleDelete}
                   onTogglePin={togglePin}
                   onToggleReaction={toggleReaction}
+                  containerRef={containerRef}
                 />
               </div>
             )

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -35,6 +35,7 @@ test('renders image message', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      containerRef={React.createRef()}
     />
   )
 
@@ -56,6 +57,7 @@ test('renders audio message', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      containerRef={React.createRef()}
     />
   )
 
@@ -71,6 +73,7 @@ test('icon buttons have aria-labels', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      containerRef={React.createRef()}
     />
   )
 


### PR DESCRIPTION
## Summary
- open message actions menu upward or downward based on message position
- propagate containerRef from `MessageList` to `MessageItem`
- adjust `MessageItem` tests for new prop

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868240588c483278bc7531dbb57b8c1