### PR TITLE
Fix invalid finally syntax

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -580,22 +580,24 @@ function useProvideMessages(): MessagesContextValue {
       }
     };
 
-    let lastError: any = null;
-    for (let i = 0; i < 3; i++) {
-      try {
-        await attemptSend();
-        lastError = null;
-        break;
-      } catch (err) {
-        lastError = err;
-        if (i < 2) {
-          await new Promise(res => setTimeout(res, 300));
+    try {
+      let lastError: any = null;
+      for (let i = 0; i < 3; i++) {
+        try {
+          await attemptSend();
+          lastError = null;
+          break;
+        } catch (err) {
+          lastError = err;
+          if (i < 2) {
+            await new Promise(res => setTimeout(res, 300));
+          }
         }
       }
-    }
 
-    if (lastError) {
-      throw lastError;
+      if (lastError) {
+        throw lastError;
+      }
     } finally {
       setSending(false);
     }


### PR DESCRIPTION
## Summary
- wrap retry logic for `sendMessage` in `try` block
- move `setSending(false)` into new `finally` block

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e75239fdc8327946d5593d2ef9bfa