### PR TITLE
Delay callbacks on visibility refresh

### DIFF
--- a/src/hooks/useVisibilityRefresh.ts
+++ b/src/hooks/useVisibilityRefresh.ts
@@ -1,13 +1,17 @@
 import { useEffect } from 'react'
 import { recreateSupabaseClient, DEBUG, forceSessionRestore, getWorkingClient } from '../lib/supabase'
-
-export function useVisibilityRefresh(onVisible?: () => void) {
+export function useVisibilityRefresh(onVisible?: () => void, delayMs = 200) {
   useEffect(() => {
     const handler = async () => {
       if (!document.hidden) {
         if (DEBUG) console.log('📱 [VISIBILITY] Page became visible - triggering component callbacks...')
-        
+
         try {
+          // Give the client reset process a moment to complete
+          if (delayMs > 0) {
+            await new Promise(res => setTimeout(res, delayMs))
+          }
+
           // The comprehensive reset is now handled by useClientResetStatus
           // This just triggers the component callbacks for message refetch, etc.
           if (DEBUG) console.log('🎯 [VISIBILITY] Triggering component callbacks...')

--- a/tests/useVisibilityRefresh.test.tsx
+++ b/tests/useVisibilityRefresh.test.tsx
@@ -1,10 +1,15 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, act } from '@testing-library/react'
 import { useVisibilityRefresh } from '../src/hooks/useVisibilityRefresh'
 
 test('runs callback on visibility change when document becomes visible', () => {
+  jest.useFakeTimers()
   const cb = jest.fn()
-  renderHook(() => useVisibilityRefresh(cb))
+  renderHook(() => useVisibilityRefresh(cb, 200))
   Object.defineProperty(document, 'hidden', { value: false, configurable: true })
-  document.dispatchEvent(new Event('visibilitychange'))
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'))
+  })
+  jest.runAllTimers()
   expect(cb).toHaveBeenCalled()
+  jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- delay callbacks triggered by `useVisibilityRefresh` so the Supabase client reset has time to finish
- adjust hook test for the asynchronous delay

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686861ff0f848327bbf13f40ade0b4c6