### PR TITLE
Fix unterminated regex error in MessageItem

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -349,15 +349,14 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
             )}
           </AnimatePresence>
         </div>
-      </div>
-    </>
-      </motion.div>
-      <ImageModal
-        open={showImageModal}
-        src={message.file_url || ''}
-        alt="uploaded image"
-        onClose={() => setShowImageModal(false)}
-      />
+        </div>
+        </motion.div>
+        <ImageModal
+          open={showImageModal}
+          src={message.file_url || ''}
+          alt="uploaded image"
+          onClose={() => setShowImageModal(false)}
+        />
       </>
     )
   }


### PR DESCRIPTION
## Summary
- correct closing tag order in `MessageItem.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868429d849c8327ab4fd49bcacb2ee3