### PR TITLE
Add conversation summary slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Grouped message bubbles with optimized UI (shows avatar only on first message in
 Editable and deletable messages, secured with row-level security (RLS)
 Pinned messages for announcements or important information
 Emoji reactions, toggled with live updates
-Slash command system (/shrug, /me, /giphy) with a pluggable command registry
+Slash command system (/shrug, /me, /giphy, /summary) with a pluggable command registry
 Typing indicators displayed in real-time using broadcast channels
 Sticky date headers that remain visible while scrolling
 "Jump to Latest" button appears when new messages arrive and you're not at the bottom
@@ -121,6 +121,7 @@ View moderation logs
 VITE_SUPABASE_URL=<your Supabase project URL>
 VITE_SUPABASE_ANON_KEY=<your Supabase anon key>
 VITE_PRESENCE_INTERVAL_MS=30000 # optional
+VITE_OPENAI_KEY=<your OpenAI API key> # for /summary
 --- ## Getting Started
 
 # Clone the repo

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -120,6 +120,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
           placeholder="Type a message"
           cacheKey="general"
           onUploadStatusChange={setUploading}
+          messages={messages}
         />
       </div>
 
@@ -134,6 +135,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
           className="border-t"
           cacheKey="general"
           onUploadStatusChange={setUploading}
+          messages={messages}
         />
       </MobileChatFooter>
     </motion.div>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -4,6 +4,7 @@ import { Send, Smile, Command, Plus, Mic } from 'lucide-react'
 import { useTyping } from '../../hooks/useTyping'
 import { Button } from '../ui/Button'
 import { processSlashCommand, slashCommands } from '../../lib/utils'
+import type { ChatMessage } from '../../lib/supabase'
 import { uploadVoiceMessage, uploadChatFile } from '../../lib/supabase'
 import type { EmojiPickerProps, EmojiClickData } from '../../types'
 import { useEmojiPicker } from '../../hooks/useEmojiPicker'
@@ -22,6 +23,7 @@ interface MessageInputProps {
   className?: string
   cacheKey?: string
   onUploadStatusChange?: (uploading: boolean) => void
+  messages?: ChatMessage[]
 }
 
 export const MessageInput: React.FC<MessageInputProps> = ({
@@ -30,7 +32,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   disabled = false,
   className = '',
   cacheKey = 'general',
-  onUploadStatusChange = () => {}
+  onUploadStatusChange = () => {},
+  messages = []
 }) => {
   const { draft, setDraft, clear } = useDraft(cacheKey)
   const [message, setMessage] = useState(draft)
@@ -123,7 +126,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
 
     // Process slash commands
-    const processedMessage = processSlashCommand(message.trim())
+    const processedMessage = await processSlashCommand(message.trim(), messages)
     const finalMessage = processedMessage || message.trim()
 
     try {

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -429,6 +429,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 placeholder={`Message @${currentConv.other_user?.username}...`}
                 cacheKey={`dm-${currentConversation}`}
                 onUploadStatusChange={setUploading}
+                messages={messages}
               />
             </div>
 
@@ -443,6 +444,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 className="border-t"
                 cacheKey={`dm-${currentConversation}`}
                 onUploadStatusChange={setUploading}
+                messages={messages}
               />
             </MobileChatFooter>
           </>

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,28 @@
+import type { ChatMessage } from './supabase'
+
+export async function summarizeConversation(messages: ChatMessage[]): Promise<string> {
+  const apiKey = import.meta.env.VITE_OPENAI_KEY
+  if (!apiKey) {
+    throw new Error('Missing OpenAI API key')
+  }
+
+  const payload = {
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: 'Summarize the following conversation in a short paragraph.' },
+      ...messages.map(m => ({ role: 'user', content: m.content }))
+    ]
+  }
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(payload)
+  })
+
+  const data = await res.json()
+  return data.choices?.[0]?.message?.content?.trim() || ''
+}

--- a/tests/summaryCommand.test.tsx
+++ b/tests/summaryCommand.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MessageInput } from '../src/components/chat/MessageInput'
+import { summarizeConversation } from '../src/lib/ai'
+
+jest.mock('../src/lib/ai')
+
+jest.mock('../src/hooks/useTyping', () => ({
+  useTyping: () => ({ startTyping: jest.fn(), stopTyping: jest.fn() })
+}))
+
+jest.mock('../src/lib/supabase', () => ({
+  uploadVoiceMessage: jest.fn(),
+  uploadChatFile: jest.fn(),
+  DEBUG: false,
+}))
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('summary slash command calls API and sends result', async () => {
+  const onSend = jest.fn()
+  ;(summarizeConversation as jest.Mock).mockResolvedValue('summary text')
+
+  render(
+    <MessageInput
+      onSendMessage={onSend}
+      messages={[{ id: '1', user_id: 'u1', content: 'hello' } as any]}
+    />
+  )
+
+  const textarea = screen.getByRole('textbox')
+  await userEvent.type(textarea, '/summary')
+  await userEvent.keyboard('{Enter}')
+
+  expect(summarizeConversation).toHaveBeenCalled()
+  await waitFor(() => expect(onSend).toHaveBeenCalledWith('summary text'))
+})


### PR DESCRIPTION
## Summary
- implement `summarizeConversation` API helper
- extend slash command processor with `/summary`
- update `MessageInput` to execute async slash commands
- pass messages down so `/summary` can read history
- document new command and `VITE_OPENAI_KEY`
- test that `/summary` calls the API and sends the returned text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc3bd102c8327bf8e6c77f91a65b2