### PR TITLE
Update pinned message styling

### DIFF
--- a/src/components/chat/PinnedMessageItem.tsx
+++ b/src/components/chat/PinnedMessageItem.tsx
@@ -45,14 +45,14 @@ export const PinnedMessageItem: React.FC<PinnedMessageItemProps> = ({
   }
 
   return (
-    <div className="relative p-2 rounded-md bg-yellow-100/60 dark:bg-yellow-800/40 flex items-start group">
+    <div className="relative p-2 rounded-md bg-white dark:bg-gray-800/40 border border-gray-200 dark:border-gray-700 flex items-start group">
       <div className="flex-1 min-w-0 space-y-1">
         <MessageReactions
           message={message}
           onReact={handleReaction}
           className="text-[0.65rem]"
         />
-        <div className="text-sm text-yellow-800 dark:text-yellow-200 break-words">
+        <div className="text-sm text-gray-900 dark:text-gray-100 break-words">
           <strong>{message.user?.display_name}:</strong>{' '}
           {message.message_type === 'audio' ? (
             <audio controls src={message.audio_url} className="mt-1 max-w-full" />
@@ -94,7 +94,7 @@ export const PinnedMessageItem: React.FC<PinnedMessageItemProps> = ({
         size="sm"
         onClick={() => onUnpin(message.id)}
         aria-label="Unpin message"
-        className="ml-2 text-yellow-700 dark:text-yellow-300"
+        className="ml-2 text-gray-500 dark:text-gray-400 hover:text-[var(--color-accent)]"
       >
         <PinOff className="w-4 h-4" />
       </Button>

--- a/src/components/chat/PinnedMessagesBar.tsx
+++ b/src/components/chat/PinnedMessagesBar.tsx
@@ -14,11 +14,11 @@ export function PinnedMessagesBar({ messages, onUnpin, onToggleReaction, classNa
   if (messages.length === 0) return null
   return (
     <div
-      className={`bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 ${className || ''}`}
+      className={`bg-gray-50 dark:bg-gray-800/40 border border-gray-200 dark:border-gray-700 rounded-lg p-4 ${className || ''}`}
     >
       <div className="flex items-center space-x-2 mb-2">
-        <Pin className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
-        <span className="text-sm font-medium text-yellow-800 dark:text-yellow-200">Pinned Messages</span>
+        <Pin className="w-4 h-4 text-[var(--color-accent)]" />
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Pinned Messages</span>
       </div>
       <div className="space-y-2">
         {messages.map(message => (


### PR DESCRIPTION
## Summary
- restyle pinned messages with gray theme and accent highlight

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869466753e88327a84bba1e59157579