### PR TITLE
Fix DM unread badge update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { DirectMessagesView } from './components/dms/DirectMessagesView'
 import { ProfileView } from './components/profile/ProfileView'
 import { SettingsView } from './components/settings/SettingsView'
 import { MessagesProvider } from './hooks/useMessages'
+import { DirectMessagesProvider } from './hooks/useDirectMessages'
 import { MobileNav } from './components/layout/MobileNav'
 import { useIsDesktop } from './hooks/useIsDesktop'
 
@@ -81,7 +82,8 @@ function App() {
   return (
     <AuthGuard>
       <MessagesProvider>
-        <div className="h-screen overflow-hidden flex flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
+        <DirectMessagesProvider>
+          <div className="h-screen overflow-hidden flex flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
           {isDesktop && (
             <Sidebar
               currentView={currentView}
@@ -121,6 +123,7 @@ function App() {
             }}
           />
         </div>
+        </DirectMessagesProvider>
       </MessagesProvider>
     </AuthGuard>
   )

--- a/tests/useDirectMessages.test.tsx
+++ b/tests/useDirectMessages.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act, render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { useDirectMessages } from '../src/hooks/useDirectMessages';
+import { useDirectMessages, DirectMessagesProvider } from '../src/hooks/useDirectMessages';
 import { useAuth } from '../src/hooks/useAuth';
 import * as dmModule from '../src/hooks/useDirectMessages';
 import * as searchModule from '../src/hooks/useUserSearch';
@@ -72,7 +72,7 @@ test('sendMessage retries on 401 error', async () => {
     rpc: jest.fn().mockReturnThis(),
   } as any));
 
-  const { result } = renderHook(() => useDirectMessages());
+  const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
 
   await act(async () => {
     result.current.setCurrentConversation('conv1');
@@ -123,7 +123,7 @@ test('sends audio message with proper type', async () => {
   const sb = supabase as SupabaseMock;
   sb.from.mockReturnValueOnce({ insert: insertFn } as any);
 
-  const { result } = renderHook(() => useDirectMessages());
+  const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
 
   await act(async () => {
     result.current.setCurrentConversation('conv1');
@@ -161,7 +161,7 @@ test('startConversation sets currentConversation', async () => {
   const conversation = { id: 'c1' } as any;
   (getOrCreateDMConversation as jest.Mock).mockResolvedValue(conversation);
 
-  const { result } = renderHook(() => useDirectMessages());
+  const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
 
   await act(async () => {
     const id = await result.current.startConversation('bob');
@@ -188,7 +188,7 @@ test('startConversation throws when user not found', async () => {
     rpc: jest.fn().mockReturnThis(),
   } as any));
 
-  const { result } = renderHook(() => useDirectMessages());
+  const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
 
   await expect(result.current.startConversation('missing')).rejects.toThrow('User not found');
 });


### PR DESCRIPTION
## Summary
- add context provider for Direct Messages state so multiple components share unread counts
- wrap app with the new DirectMessagesProvider
- adjust direct message hook tests for the provider

## Testing
- `npx jest` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68684a27ff1c83279174432e6fcfcd12