### PR TITLE
Implement threaded replies with collapsible chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Grouped message bubbles with optimized UI (shows avatar only on first message in
 Editable and deletable messages, secured with row-level security (RLS)
 Pinned messages for announcements or important information
 Emoji reactions, toggled with live updates
+Threaded replies with collapsible chains
 Slash command system (/shrug, /me, /giphy) with a pluggable command registry
 Typing indicators displayed in real-time using broadcast channels
 Sticky date headers that remain visible while scrolling
@@ -182,7 +183,6 @@ entries do not linger in `localStorage`.
 --- ## Future Features
 Push notifications (web + mobile)
 Offline drafts and local caching (message history cached on load)
-Threaded replies and collapsible chains
 Video or voice rooms using WebRTC
 Third-party plugin support
 Federation or multi-tenant support

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -33,7 +33,8 @@ interface DirectMessagesContextValue {
   sendMessage: (
     content: string,
     messageType?: 'text' | 'command' | 'audio' | 'image' | 'file',
-    fileUrl?: string
+    fileUrl?: string,
+    replyTo?: string
   ) => Promise<void>;
   markAsRead: (conversationId: string) => Promise<void>;
   loadOlderMessages: () => Promise<void>;
@@ -421,7 +422,8 @@ export function useConversationMessages(conversationId: string | null) {
     async (
       content: string,
       messageType: 'text' | 'command' | 'audio' | 'image' | 'file' = 'text',
-      fileUrl?: string
+      fileUrl?: string,
+      _replyTo?: string
     ) => {
     
       if (!user || !conversationId || !content.trim()) return;

--- a/tests/buildMessageTree.test.ts
+++ b/tests/buildMessageTree.test.ts
@@ -1,0 +1,25 @@
+import { buildMessageTree } from '../src/lib/utils'
+import type { Message } from '../src/lib/supabase'
+
+test('builds nested message tree', () => {
+  const base: Partial<Message> = {
+    user_id: 'u1',
+    content: 'hi',
+    message_type: 'text',
+    reactions: {},
+    pinned: false,
+    created_at: '2020-01-01T00:00:00Z',
+    updated_at: '2020-01-01T00:00:00Z'
+  }
+  const msgs: Message[] = [
+    { ...base, id: '1' } as Message,
+    { ...base, id: '2', reply_to: '1', created_at: '2020-01-01T00:01:00Z' } as Message,
+    { ...base, id: '3', reply_to: '2', created_at: '2020-01-01T00:02:00Z' } as Message
+  ]
+
+  const tree = buildMessageTree(msgs)
+  expect(tree).toHaveLength(1)
+  expect(tree[0].id).toBe('1')
+  expect(tree[0].replies[0].id).toBe('2')
+  expect(tree[0].replies[0].replies[0].id).toBe('3')
+})


### PR DESCRIPTION
## Summary
- support replying to specific messages and show reply banner
- create nested message display with collapsible reply chains
- extend message sending hooks to include `reply_to`
- add `buildMessageTree` helper
- update docs for threaded replies
- add unit test for message tree logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc4a32edc8327892170ea537f18cd