### PR TITLE
Store mic stream ref and release tracks

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -49,6 +49,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const imageInputRef = useRef<HTMLInputElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const mediaStreamRef = useRef<MediaStream | null>(null)
   const audioChunksRef = useRef<Blob[]>([])
 
   // Handle typing indicators
@@ -249,6 +250,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     try {
       if (DEBUG) console.log('🎤 [MESSAGE_INPUT] startRecording: Starting...')
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      mediaStreamRef.current = stream
       const recorder = new MediaRecorder(stream)
       audioChunksRef.current = []
       recorder.ondataavailable = e => audioChunksRef.current.push(e.data)
@@ -266,6 +268,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         } finally {
           onUploadStatusChange(false)
           setShowRecordPopup(false)
+          mediaStreamRef.current = null
+          mediaRecorderRef.current = null
         }
       }
       recorder.start()
@@ -280,6 +284,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const stopRecording = () => {
     if (DEBUG) console.log('🛑 [MESSAGE_INPUT] stopRecording')
     mediaRecorderRef.current?.stop()
+    mediaStreamRef.current?.getTracks().forEach(track => track.stop())
+    mediaStreamRef.current = null
     setRecording(false)
   }
 

--- a/tests/MessageInput.test.tsx
+++ b/tests/MessageInput.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MessageInput } from '../src/components/chat/MessageInput'
+
+jest.mock('../src/hooks/useTyping', () => ({
+  useTyping: () => ({ startTyping: jest.fn(), stopTyping: jest.fn() })
+}))
+
+jest.mock('../src/lib/supabase', () => ({
+  uploadVoiceMessage: jest.fn().mockResolvedValue('url'),
+  uploadChatFile: jest.fn(),
+  DEBUG: false,
+}))
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('stops media stream tracks when recording stops', async () => {
+  const trackStop = jest.fn()
+  const mockStream = { getTracks: () => [{ stop: trackStop }] } as any
+  const getUserMedia = jest.fn().mockResolvedValue(mockStream)
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia },
+    configurable: true,
+  })
+  class MockRecorder {
+    onstop: (() => void) | null = null
+    ondataavailable: ((e: any) => void) | null = null
+    start = jest.fn()
+    stop = jest.fn(() => {
+      this.onstop?.()
+    })
+    constructor(public stream: MediaStream) {}
+  }
+  ;(global as any).MediaRecorder = MockRecorder
+  const user = userEvent.setup()
+  render(<MessageInput onSendMessage={() => {}} />)
+  const btn = screen.getByRole('button', { name: /record audio/i })
+  await user.click(btn)
+  await user.click(btn)
+  expect(trackStop).toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- track user media stream and set to null on finish
- release mic tracks when stopping recording
- test that tracks are stopped

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686866ea39248327ac083e24c36d11a8