### PR TITLE
Fix GoTrueClient duplication warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,10 @@ This disconnects the realtime client, reconnects it and sets the auth token
 from the current session.
 
 Fresh clients store auth tokens under keys prefixed with
-`sb-${projectRef}-auth-token-fresh-`. The library automatically purges old
-keys whenever a new fresh client is created or promoted so stale entries do not
-linger in `localStorage`.
+`sb-${projectRef}-auth-token-fresh-<unique-id>` where the unique id is
+generated via `crypto.randomUUID()` when available. The library automatically
+purges old keys whenever a new fresh client is created or promoted so stale
+entries do not linger in `localStorage`.
 
 --- ## Future Features
 Push notifications (web + mobile)

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -68,7 +68,9 @@ export const purgeOldAuthKeys = (activeKey?: string) => {
 
 // Create fresh client with unique storage key to avoid conflicts
 export function createFreshSupabaseClient() {
-  const uniqueStorageKey = `sb-${projectRef}-auth-token-fresh-${Date.now()}`
+  const uniqueStorageKey = `sb-${projectRef}-auth-token-fresh-${
+    typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)
+  }`
   purgeOldAuthKeys(uniqueStorageKey)
   
   try {


### PR DESCRIPTION
## Summary
- ensure fresh Supabase clients always have a unique storage key
- document unique key generation in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695c7b106c83279f50f3719c307955