### PR TITLE
Purge stale Supabase auth keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ await resetRealtimeConnection()
 This disconnects the realtime client, reconnects it and sets the auth token
 from the current session.
 
+Fresh clients store auth tokens under keys prefixed with
+`sb-${projectRef}-auth-token-fresh-`. The library automatically purges old
+keys whenever a new fresh client is created or promoted so stale entries do not
+linger in `localStorage`.
+
 --- ## Future Features
 Push notifications (web + mobile)
 Offline drafts and local caching (message history cached on load)

--- a/tests/purgeOldAuthKeys.test.ts
+++ b/tests/purgeOldAuthKeys.test.ts
@@ -1,0 +1,31 @@
+import { purgeOldAuthKeys, createFreshSupabaseClient, localStorageKey } from '../src/lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+jest.mock('@supabase/supabase-js', () => {
+  return {
+    createClient: jest.fn(() => ({ auth: {}, realtime: {} }))
+  };
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  (createClient as jest.Mock).mockClear();
+});
+
+test('purgeOldAuthKeys removes stale keys', () => {
+  const prefix = `${localStorageKey}-fresh-`;
+  localStorage.setItem(`${prefix}old`, 'a');
+  localStorage.setItem(`${prefix}keep`, 'b');
+  purgeOldAuthKeys(`${prefix}keep`);
+  expect(localStorage.getItem(`${prefix}old`)).toBeNull();
+  expect(localStorage.getItem(`${prefix}keep`)).toBe('b');
+});
+
+test('createFreshSupabaseClient purges previous keys', () => {
+  const prefix = `${localStorageKey}-fresh-`;
+  localStorage.setItem(`${prefix}stale`, 'x');
+  const client = createFreshSupabaseClient();
+  const key = (client as any).__storageKey;
+  expect(localStorage.getItem(`${prefix}stale`)).toBeNull();
+  expect(localStorage.getItem(key)).not.toBeNull();
+});


### PR DESCRIPTION
## Summary
- automatically remove old `sb-<project>-auth-token-fresh-*` keys from localStorage
- keep only the active key when creating a new fresh client
- purge keys again after promoting a fallback client
- document the cleanup behaviour
- add unit tests for the helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694b59b35883279bf87e71affe6e26