### PR TITLE
Fix realtime reset channel cleanup

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -494,6 +494,19 @@ export const resetRealtimeConnection = async () => {
   } = await workingClient.auth.getSession()
   workingClient.realtime.setAuth(session?.access_token || '')
   try {
+    // remove any existing channels to avoid binding mismatches
+    const channels = workingClient.getChannels()
+    channels.forEach(ch => {
+      try {
+        workingClient.removeChannel(ch)
+      } catch (removeErr) {
+        if (DEBUG) console.warn('removeChannel error', removeErr)
+      }
+    })
+  } catch (err) {
+    if (DEBUG) console.warn('failed to clean channels', err)
+  }
+  try {
     workingClient.realtime.disconnect()
   } catch (err) {
     if (DEBUG) console.error('realtime.disconnect error', err)


### PR DESCRIPTION
## Summary
- clear any active channels before reconnecting realtime client

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868536b9c488327a970e504b3b40fd6