### PR TITLE
Enable incremental chat history loading

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -25,7 +25,10 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     editMessage,
     deleteMessage,
     togglePin,
-    toggleReaction
+    toggleReaction,
+    loadOlderMessages,
+    loadingMore,
+    hasMore
   } = useMessages()
   const { typingUsers } = useTyping('general')
   const containerRef = useRef<HTMLDivElement>(null)
@@ -36,7 +39,11 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     if (!el) return
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 20
     setAutoScroll(atBottom)
-  }, [])
+
+    if (el.scrollTop < 100 && hasMore && !loadingMore) {
+      loadOlderMessages()
+    }
+  }, [hasMore, loadingMore, loadOlderMessages])
 
   const scrollToBottom = useCallback(() => {
     if (containerRef.current) {
@@ -89,6 +96,12 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
       onScroll={handleScroll}
       className="relative flex-1 w-full overflow-y-auto overflow-x-hidden p-4 md:p-2 pb-[calc(env(safe-area-inset-bottom)_+_24rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_6rem)]"
     >
+
+      {loadingMore && (
+        <div className="flex justify-center py-2 text-gray-500 text-sm">
+          <LoadingSpinner size="sm" /> Loading more...
+        </div>
+      )}
 
 
       {groupedMessages.map(group => (

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -40,7 +40,10 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
     startConversation,
     sendMessage,
     markAsRead,
-    sending
+    sending,
+    loadOlderMessages,
+    loadingMore,
+    hasMore
   } = useDirectMessages()
   const { failedMessages, addFailedMessage, removeFailedMessage } = useFailedMessages(currentConversation || 'none')
   
@@ -96,7 +99,10 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
     if (!el) return
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 20
     setAutoScroll(atBottom)
-  }, [])
+    if (el.scrollTop < 100 && hasMore && !loadingMore) {
+      loadOlderMessages()
+    }
+  }, [hasMore, loadingMore, loadOlderMessages])
 
   const scrollToBottom = useCallback(() => {
     if (messagesRef.current) {
@@ -326,6 +332,11 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
               onScroll={handleScroll}
               className="relative flex-1 w-full overflow-y-auto overflow-x-hidden p-4 space-y-3 pb-[calc(env(safe-area-inset-bottom)_+_24rem)] md:pb-[calc(env(safe-area-inset-bottom)_+_6rem)]"
             >
+              {loadingMore && (
+                <div className="flex justify-center py-2 text-gray-500 text-sm">
+                  <LoadingSpinner size="sm" /> Loading more...
+                </div>
+              )}
               {messages.map((message, index) => {
                 const previousMessage = messages[index - 1]
                 const isGrouped = shouldGroupMessage(message, previousMessage)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const MESSAGE_FETCH_LIMIT = parseInt(
-  import.meta.env.VITE_MESSAGE_FETCH_LIMIT || '100'
+  import.meta.env.VITE_MESSAGE_FETCH_LIMIT || '40'
 )
 export const PRESENCE_INTERVAL_MS = parseInt(
   import.meta.env.VITE_PRESENCE_INTERVAL_MS || '30000'


### PR DESCRIPTION
## Summary
- limit initial chat history load to 40 messages
- fetch older group messages when scrolling near the top
- add same lazy loading for direct message conversations
- show loading indicators while fetching older messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef9c526ec832783f7e6e4fbf737b1