### PR TITLE
Remove leftover console comment

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -16,10 +16,6 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    // eslint-disable-next-line no-console
-  }
-
   private handleReset = () => {
     this.setState({ hasError: false });
   };


### PR DESCRIPTION
## Summary
- remove empty `componentDidCatch` implementation from the ErrorBoundary

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694e188d408327a722a0f62b3e170c