### PR TITLE
Fix JSX closing syntax in MessageItem

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -359,7 +359,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
       </>
     )
   }
-)
+);
 
 MessageItem.displayName = 'MessageItem'
 
@@ -399,6 +399,6 @@ export const MessageReactions: React.FC<{
       })}
     </div>
   )
-}
+};
 
 


### PR DESCRIPTION
## Summary
- add missing semicolons after `React.memo` and `MessageReactions` definitions

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682b08dcb083278875aad8dd1a8bc2