### PR TITLE
Fix mobile padding and disable horizontal chat scroll

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -79,7 +79,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className="relative flex-1 overflow-y-auto overflow-x-visible p-4 md:p-2 pb-[calc(env(safe-area-inset-bottom)_+_20rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_6rem)]"
+      className="relative flex-1 w-full overflow-y-auto overflow-x-hidden p-4 md:p-2 pb-[calc(env(safe-area-inset-bottom)_+_24rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_6rem)]"
     >
 
 

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -316,7 +316,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             <div
               ref={messagesRef}
               onScroll={handleScroll}
-              className="flex-1 overflow-y-auto p-4 space-y-3 pb-[calc(env(safe-area-inset-bottom)_+_20rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_6rem)]"
+              className="flex-1 w-full overflow-y-auto overflow-x-hidden p-4 space-y-3 pb-[calc(env(safe-area-inset-bottom)_+_24rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_6rem)]"
             >
               {messages.map((message, index) => {
                 const previousMessage = messages[index - 1]


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on message views
- increase mobile bottom padding so the text box doesn't cover the last message

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686957f6fb5c83278c4fb97b410efaa1