### PR TITLE
Add DM notification popup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { SettingsView } from './components/settings/SettingsView'
 import { MessagesProvider } from './hooks/useMessages'
 import { MobileNav } from './components/layout/MobileNav'
 import { useIsDesktop } from './hooks/useIsDesktop'
+import { useMessageNotifications } from './hooks/useMessageNotifications'
 
 type View = 'chat' | 'dms' | 'profile' | 'settings'
 
@@ -16,6 +17,7 @@ function App() {
   const [currentView, setCurrentView] = useState<View>('chat')
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const isDesktop = useIsDesktop()
+  const [dmTarget, setDmTarget] = useState<string | null>(null)
   const [isDarkMode, setIsDarkMode] = useState(() => {
     if (typeof window !== 'undefined') {
       return localStorage.getItem('darkMode') === 'true' ||
@@ -43,7 +45,18 @@ function App() {
     setSidebarOpen((prev) => !prev)
   }
 
+  useMessageNotifications((conversationId) => {
+    setDmTarget(conversationId)
+    setCurrentView('dms')
+  })
+
   const closeSidebar = () => setSidebarOpen(false)
+
+  useEffect(() => {
+    if (currentView === 'dms' && dmTarget) {
+      setDmTarget(null)
+    }
+  }, [currentView, dmTarget])
 
   const renderCurrentView = () => {
     switch (currentView) {
@@ -61,6 +74,7 @@ function App() {
             onToggleSidebar={toggleSidebar}
             currentView={currentView}
             onViewChange={setCurrentView}
+            initialConversation={dmTarget || undefined}
           />
         )
       case 'profile':

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -24,9 +24,10 @@ interface DirectMessagesViewProps {
   onToggleSidebar: () => void
   currentView: 'chat' | 'dms' | 'profile' | 'settings'
   onViewChange: (view: 'chat' | 'dms' | 'profile' | 'settings') => void
+  initialConversation?: string
 }
 
-export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggleSidebar, currentView, onViewChange }) => {
+export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggleSidebar, currentView, onViewChange, initialConversation }) => {
   const { profile } = useAuth()
   const isDesktop = useIsDesktop()
   const {
@@ -47,6 +48,13 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   const messagesRef = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState(true)
   const [uploading, setUploading] = useState(false)
+
+  useEffect(() => {
+    if (initialConversation && currentConversation !== initialConversation) {
+      setCurrentConversation(initialConversation)
+      markAsRead(initialConversation)
+    }
+  }, [initialConversation, currentConversation, markAsRead])
 
   const handleUserSelect = async (user: { username: string }) => {
     try {

--- a/src/components/notifications/MessageNotification.tsx
+++ b/src/components/notifications/MessageNotification.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Avatar } from '../ui/Avatar'
+
+interface MessageNotificationProps {
+  t: any
+  content: string
+  sender: {
+    display_name?: string
+    avatar_url?: string
+    color?: string
+  }
+  onClick: () => void
+  desktop: boolean
+}
+
+export const MessageNotification: React.FC<MessageNotificationProps> = ({ t, content, sender, onClick, desktop }) => {
+  return (
+    <AnimatePresence>
+      {t.visible && (
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+          onClick={onClick}
+          className={`fixed z-50 cursor-pointer flex items-center space-x-2 p-3 rounded-lg shadow-lg border bg-white dark:bg-gray-800 dark:border-gray-700 ${desktop ? 'md:top-16 md:right-4 md:w-72' : 'top-0 inset-x-0 w-full'}`}
+        >
+          <Avatar src={sender.avatar_url} alt={sender.display_name || 'User'} size="sm" color={sender.color} />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+              {sender.display_name}
+            </p>
+            <p className="text-sm text-gray-600 dark:text-gray-300 truncate">
+              {content}
+            </p>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/hooks/useMessageNotifications.tsx
+++ b/src/hooks/useMessageNotifications.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react'
+import toast from 'react-hot-toast'
+import { supabase, getWorkingClient } from '../lib/supabase'
+import { useAuth } from './useAuth'
+import { useIsDesktop } from './useIsDesktop'
+import { MessageNotification } from '../components/notifications/MessageNotification'
+
+export function useMessageNotifications(onOpenConversation: (id: string) => void) {
+  const { user } = useAuth()
+  const isDesktop = useIsDesktop()
+
+  useEffect(() => {
+    if (!user) return
+
+    const channel = supabase
+      .channel('dm_notifications')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'dm_messages' },
+        async payload => {
+          if (payload.new.sender_id === user.id) return
+
+          const working = await getWorkingClient()
+          const { data } = await working
+            .from('dm_messages')
+            .select(
+              `id, content, conversation_id, sender:users!sender_id(id, display_name, avatar_url, color)`
+            )
+            .eq('id', payload.new.id)
+            .single()
+
+          if (data) {
+            toast.custom(t => (
+              <MessageNotification
+                t={t}
+                content={data.content}
+                sender={data.sender || {}}
+                onClick={() => {
+                  toast.dismiss(t.id)
+                  onOpenConversation(data.conversation_id)
+                }}
+                desktop={isDesktop}
+              />
+            ))
+          }
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [user, onOpenConversation, isDesktop])
+}


### PR DESCRIPTION
## Summary
- notify on new direct messages with preview
- tap/click notification to open the conversation
- wire up DM popup logic in app
- allow DirectMessagesView to accept an initial conversation id

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684af692fc8327a93a9f58b5c6d418