### PR TITLE
Add connectivity monitoring to reconnect after network loss

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import { DirectMessagesProvider } from './hooks/useDirectMessages'
 import { MobileNav } from './components/layout/MobileNav'
 import { useIsDesktop } from './hooks/useIsDesktop'
 import { useMessageNotifications } from './hooks/useMessageNotifications'
+import { ClientResetProvider } from './hooks/ClientResetContext'
+import { ConnectivityBanner } from './components/ui/ConnectivityBanner'
 
 type View = 'chat' | 'dms' | 'profile' | 'settings'
 
@@ -95,9 +97,11 @@ function App() {
 
   return (
     <AuthGuard>
-      <MessagesProvider>
-        <DirectMessagesProvider>
+      <ClientResetProvider>
+        <MessagesProvider>
+          <DirectMessagesProvider>
           <div className="h-screen overflow-hidden flex flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
+          <ConnectivityBanner />
           {isDesktop && (
             <Sidebar
               currentView={currentView}
@@ -139,6 +143,7 @@ function App() {
         </div>
         </DirectMessagesProvider>
       </MessagesProvider>
+      </ClientResetProvider>
     </AuthGuard>
   )
 }

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -8,7 +8,7 @@ import { useFailedMessages } from '../../hooks/useFailedMessages'
 import { MobileChatFooter } from '../layout/MobileChatFooter'
 import toast from 'react-hot-toast'
 import { ClientResetIndicator } from '../ui/ClientResetIndicator'
-import { useClientResetStatus } from '../../hooks/useClientResetStatus'
+import { useClientReset } from '../../hooks/ClientResetContext'
 import {
   ensureSession,
 } from '../../lib/supabase'
@@ -22,7 +22,7 @@ interface ChatViewProps {
 
 export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView, onViewChange }) => {
   const { sendMessage, sending } = useMessages()
-  const { status: resetStatus, lastResetTime } = useClientResetStatus()
+  const { status: resetStatus, lastResetTime } = useClientReset()
   const { failedMessages, addFailedMessage, removeFailedMessage } = useFailedMessages('general')
 
   const [uploading, setUploading] = useState(false)

--- a/src/components/ui/ConnectivityBanner.tsx
+++ b/src/components/ui/ConnectivityBanner.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { useConnectivity } from '../../hooks/useConnectivity'
+
+export const ConnectivityBanner: React.FC = () => {
+  const { offline } = useConnectivity()
+  if (!offline) return null
+  return (
+    <div className="bg-red-500 text-white text-sm text-center py-1">
+      Temporary connectivity issue. Reconnecting...
+    </div>
+  )
+}

--- a/src/hooks/ClientResetContext.tsx
+++ b/src/hooks/ClientResetContext.tsx
@@ -1,0 +1,24 @@
+import React, { createContext, useContext } from 'react'
+import type { ClientResetStatus } from './useClientResetStatus'
+import { useClientResetStatus } from './useClientResetStatus'
+
+interface ClientResetContextValue {
+  status: ClientResetStatus
+  lastResetTime: Date | null
+  manualReset: () => Promise<void>
+}
+
+const ClientResetContext = createContext<ClientResetContextValue | undefined>(undefined)
+
+export function ClientResetProvider({ children }: { children: React.ReactNode }) {
+  const value = useClientResetStatus()
+  return <ClientResetContext.Provider value={value}>{children}</ClientResetContext.Provider>
+}
+
+export function useClientReset() {
+  const ctx = useContext(ClientResetContext)
+  if (!ctx) {
+    throw new Error('useClientReset must be used within a ClientResetProvider')
+  }
+  return ctx
+}

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useRef } from 'react'
+import { useClientReset } from './ClientResetContext'
+
+export function useConnectivity() {
+  const { manualReset } = useClientReset()
+  const [offline, setOffline] = useState(typeof navigator !== 'undefined' ? !navigator.onLine : false)
+  const intervalRef = useRef<number | null>(null)
+
+  const checkConnectivity = async () => {
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      setOffline(true)
+      return
+    }
+    try {
+      const controller = new AbortController()
+      const timeoutId = window.setTimeout(() => controller.abort(), 3000)
+      await fetch('/favicon.ico', { method: 'HEAD', cache: 'no-store', signal: controller.signal })
+      clearTimeout(timeoutId)
+      if (offline) {
+        setOffline(false)
+        try {
+          await manualReset()
+        } catch {
+          // ignore
+        }
+      }
+    } catch {
+      setOffline(true)
+    }
+  }
+
+  useEffect(() => {
+    const handleOnline = () => {
+      checkConnectivity()
+    }
+    const handleOffline = () => {
+      setOffline(true)
+    }
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    checkConnectivity()
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (offline) {
+      if (intervalRef.current === null) {
+        intervalRef.current = window.setInterval(checkConnectivity, 5000)
+      }
+    } else if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [offline])
+
+  return { offline }
+}


### PR DESCRIPTION
## Summary
- provide a ClientReset context around the app so components can share reset logic
- add a connectivity hook and banner that detects offline status and attempts reconnection
- update ChatView to use the new context
- display a reconnection banner and reset the Supabase client once connectivity is restored

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868992360208327941e1ee491dde45c