### PR TITLE
Add double-tap start conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Sticky date headers that remain visible while scrolling
 Unread tracking with live badge updates and local fallback
 Toast preview notifications for new incoming messages (if not viewing that thread)
 Search and initiate new conversations via username
+Double-tap a user in search to start a new conversation if one doesn't already exist
 Live presence updates in DMs (online/away indicators)
 Message read status stored with read_at timestamps per message
 ### User Presence System

--- a/src/components/dms/UserSearchSelect.tsx
+++ b/src/components/dms/UserSearchSelect.tsx
@@ -35,7 +35,7 @@ export const UserSearchSelect: React.FC<UserSearchSelectProps> = ({ value, onCha
           {!isLoading && list.map(u => (
             <button
               key={u.id}
-              onClick={() => onSelect(u)}
+              onDoubleClick={() => onSelect(u)}
               className="w-full flex items-center px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 text-left"
             >
               <Avatar src={u.avatar_url} alt={u.display_name} size="sm" color={u.color} status={u.status} showStatus />


### PR DESCRIPTION
## Summary
- require a double-click/double-tap on usernames in the DM search list to start a conversation
- document the new DM search gesture in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc650841c8327a76f0e2b6a2022c8