### PR TITLE
Add user-based chat bubble colors

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -16,7 +16,7 @@ import { Avatar } from '../ui/Avatar'
 import { ImageModal } from '../ui/ImageModal'
 import { Button } from '../ui/Button'
 import { FileAttachment } from './FileAttachment'
-import { formatTime, shouldGroupMessage, cn } from '../../lib/utils'
+import { formatTime, shouldGroupMessage, cn, getReadableTextColor } from '../../lib/utils'
 import type { Message } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import toast from 'react-hot-toast'
@@ -55,6 +55,11 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
 
     const isGrouped = shouldGroupMessage(message, previousMessage)
     const isOwner = profile?.id === message.user_id
+
+    const bubbleColor = message.user?.color
+    const bubbleStyle = bubbleColor
+      ? { backgroundColor: bubbleColor, color: getReadableTextColor(bubbleColor) }
+      : undefined
 
     const handleMouseEnterReactions = () => {
       if (reactionTimeoutRef.current) {
@@ -245,8 +250,10 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
               <div className="relative inline-block max-w-full group/message">
                 <div
                   className={cn(
-                    'relative peer bg-gray-100 dark:bg-gray-700 rounded-xl px-3 py-2 break-words space-y-1'
+                    'relative peer rounded-xl px-3 py-2 break-words space-y-1',
+                    bubbleStyle ? '' : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
                   )}
+                  style={bubbleStyle}
                 >
                   <MessageReactions
                     message={message}

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -16,7 +16,7 @@ import { MobileChatFooter } from '../layout/MobileChatFooter'
 import { FailedMessageItem } from '../chat/FailedMessageItem'
 import { FileAttachment } from '../chat/FileAttachment'
 import { useFailedMessages } from '../../hooks/useFailedMessages'
-import { formatTime, shouldGroupMessage } from '../../lib/utils'
+import { formatTime, shouldGroupMessage, getReadableTextColor } from '../../lib/utils'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { LoadingSpinner } from '../ui/LoadingSpinner'
 import toast from 'react-hot-toast'
@@ -322,6 +322,10 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 const previousMessage = messages[index - 1]
                 const isGrouped = shouldGroupMessage(message, previousMessage)
                 const isOwn = message.sender_id === profile?.id
+                const bubbleColor = isOwn ? profile?.color : message.sender?.color
+                const bubbleStyle = bubbleColor
+                  ? { backgroundColor: bubbleColor, color: getReadableTextColor(bubbleColor) }
+                  : undefined
 
                 return (
                   <motion.div
@@ -344,11 +348,14 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                         />
                       )}
                       
-                      <div className={`rounded-2xl px-4 py-2 ${
-                        isOwn
-                          ? 'bg-blue-600 text-white'
-                          : 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-600'
-                      }`}>
+                      <div
+                        className={`rounded-2xl px-4 py-2 ${
+                          bubbleStyle ? '' : isOwn
+                              ? 'bg-blue-600 text-white'
+                              : 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-600'
+                        }`}
+                        style={bubbleStyle}
+                      >
                         {message.message_type === 'audio' ? (
                           <audio controls src={message.content} className="mt-1 max-w-full" />
                         ) : message.message_type === 'image' && message.file_url ? (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,16 @@ import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import type { ChatMessage } from './supabase'
 
+export function getReadableTextColor(hexColor: string) {
+  if (!hexColor) return '#000'
+  const c = hexColor.replace('#', '')
+  const r = parseInt(c.substring(0, 2), 16)
+  const g = parseInt(c.substring(2, 4), 16)
+  const b = parseInt(c.substring(4, 6), 16)
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000
+  return yiq >= 128 ? '#000' : '#fff'
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -128,3 +128,25 @@ test('icon buttons have aria-labels', () => {
   const addReaction = screen.getByRole('button', { name: /add reaction/i })
   expect(addReaction).toBeInTheDocument()
 })
+
+test('applies user color to message bubble', () => {
+  const colored = {
+    ...baseMessage,
+    content: 'hello',
+    user: { ...baseMessage.user, color: '#ff0000' }
+  } as Message
+
+  render(
+    <MessageItem
+      message={colored}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+      containerRef={React.createRef()}
+    />
+  )
+
+  const msg = screen.getByText('hello')
+  expect(msg.parentElement).toHaveStyle('background-color: #ff0000')
+})


### PR DESCRIPTION
## Summary
- show message bubbles using the sender's chosen color
- apply same bubble coloring in direct messages
- expose `getReadableTextColor` util for text contrast
- test chat bubble color in `MessageItem`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869637bf0688327a5f71e12d7e3e4df