### PR TITLE
Fix mismatched closing tags

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -349,6 +349,8 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
             )}
           </AnimatePresence>
         </div>
+      </div>
+    </div>
       </motion.div>
       <ImageModal
         open={showImageModal}


### PR DESCRIPTION
## Summary
- close missing `<div>` containers in `MessageItem`

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68683e4ac55083278dda59c32ccd8a12