### PR TITLE
Add image modal for thumbnails

### DIFF
--- a/src/components/chat/FailedMessageItem.tsx
+++ b/src/components/chat/FailedMessageItem.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { FailedMessage } from '../../hooks/useFailedMessages'
 import { Button } from '../ui/Button'
+import { ImageModal } from '../ui/ImageModal'
 
 interface Props {
   message: FailedMessage
@@ -8,12 +9,18 @@ interface Props {
 }
 
 export const FailedMessageItem: React.FC<Props> = ({ message, onResend }) => {
+  const [showImageModal, setShowImageModal] = useState(false)
   return (
     <div className="flex space-x-2 items-start ml-12 my-2">
       <div className="bg-red-100 dark:bg-red-900/40 rounded-xl px-3 py-2">
         {message.type === 'text' && <div>{message.content}</div>}
         {message.type === 'image' && message.dataUrl && (
-          <img src={message.dataUrl} alt={message.fileName} className="max-w-xs rounded" />
+          <img
+            src={message.dataUrl}
+            alt={message.fileName}
+            className="max-w-xs rounded cursor-pointer"
+            onClick={() => setShowImageModal(true)}
+          />
         )}
         {message.type === 'audio' && message.dataUrl && (
           <audio controls src={message.dataUrl} className="max-w-xs" />
@@ -23,6 +30,12 @@ export const FailedMessageItem: React.FC<Props> = ({ message, onResend }) => {
           Resend
         </Button>
       </div>
+      <ImageModal
+        open={showImageModal}
+        src={message.dataUrl || ''}
+        alt={message.fileName}
+        onClose={() => setShowImageModal(false)}
+      />
     </div>
   )
 }

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -13,6 +13,7 @@ import {
   Check,
 } from 'lucide-react'
 import { Avatar } from '../ui/Avatar'
+import { ImageModal } from '../ui/ImageModal'
 import { Button } from '../ui/Button'
 import { formatTime, shouldGroupMessage, cn } from '../../lib/utils'
 import type { Message } from '../../lib/supabase'
@@ -42,6 +43,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     const [showActions, setShowActions] = useState(false)
     const [showReactionPicker, setShowReactionPicker] = useState(false)
     const [openAbove, setOpenAbove] = useState(false)
+    const [showImageModal, setShowImageModal] = useState(false)
     const EmojiPicker = useEmojiPicker(showReactionPicker)
     const reactionPickerRef = useRef<HTMLDivElement>(null)
     const actionsRef = useRef<HTMLDivElement>(null)
@@ -207,7 +209,8 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                     <img
                       src={message.file_url}
                       alt="uploaded image"
-                      className="mt-1 max-w-full rounded"
+                      className="mt-1 max-w-xs rounded cursor-pointer"
+                      onClick={() => setShowImageModal(true)}
                     />
                   ) : (
                     message.content
@@ -353,6 +356,12 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
           </AnimatePresence>
         </div>
       </motion.div>
+      <ImageModal
+        open={showImageModal}
+        src={message.file_url || ''}
+        alt="uploaded image"
+        onClose={() => setShowImageModal(false)}
+      />
     )
   }
 )

--- a/src/components/ui/ImageModal.tsx
+++ b/src/components/ui/ImageModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { X } from 'lucide-react'
+
+interface ImageModalProps {
+  open: boolean
+  src: string
+  alt?: string
+  onClose: () => void
+}
+
+export const ImageModal: React.FC<ImageModalProps> = ({ open, src, alt, onClose }) => {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="relative max-w-full max-h-full">
+        <button
+          className="absolute top-2 right-2 p-1 bg-black/70 rounded-full text-white"
+          onClick={onClose}
+          aria-label="Close image"
+          type="button"
+        >
+          <X className="w-5 h-5" />
+        </button>
+        <img src={src} alt={alt} className="max-w-screen max-h-screen rounded" />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add ImageModal component for viewing full-size images
- show chat images as small thumbnails with modal
- apply same thumbnail pattern to failed messages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686827797ff88327b7f0608fd0117e5c