### PR TITLE
Add pinned message headers

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -4,6 +4,7 @@ import { Users, Pin } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
 import { MessageList } from './MessageList'
 import { MessageInput } from './MessageInput'
+import { PinnedMessagesBar } from './PinnedMessagesBar'
 import { useFailedMessages } from '../../hooks/useFailedMessages'
 import { MobileChatFooter } from '../layout/MobileChatFooter'
 import toast from 'react-hot-toast'
@@ -21,7 +22,8 @@ interface ChatViewProps {
 }
 
 export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView, onViewChange }) => {
-  const { sendMessage, sending } = useMessages()
+  const { messages, sendMessage, sending, togglePin, toggleReaction } = useMessages()
+  const pinnedMessages = messages.filter(m => m.pinned)
   const { status: resetStatus, lastResetTime } = useClientReset()
   const { failedMessages, addFailedMessage, removeFailedMessage } = useFailedMessages('general')
 
@@ -83,7 +85,27 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
             </div>
           </div>
         </div>
+        {pinnedMessages.length > 0 && (
+          <div className="mt-4">
+            <PinnedMessagesBar
+              messages={pinnedMessages}
+              onUnpin={togglePin}
+              onToggleReaction={toggleReaction}
+            />
+          </div>
+        )}
       </div>
+
+      {/* Pinned messages on mobile */}
+      {pinnedMessages.length > 0 && (
+        <div className="md:hidden px-4 pt-4">
+          <PinnedMessagesBar
+            messages={pinnedMessages}
+            onUnpin={togglePin}
+            onToggleReaction={toggleReaction}
+          />
+        </div>
+      )}
 
       {/* Messages */}
       <MessageList

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Pin } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
 import { useTyping } from '../../hooks/useTyping'
 import { groupMessagesByDate, cn, shouldGroupMessage } from '../../lib/utils'
 import { MessageItem } from './MessageItem'
-import { PinnedMessageItem } from './PinnedMessageItem'
 import type { FailedMessage } from '../../hooks/useFailedMessages'
 import { FailedMessageItem } from './FailedMessageItem'
 import toast from 'react-hot-toast'
@@ -83,26 +81,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
       onScroll={handleScroll}
       className="relative flex-1 overflow-y-auto overflow-x-visible p-4 md:p-2 pb-[calc(env(safe-area-inset-bottom)_+_20rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_6rem)]"
     >
-      {messages.some(m => m.pinned) && (
-        <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">
-          <div className="flex items-center space-x-2 mb-2">
-            <Pin className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
-            <span className="text-sm font-medium text-yellow-800 dark:text-yellow-200">Pinned Messages</span>
-          </div>
-          <div className="space-y-2">
-            {messages
-              .filter(m => m.pinned)
-              .map(message => (
-                <PinnedMessageItem
-                  key={message.id}
-                  message={message}
-                  onUnpin={togglePin}
-                  onToggleReaction={toggleReaction}
-                />
-              ))}
-          </div>
-        </div>
-      )}
+
 
       {groupedMessages.map(group => (
         <React.Fragment key={group.date}>

--- a/src/components/chat/PinnedMessagesBar.tsx
+++ b/src/components/chat/PinnedMessagesBar.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Pin } from 'lucide-react'
+import { PinnedMessageItem } from './PinnedMessageItem'
+import type { Message } from '../../lib/supabase'
+
+interface PinnedMessagesBarProps {
+  messages: Message[]
+  onUnpin: (messageId: string) => Promise<void>
+  onToggleReaction: (messageId: string, emoji: string) => Promise<void>
+  className?: string
+}
+
+export function PinnedMessagesBar({ messages, onUnpin, onToggleReaction, className }: PinnedMessagesBarProps) {
+  if (messages.length === 0) return null
+  return (
+    <div
+      className={`bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 ${className || ''}`}
+    >
+      <div className="flex items-center space-x-2 mb-2">
+        <Pin className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
+        <span className="text-sm font-medium text-yellow-800 dark:text-yellow-200">Pinned Messages</span>
+      </div>
+      <div className="space-y-2">
+        {messages.map(message => (
+          <PinnedMessageItem
+            key={message.id}
+            message={message}
+            onUnpin={onUnpin}
+            onToggleReaction={onToggleReaction}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `PinnedMessagesBar` component
- display pinned messages in chat header on desktop
- show pinned messages before messages on mobile
- remove pinned section from message list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868a07472fc8327afd65ff943854674