### PR TITLE
Adjust mobile jump button offset

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -162,7 +162,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
           type="button"
           onClick={scrollToBottom}
           aria-label="Jump to latest"
-          className="fixed bottom-[calc(env(safe-area-inset-bottom)_+_8rem)] md:bottom-32 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90"
+          className="fixed bottom-[calc(env(safe-area-inset-bottom)_+_10rem)] md:bottom-32 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90"
         >
           <ArrowDown className="w-5 h-5" />
         </button>

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -404,7 +404,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                   type="button"
                   onClick={scrollToBottom}
                   aria-label="Jump to latest"
-                  className="fixed bottom-[calc(env(safe-area-inset-bottom)_+_8rem)] md:bottom-32 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90"
+                  className="fixed bottom-[calc(env(safe-area-inset-bottom)_+_10rem)] md:bottom-32 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90"
                 >
                   <ArrowDown className="w-5 h-5" />
                 </button>


### PR DESCRIPTION
## Summary
- tweak jump-to-present button spacing for chat messages
- tweak jump-to-present button spacing for DMs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686ef2a9798c8327a940d6c85c282615