### PR TITLE
Add audio preview for file attachments

### DIFF
--- a/src/components/chat/FileAttachment.tsx
+++ b/src/components/chat/FileAttachment.tsx
@@ -20,16 +20,20 @@ export const FileAttachment: React.FC<FileAttachmentProps> = ({ url, meta }) => 
     // ignore
   }
 
-  const preview = type === 'application/pdf' || type.startsWith('text/')
+  const previewDocument = type === 'application/pdf' || type.startsWith('text/')
+  const previewAudio = type.startsWith('audio/')
 
   return (
     <div className="mt-1 max-w-xs">
-      {preview && (
+      {previewDocument && (
         <iframe
           src={url}
           title={name}
           className="w-full h-48 rounded border mb-2"
         />
+      )}
+      {previewAudio && (
+        <audio controls src={url} className="w-full mt-1 mb-2" />
       )}
       <div className="flex items-center space-x-2">
         <FileText className="w-4 h-4 flex-shrink-0" />
@@ -39,7 +43,7 @@ export const FileAttachment: React.FC<FileAttachmentProps> = ({ url, meta }) => 
         {size > 0 && (
           <span className="text-xs text-gray-500">({formatBytes(size)})</span>
         )}
-        {!preview && type && (
+        {!previewDocument && !previewAudio && type && (
           <span className="text-xs text-gray-500">{type}</span>
         )}
       </div>

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -89,6 +89,30 @@ test('renders file message', () => {
   expect(link).toHaveAttribute('href', fileMessage.file_url)
 })
 
+test('renders audio file preview', () => {
+  const fileMeta = JSON.stringify({ name: 'sound.mp3', size: 123, type: 'audio/mpeg' })
+  const audioFile = {
+    ...baseMessage,
+    message_type: 'file',
+    content: fileMeta,
+    file_url: 'https://example.com/sound.mp3'
+  } as Message
+
+  const { container } = render(
+    <MessageItem
+      message={audioFile}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+      containerRef={React.createRef()}
+    />
+  )
+
+  const audio = container.querySelector('audio')
+  expect(audio).toHaveAttribute('src', audioFile.file_url)
+})
+
 test('icon buttons have aria-labels', () => {
   render(
     <MessageItem


### PR DESCRIPTION
## Summary
- preview audio files in chat attachments
- test audio file preview in message item

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695852d5288327aff81896b6381a6f