### PR TITLE
Add localStorage cleanup on sign out

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Sidebar shows unread message badges and typing indicators
 ### Dark Mode
 Theme toggle available in settings
 Stored in localStorage to persist across sessions
+Signing out clears cached chat history and failed message queues
 ### Typing Indicators
 When a user types, a typing event is broadcast to the channel
 Other users in that room see "User is typing..."

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -15,7 +15,7 @@ import {
   Menu
 } from 'lucide-react'
 import { Button } from '../ui/Button'
-import { signOut } from '../../lib/auth'
+import { useAuth } from '../../hooks/useAuth'
 import toast from 'react-hot-toast'
 import { useTheme, colorSchemes, ColorScheme } from '../../hooks/useTheme'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
@@ -30,6 +30,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
   const [showDangerZone, setShowDangerZone] = useState(false)
   const { scheme, setScheme } = useTheme()
   const isDesktop = useIsDesktop()
+  const { signOut } = useAuth()
 
   const handleExportData = () => {
     toast.success('Data export started - you will receive an email when ready')

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -239,6 +239,20 @@ function useProvideAuth() {
       setError(error instanceof Error ? error.message : 'Sign out failed');
       throw error;
     } finally {
+      // Clear cached chat history and failed message queues on sign out
+      if (typeof localStorage !== 'undefined') {
+        try {
+          localStorage.removeItem('chatHistory');
+          Object.keys(localStorage).forEach(key => {
+            if (key.startsWith('failed-')) {
+              localStorage.removeItem(key);
+            }
+          });
+        } catch {
+          // ignore storage errors
+        }
+      }
+
       setLoading(false);
     }
   };


### PR DESCRIPTION
## Summary
- clear cached chat history and failed message queues when signing out
- switch SettingsView to use the Auth hook for sign out
- document the cleanup behavior in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684ba2b59c8327a427f434adef6c68