### PR TITLE
Fix closing tag in MessageItem

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -350,7 +350,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
           </AnimatePresence>
         </div>
       </div>
-    </div>
+    </>
       </motion.div>
       <ImageModal
         open={showImageModal}


### PR DESCRIPTION
## Summary
- fix incorrect closing tag that broke build

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686840ece350832792bab144d43374a1