### PR TITLE
Add file attachment support

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -41,7 +41,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
 
   const handleSendMessage = async (
     content: string,
-    type?: 'text' | 'command' | 'audio' | 'image',
+    type?: 'text' | 'command' | 'audio' | 'image' | 'file',
     fileUrl?: string
   ) => {
     try {

--- a/src/components/chat/FailedMessageItem.tsx
+++ b/src/components/chat/FailedMessageItem.tsx
@@ -22,6 +22,13 @@ export const FailedMessageItem: React.FC<Props> = ({ message, onResend }) => {
             onClick={() => setShowImageModal(true)}
           />
         )}
+        {message.type === 'file' && (
+          <div className="max-w-xs">
+            <a href={message.dataUrl} download className="text-blue-600 underline break-all">
+              {message.fileName || 'Download file'}
+            </a>
+          </div>
+        )}
         {message.type === 'audio' && message.dataUrl && (
           <audio controls src={message.dataUrl} className="max-w-xs" />
         )}

--- a/src/components/chat/FileAttachment.tsx
+++ b/src/components/chat/FileAttachment.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { FileText } from 'lucide-react'
+import { formatBytes } from '../../lib/utils'
+
+interface FileAttachmentProps {
+  url: string
+  meta?: string
+}
+
+export const FileAttachment: React.FC<FileAttachmentProps> = ({ url, meta }) => {
+  let name = 'file'
+  let size = 0
+  let type = ''
+  try {
+    const parsed = meta ? JSON.parse(meta) : {}
+    name = parsed.name || name
+    size = parsed.size || size
+    type = parsed.type || type
+  } catch {
+    // ignore
+  }
+
+  const preview = type === 'application/pdf' || type.startsWith('text/')
+
+  return (
+    <div className="mt-1 max-w-xs">
+      {preview && (
+        <iframe
+          src={url}
+          title={name}
+          className="w-full h-48 rounded border mb-2"
+        />
+      )}
+      <div className="flex items-center space-x-2">
+        <FileText className="w-4 h-4 flex-shrink-0" />
+        <a href={url} download className="text-blue-600 underline break-all">
+          {name}
+        </a>
+        {size > 0 && (
+          <span className="text-xs text-gray-500">({formatBytes(size)})</span>
+        )}
+        {!preview && type && (
+          <span className="text-xs text-gray-500">{type}</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -14,7 +14,7 @@ import toast from 'react-hot-toast'
 interface MessageInputProps {
   onSendMessage: (
     content: string,
-    type?: 'text' | 'command' | 'audio' | 'image',
+    type?: 'text' | 'command' | 'audio' | 'image' | 'file',
     fileUrl?: string
   ) => Promise<void> | void
   placeholder?: string
@@ -201,6 +201,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         })
         .finally(() => onUploadStatusChange(false))
     }
+    e.target.value = ''
   }
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -209,12 +210,15 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       onUploadStatusChange(true)
       uploadChatFile(file)
         .then(url => {
-          onSendMessage('', 'image', url)
+          const messageType = file.type.startsWith('image/') ? 'image' : 'file'
+          const meta = JSON.stringify({ name: file.name, size: file.size, type: file.type })
+          onSendMessage(messageType === 'image' ? '' : meta, messageType as any, url)
         })
         .catch(err => {
         })
         .finally(() => onUploadStatusChange(false))
     }
+    e.target.value = ''
   }
 
   const startRecording = async () => {

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -15,6 +15,7 @@ import {
 import { Avatar } from '../ui/Avatar'
 import { ImageModal } from '../ui/ImageModal'
 import { Button } from '../ui/Button'
+import { FileAttachment } from './FileAttachment'
 import { formatTime, shouldGroupMessage, cn } from '../../lib/utils'
 import type { Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
@@ -261,6 +262,8 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                       className="mt-1 max-w-xs rounded cursor-pointer"
                       onClick={() => setShowImageModal(true)}
                     />
+                  ) : message.message_type === 'file' && message.file_url ? (
+                    <FileAttachment url={message.file_url} meta={message.content} />
                   ) : (
                     message.content
                   )}

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -14,6 +14,7 @@ import { UserSearchSelect } from './UserSearchSelect'
 import { MessageInput } from '../chat/MessageInput'
 import { MobileChatFooter } from '../layout/MobileChatFooter'
 import { FailedMessageItem } from '../chat/FailedMessageItem'
+import { FileAttachment } from '../chat/FileAttachment'
 import { useFailedMessages } from '../../hooks/useFailedMessages'
 import { formatTime, shouldGroupMessage } from '../../lib/utils'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
@@ -72,7 +73,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
 
   const handleSendMessage = async (
     content: string,
-    type?: 'text' | 'command' | 'audio' | 'image',
+    type?: 'text' | 'command' | 'audio' | 'image' | 'file',
     fileUrl?: string
   ) => {
     try {
@@ -350,6 +351,10 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                       }`}>
                         {message.message_type === 'audio' ? (
                           <audio controls src={message.content} className="mt-1 max-w-full" />
+                        ) : message.message_type === 'image' && message.file_url ? (
+                          <img src={message.file_url} alt="uploaded" className="mt-1 max-w-xs rounded" />
+                        ) : message.message_type === 'file' && message.file_url ? (
+                          <FileAttachment url={message.file_url} meta={message.content} />
                         ) : (
                           <p className="text-sm break-words">{message.content}</p>
                         )}

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -30,7 +30,7 @@ interface DirectMessagesContextValue {
   startConversation: (username: string) => Promise<string | null>;
   sendMessage: (
     content: string,
-    messageType?: 'text' | 'command' | 'audio' | 'image',
+    messageType?: 'text' | 'command' | 'audio' | 'image' | 'file',
     fileUrl?: string
   ) => Promise<void>;
   markAsRead: (conversationId: string) => Promise<void>;
@@ -374,7 +374,7 @@ export function useConversationMessages(conversationId: string | null) {
   const sendMessage = useCallback(
     async (
       content: string,
-      messageType: 'text' | 'command' | 'audio' | 'image' = 'text',
+      messageType: 'text' | 'command' | 'audio' | 'image' | 'file' = 'text',
       fileUrl?: string
     ) => {
     

--- a/src/hooks/useFailedMessages.tsx
+++ b/src/hooks/useFailedMessages.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 export interface FailedMessage {
   id: string
-  type: 'text' | 'image' | 'audio'
+  type: 'text' | 'image' | 'audio' | 'file'
   content: string
   dataUrl?: string
   fileName?: string

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -18,7 +18,7 @@ const STORED_MESSAGE_LIMIT = 200;
 export const prepareMessageData = (
   userId: string,
   content: string,
-  messageType: 'text' | 'command' | 'audio' | 'image',
+  messageType: 'text' | 'command' | 'audio' | 'image' | 'file',
   fileUrl?: string
 ) => ({
   user_id: userId,
@@ -31,7 +31,7 @@ export const prepareMessageData = (
 export const insertMessage = async (messageData: {
   user_id: string;
   content: string;
-  message_type: 'text' | 'command' | 'audio' | 'image';
+  message_type: 'text' | 'command' | 'audio' | 'image' | 'file';
   file_url?: string;
   audio_url?: string;
 }) => {
@@ -63,7 +63,7 @@ export const insertMessage = async (messageData: {
 export const refreshSessionAndRetry = async (messageData: {
   user_id: string;
   content: string;
-  message_type: 'text' | 'command' | 'audio' | 'image';
+  message_type: 'text' | 'command' | 'audio' | 'image' | 'file';
   file_url?: string;
   audio_url?: string;
 }) => {
@@ -96,7 +96,7 @@ interface MessagesContextValue {
   sending: boolean;
   sendMessage: (
     content: string,
-    type?: 'text' | 'command' | 'audio' | 'image',
+    type?: 'text' | 'command' | 'audio' | 'image' | 'file',
     fileUrl?: string
   ) => Promise<void>;
   editMessage: (id: string, content: string) => Promise<void>;
@@ -490,7 +490,7 @@ function useProvideMessages(): MessagesContextValue {
 
   const sendMessage = useCallback(async (
     content: string,
-    messageType: 'text' | 'command' | 'audio' | 'image' = 'text',
+    messageType: 'text' | 'command' | 'audio' | 'image' | 'file' = 'text',
     fileUrl?: string
   ) => {
     const timestamp = new Date().toISOString();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,14 @@ export function isToday(date: string | Date) {
   return d.toDateString() === today.toDateString()
 }
 
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
 export function groupMessagesByDate(messages: ChatMessage[]) {
   const groups: { date: string; messages: ChatMessage[] }[] = []
   let currentDate = ''

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -65,6 +65,30 @@ test('renders audio message', () => {
   expect(audio).toHaveAttribute('src', audioMessage.audio_url)
 })
 
+test('renders file message', () => {
+  const fileMeta = JSON.stringify({ name: 'doc.txt', size: 10, type: 'text/plain' })
+  const fileMessage = {
+    ...baseMessage,
+    message_type: 'file',
+    content: fileMeta,
+    file_url: 'https://example.com/doc.txt',
+  } as Message
+
+  render(
+    <MessageItem
+      message={fileMessage}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+      containerRef={React.createRef()}
+    />
+  )
+
+  const link = screen.getByRole('link', { name: /doc.txt/i })
+  expect(link).toHaveAttribute('href', fileMessage.file_url)
+})
+
 test('icon buttons have aria-labels', () => {
   render(
     <MessageItem


### PR DESCRIPTION
## Summary
- support new `file` message type for chat and DMs
- add `FileAttachment` component to preview/download files
- update message input to upload any file type
- show file attachments in message items
- update unit tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694ebbf90083279381b57696234420