### PR TITLE
Fix reaction totals for user stats

### DIFF
--- a/supabase/migrations/20250630230000_dm_reaction_count.sql
+++ b/supabase/migrations/20250630230000_dm_reaction_count.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION count_reactions_to_user_dm_messages(user_id uuid)
+RETURNS integer AS $$
+  SELECT COALESCE(SUM((data->>'count')::int), 0)
+  FROM dm_messages m
+  CROSS JOIN LATERAL jsonb_each(coalesce(m.reactions, '{}'::jsonb)) AS e(emoji, data)
+  WHERE m.sender_id = user_id;
+$$ LANGUAGE sql STABLE;
+
+GRANT EXECUTE ON FUNCTION count_reactions_to_user_dm_messages(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION count_reactions_to_user_messages(user_id uuid)
+RETURNS integer AS $$
+  SELECT COUNT(*)
+  FROM message_reactions r
+  JOIN messages m ON r.message_id = m.id
+  WHERE m.user_id = user_id;
+$$ LANGUAGE sql STABLE;
+
+GRANT EXECUTE ON FUNCTION count_reactions_to_user_messages(uuid) TO authenticated;


### PR DESCRIPTION
## Summary
- count reactions on user messages in direct messages and channels
- call new RPC helpers in `fetchUserStats`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6868986a24dc83279a0c36eeca3f362e