### PR TITLE
Overlay message actions

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -246,42 +246,35 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                     />
                   </div>
                 )}
-              </div>
-            </>
-          )}
-        </div>
 
-        {/* Actions */}
-        <div
-          className="relative"
-          ref={actionsRef}
-        >
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowActions(!showActions)}
-            className="opacity-70 group-hover:opacity-100 transition-opacity"
-            aria-label="Message actions"
-            type="button"
-          >
-            <MoreHorizontal className="w-4 h-4" />
-          </Button>
+                {/* Actions */}
+                <div className="absolute top-1 right-1" ref={actionsRef}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowActions(!showActions)}
+                    className="opacity-70 group-hover:opacity-100 transition-opacity"
+                    aria-label="Message actions"
+                    type="button"
+                  >
+                    <MoreHorizontal className="w-4 h-4" />
+                  </Button>
 
-          <AnimatePresence>
-            {showActions && (
-              <div
-                className={cn(
-                  'absolute right-0 p-2 -m-2 z-50',
-                  openAbove ? 'bottom-full mb-1' : 'top-full mt-1'
-                )}
-                ref={menuRef}
-              >
-                <motion.div
-                  initial={{ opacity: 0, scale: 0.95 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.95 }}
-                  className="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50 min-w-[160px]"
-                >
+                  <AnimatePresence>
+                    {showActions && (
+                      <div
+                        className={cn(
+                          'absolute right-0 p-2 -m-2 z-50',
+                          openAbove ? 'bottom-full mb-1' : 'top-full mt-1'
+                        )}
+                        ref={menuRef}
+                      >
+                        <motion.div
+                          initial={{ opacity: 0, scale: 0.95 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          exit={{ opacity: 0, scale: 0.95 }}
+                          className="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50 min-w-[160px]"
+                        >
 
                 <button
                   onClick={handleCopyMessage}


### PR DESCRIPTION
## Summary
- move message actions inside message bubble
- position button top right so menu overlays content

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686826b23cbc8327a0ddd589a7a42c68