### PR TITLE
Position action menu outside message bubble

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -252,7 +252,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                 )}
 
                 {/* Actions */}
-                <div className="absolute top-1 right-1" ref={actionsRef}>
+                <div className="absolute -right-6 top-1" ref={actionsRef}>
                   <Button
                     variant="ghost"
                     size="sm"


### PR DESCRIPTION
## Summary
- adjust actions button placement on message items

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684ede88d0832793da91502d5facef