### PR TITLE
Add jump to latest button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Emoji reactions, toggled with live updates
 Slash command system (/shrug, /me, /giphy) with a pluggable command registry
 Typing indicators displayed in real-time using broadcast channels
 Sticky date headers that remain visible while scrolling
+"Jump to Latest" button appears when new messages arrive and you're not at the bottom
 ### Direct Messaging (DMs)
 1-on-1 private chats using dedicated DM tables and RLS policies
 Unread tracking with live badge updates and local fallback

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { ArrowDown } from 'lucide-react'
 import { useMessages } from '../../hooks/useMessages'
 import { useTyping } from '../../hooks/useTyping'
 import { groupMessagesByDate, cn, shouldGroupMessage } from '../../lib/utils'
@@ -35,6 +36,13 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     if (!el) return
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 20
     setAutoScroll(atBottom)
+  }, [])
+
+  const scrollToBottom = useCallback(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+      setAutoScroll(true)
+    }
   }, [])
 
   const groupedMessages = useMemo(() => groupMessagesByDate(messages), [messages])
@@ -148,6 +156,17 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
           </motion.div>
         )}
       </AnimatePresence>
+
+      {!autoScroll && (
+        <button
+          type="button"
+          onClick={scrollToBottom}
+          aria-label="Jump to latest"
+          className="absolute bottom-20 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90"
+        >
+          <ArrowDown className="w-5 h-5" />
+        </button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- offer a small floating button in the chat message list for jumping to the latest messages
- document the jump to latest control in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee79e6b30832793d4537cc6fb44b8