### PR TITLE
Fix message menu icon position

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -235,7 +235,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                   )}
                 </div>
                 {/* Actions */}
-                <div className="absolute -right-8 -top-2" ref={actionsRef}>
+                <div className="absolute -right-9 -top-3" ref={actionsRef}>
                   <Button
                     variant="ghost"
                     size="sm"


### PR DESCRIPTION
## Summary
- move the actions menu icon slightly up and out from the message bubble

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685ff984688327ba7d3c23620645df