### PR TITLE
Fix JSX return for MessageItem

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -130,11 +130,12 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
 
 
     return (
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        className={cn('group flex space-x-3 ml-2')}
-      >
+      <>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className={cn('group flex space-x-3 ml-2')}
+        >
         {/* Avatar */}
         <div className="flex-shrink-0 w-10">
           {!isGrouped && (
@@ -355,6 +356,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
         alt="uploaded image"
         onClose={() => setShowImageModal(false)}
       />
+      </>
     )
   }
 )


### PR DESCRIPTION
## Summary
- wrap MessageItem JSX return with a fragment to ensure valid syntax

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868290654248327aea6d05e944c1a35