### PR TITLE
Fix mobile menu visibility

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -120,6 +120,13 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
         } else {
           setOpenRight(false)
         }
+
+        // Ensure menu stays in view on mobile by scrolling it into view
+        if (window.innerWidth <= 768) {
+          setTimeout(() => {
+            menuRef.current?.scrollIntoView({ block: 'nearest' })
+          }, 0)
+        }
       }
     }, [showActions, containerRef])
 


### PR DESCRIPTION
## Summary
- ensure the message actions menu scrolls into view on mobile

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685d36cea08327954ee8807e434e97