### PR TITLE
Add AI suggested replies hook and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Message results are highlighted and jump-to enabled
 --- ## AI-Ready Features (Planned)
 Thread summarization using OpenAI GPT
 Tone analysis to detect emotional content
-AI replies and auto-suggested responses
+AI replies and auto-suggested responses (implemented)
 Moderation engine to flag offensive or inappropriate content
 Smart mentions or entity linking to user profiles, topics, or commands
 --- ## Security & Moderation
@@ -122,7 +122,7 @@ View moderation logs
 VITE_SUPABASE_URL=<your Supabase project URL>
 VITE_SUPABASE_ANON_KEY=<your Supabase anon key>
 VITE_PRESENCE_INTERVAL_MS=30000 # optional
-VITE_OPENAI_KEY=<your OpenAI API key> # for /summary
+VITE_OPENAI_KEY=<your OpenAI API key> # for /summary and suggestions
 --- ## Getting Started
 
 # Clone the repo
@@ -147,6 +147,9 @@ npx supabase db push
 
 # Start the dev server
 npm run dev
+
+# AI suggested replies
+OpenAI-powered reply suggestions appear above the message box. Toggle this feature in **Settings → AI → Suggested Replies**.
 --- ## Testing & CI/CD ### Testing Stack
 Jest for unit tests
 React Testing Library for DOM interaction

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -10,6 +10,7 @@ import type { EmojiPickerProps, EmojiClickData } from '../../types'
 import { useEmojiPicker } from '../../hooks/useEmojiPicker'
 import { RecordingIndicator } from '../ui/RecordingIndicator'
 import { useDraft } from '../../hooks/useDraft'
+import { useSuggestedReplies, useSuggestionsEnabled } from '../../hooks/useSuggestedReplies'
 import toast from 'react-hot-toast'
 
 interface MessageInputProps {
@@ -53,6 +54,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const mediaStreamRef = useRef<MediaStream | null>(null)
   const audioChunksRef = useRef<Blob[]>([])
+  const { enabled: suggestionsEnabled, setEnabled: _set } = useSuggestionsEnabled()
+  const { suggestions } = useSuggestedReplies(messages, suggestionsEnabled)
 
   // Handle typing indicators
   useEffect(() => {
@@ -320,6 +323,24 @@ export const MessageInput: React.FC<MessageInputProps> = ({
             height={400}
             theme={document.documentElement.classList.contains('dark') ? 'dark' : 'light'}
           />
+        </div>
+      )}
+
+      {suggestionsEnabled && suggestions.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-2">
+          {suggestions.map(s => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => {
+                setMessage(s)
+                textareaRef.current?.focus()
+              }}
+              className="px-3 py-1 rounded-full text-sm bg-gray-200 dark:bg-gray-700"
+            >
+              {s}
+            </button>
+          ))}
         </div>
       )}
 

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { motion } from 'framer-motion'
-import { 
-  Bell, 
+import {
+  Bell,
   Moon,
   Sun,
   Volume2,
@@ -12,13 +12,15 @@ import {
   Download,
   Trash2,
   AlertTriangle,
-  Menu
+  Menu,
+  Brain
 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { useAuth } from '../../hooks/useAuth'
 import toast from 'react-hot-toast'
 import { useTheme, colorSchemes, ColorScheme } from '../../hooks/useTheme'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
+import { useSuggestionsEnabled } from '../../hooks/useSuggestedReplies'
 
 interface SettingsViewProps {
   onToggleSidebar: () => void
@@ -31,6 +33,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
   const { scheme, setScheme } = useTheme()
   const isDesktop = useIsDesktop()
   const { signOut } = useAuth()
+  const { enabled: suggestionsEnabled, setEnabled: setSuggestionsEnabled } = useSuggestionsEnabled()
 
   const handleExportData = () => {
     toast.success('Data export started - you will receive an email when ready')
@@ -71,6 +74,18 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
           description: 'Play sounds for message notifications',
           enabled: sounds,
           onChange: setSounds
+        }
+      ]
+    },
+    {
+      title: 'AI',
+      icon: Brain,
+      settings: [
+        {
+          label: 'Suggested Replies',
+          description: 'Show AI generated reply suggestions',
+          enabled: suggestionsEnabled,
+          onChange: setSuggestionsEnabled
         }
       ]
     }

--- a/src/hooks/useSuggestedReplies.ts
+++ b/src/hooks/useSuggestedReplies.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react'
+import type { ChatMessage } from '../lib/supabase'
+import { getSuggestedReplies } from '../lib/ai'
+
+export function useSuggestionsEnabled() {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('suggestionsEnabled')
+      return stored !== 'false'
+    }
+    return true
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('suggestionsEnabled', String(enabled))
+    } catch {
+      // ignore
+    }
+  }, [enabled])
+
+  return { enabled, setEnabled }
+}
+
+export function useSuggestedReplies(
+  messages: ChatMessage[],
+  enabled: boolean
+) {
+  const [suggestions, setSuggestions] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!enabled) {
+      setSuggestions([])
+      return
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+
+    getSuggestedReplies(messages.slice(-10))
+      .then(res => {
+        if (!controller.signal.aborted) setSuggestions(res)
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setSuggestions([])
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [messages, enabled])
+
+  return { suggestions, loading }
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -26,3 +26,45 @@ export async function summarizeConversation(messages: ChatMessage[]): Promise<st
   const data = await res.json()
   return data.choices?.[0]?.message?.content?.trim() || ''
 }
+
+export async function getSuggestedReplies(messages: ChatMessage[]): Promise<string[]> {
+  const apiKey = import.meta.env.VITE_OPENAI_KEY
+  if (!apiKey) {
+    throw new Error('Missing OpenAI API key')
+  }
+
+  const payload = {
+    model: 'gpt-3.5-turbo',
+    messages: [
+      {
+        role: 'system',
+        content:
+          'Provide three short reply suggestions as a JSON array of strings for continuing this conversation.'
+      },
+      ...messages.map(m => ({ role: 'user', content: m.content }))
+    ]
+  }
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(payload)
+  })
+
+  const data = await res.json()
+  const content = data.choices?.[0]?.message?.content?.trim() || '[]'
+
+  try {
+    const parsed = JSON.parse(content)
+    if (Array.isArray(parsed)) {
+      return parsed.map((s: any) => String(s))
+    }
+  } catch {
+    // ignore JSON parse errors
+  }
+
+  return content.split('\n').map((s: string) => s.trim()).filter(Boolean)
+}

--- a/tests/MessageInput.test.tsx
+++ b/tests/MessageInput.test.tsx
@@ -7,6 +7,11 @@ jest.mock('../src/hooks/useTyping', () => ({
   useTyping: () => ({ startTyping: jest.fn(), stopTyping: jest.fn() })
 }))
 
+jest.mock('../src/hooks/useSuggestedReplies', () => ({
+  useSuggestedReplies: () => ({ suggestions: [], loading: false }),
+  useSuggestionsEnabled: () => ({ enabled: false, setEnabled: jest.fn() })
+}))
+
 jest.mock('../src/lib/supabase', () => ({
   uploadVoiceMessage: jest.fn().mockResolvedValue('url'),
   uploadChatFile: jest.fn(),

--- a/tests/MessageInputRecording.test.tsx
+++ b/tests/MessageInputRecording.test.tsx
@@ -15,6 +15,11 @@ jest.mock('../src/hooks/useTyping', () => ({
   useTyping: () => ({ startTyping: jest.fn(), stopTyping: jest.fn() })
 }))
 
+jest.mock('../src/hooks/useSuggestedReplies', () => ({
+  useSuggestedReplies: () => ({ suggestions: [], loading: false }),
+  useSuggestionsEnabled: () => ({ enabled: false, setEnabled: jest.fn() })
+}))
+
 jest.mock('../src/hooks/useEmojiPicker', () => ({
   useEmojiPicker: () => null
 }))

--- a/tests/MessageInputSuggestions.test.tsx
+++ b/tests/MessageInputSuggestions.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MessageInput } from '../src/components/chat/MessageInput'
+import { useSuggestedReplies, useSuggestionsEnabled } from '../src/hooks/useSuggestedReplies'
+
+jest.mock('../src/hooks/useTyping', () => ({
+  useTyping: () => ({ startTyping: jest.fn(), stopTyping: jest.fn() })
+}))
+
+jest.mock('../src/hooks/useSuggestedReplies')
+
+jest.mock('../src/lib/supabase', () => ({
+  uploadVoiceMessage: jest.fn(),
+  uploadChatFile: jest.fn(),
+  DEBUG: false,
+}))
+
+const mockedHooks = useSuggestedReplies as jest.MockedFunction<typeof useSuggestedReplies>
+const mockedPref = useSuggestionsEnabled as unknown as jest.MockedFunction<typeof useSuggestionsEnabled>
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  mockedPref.mockReturnValue({ enabled: true, setEnabled: jest.fn() })
+})
+
+test('inserts suggestion on click', async () => {
+  mockedHooks.mockReturnValue({ suggestions: ['hello there'], loading: false })
+  render(<MessageInput onSendMessage={() => {}} messages={[]} />)
+  const suggestion = screen.getByText('hello there')
+  const user = userEvent.setup()
+  await user.click(suggestion)
+  expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('hello there')
+})

--- a/tests/useSuggestedReplies.test.tsx
+++ b/tests/useSuggestedReplies.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook, act } from '@testing-library/react'
+import { useSuggestedReplies } from '../src/hooks/useSuggestedReplies'
+import { getSuggestedReplies } from '../src/lib/ai'
+
+jest.mock('../src/lib/ai', () => ({
+  getSuggestedReplies: jest.fn()
+}))
+
+type GetMock = jest.MockedFunction<typeof getSuggestedReplies>
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('fetches suggestions when enabled', async () => {
+  const mock = getSuggestedReplies as GetMock
+  mock.mockResolvedValue(['hi'])
+
+  const { result } = renderHook(() => useSuggestedReplies([{ id: '1', content: 'hello' } as any], true))
+
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  expect(mock).toHaveBeenCalled()
+  expect(result.current.suggestions).toEqual(['hi'])
+})
+
+test('does not fetch when disabled', async () => {
+  const mock = getSuggestedReplies as GetMock
+
+  const { result } = renderHook(() => useSuggestedReplies([{ id: '1', content: 'hello' } as any], false))
+
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  expect(mock).not.toHaveBeenCalled()
+  expect(result.current.suggestions).toEqual([])
+})


### PR DESCRIPTION
## Summary
- add `getSuggestedReplies` API helper
- implement `useSuggestedReplies` with persistence toggle
- show suggested replies in `MessageInput`
- add settings toggle for AI suggestions
- document feature in README
- test new hook and component behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fcebd94dc83279b6d8bed2639bd82