### PR TITLE
Handle microphone denial

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -10,6 +10,7 @@ import { useEmojiPicker } from '../../hooks/useEmojiPicker'
 import { RecordingIndicator } from '../ui/RecordingIndicator'
 import { RecordingPopup } from '../ui/RecordingPopup'
 import { useDraft } from '../../hooks/useDraft'
+import toast from 'react-hot-toast'
 
 interface MessageInputProps {
   onSendMessage: (
@@ -274,6 +275,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       if (DEBUG) console.log('✅ [MESSAGE_INPUT] Recording started')
     } catch (err) {
       if (DEBUG) console.error('❌ [MESSAGE_INPUT] Failed to start recording:', err)
+      toast.error('Microphone access was denied')
+      setRecording(false)
+      setShowRecordPopup(false)
     }
   }
 

--- a/tests/MessageInputRecording.test.tsx
+++ b/tests/MessageInputRecording.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MessageInput } from '../src/components/chat/MessageInput'
+import toast from 'react-hot-toast'
+
+jest.mock('react-hot-toast', () => {
+  const toastFn = jest.fn()
+  toastFn.error = jest.fn()
+  toastFn.success = jest.fn()
+  return { __esModule: true, default: toastFn }
+})
+
+jest.mock('../src/hooks/useTyping', () => ({
+  useTyping: () => ({ startTyping: jest.fn(), stopTyping: jest.fn() })
+}))
+
+jest.mock('../src/hooks/useEmojiPicker', () => ({
+  useEmojiPicker: () => null
+}))
+
+// Ensure useDraft doesn't persist to localStorage during tests
+jest.mock('../src/hooks/useDraft', () => ({
+  useDraft: () => ({ draft: '', setDraft: jest.fn(), clear: jest.fn() })
+}))
+
+test('shows toast and resets when microphone access denied', async () => {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia: jest.fn().mockRejectedValue(new Error('denied')) },
+    configurable: true
+  })
+
+  render(<MessageInput onSendMessage={async () => {}} />)
+
+  const recordButton = screen.getByRole('button', { name: /record audio/i })
+  await userEvent.click(recordButton)
+
+  // allow any microtasks to run
+  await Promise.resolve()
+
+  expect((toast as any).error).toHaveBeenCalledWith('Microphone access was denied')
+  expect(screen.queryByText(/Recording/)).not.toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- catch microphone permission errors in `MessageInput`
- reset recording state and show a toast when permission denied
- test denied microphone access scenario

## Testing
- `npm test -- -t 'microphone access denied'` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686866f6d5848327b7a97ecb9a9bad85