### PR TITLE
Implement threaded replies

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -28,6 +28,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
   const { failedMessages, addFailedMessage, removeFailedMessage } = useFailedMessages('general')
 
   const [uploading, setUploading] = useState(false)
+  const [replyTo, setReplyTo] = useState<{ id: string; content: string } | null>(null)
 
   const handleFocusRefresh = useCallback(async () => {
     // Let the visibility refresh hook handle client reset
@@ -39,13 +40,19 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
 
   useVisibilityRefresh(handleFocusRefresh)
 
+  const handleReply = useCallback((id: string, content: string) => {
+    setReplyTo({ id, content })
+  }, [])
+
   const handleSendMessage = async (
     content: string,
     type?: 'text' | 'command' | 'audio' | 'image' | 'file',
-    fileUrl?: string
+    fileUrl?: string,
+    replyToId?: string
   ) => {
     try {
-      await sendMessage(content, type, fileUrl)
+      await sendMessage(content, type, fileUrl, replyToId)
+      setReplyTo(null)
     } catch {
       toast.error('Failed to send message')
       addFailedMessage({ id: Date.now().toString(), type: type || 'text', content: content, dataUrl: fileUrl })
@@ -104,6 +111,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
 
       {/* Messages */}
       <MessageList
+        onReply={handleReply}
         failedMessages={failedMessages}
         onResend={msg => {
           removeFailedMessage(msg.id)
@@ -121,6 +129,8 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
           cacheKey="general"
           onUploadStatusChange={setUploading}
           messages={messages}
+          replyingTo={replyTo || undefined}
+          onCancelReply={() => setReplyTo(null)}
         />
       </div>
 
@@ -136,6 +146,8 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
           cacheKey="general"
           onUploadStatusChange={setUploading}
           messages={messages}
+          replyingTo={replyTo || undefined}
+          onCancelReply={() => setReplyTo(null)}
         />
       </MobileChatFooter>
     </motion.div>

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -29,6 +29,7 @@ const QUICK_REACTIONS = ['👍', '❤️', '😂', '🎉', '🙏']
 interface MessageItemProps {
   message: Message
   previousMessage?: Message
+  parentMessage?: Message
   onReply?: (messageId: string, content: string) => void
   onEdit: (messageId: string, content: string) => Promise<void>
   onDelete: (messageId: string) => Promise<void>
@@ -38,7 +39,7 @@ interface MessageItemProps {
 }
 
 export const MessageItem: React.FC<MessageItemProps> = React.memo(
-  ({ message, previousMessage, onReply, onEdit, onDelete, onTogglePin, onToggleReaction, containerRef }) => {
+  ({ message, previousMessage, parentMessage, onReply, onEdit, onDelete, onTogglePin, onToggleReaction, containerRef }) => {
     const { profile } = useAuth()
     const [isEditing, setIsEditing] = useState(false)
     const [editContent, setEditContent] = useState(message.content)
@@ -252,6 +253,11 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
           ) : (
             <>
               <div className="relative inline-block max-w-full group/message">
+                {parentMessage && (
+                  <div className="text-xs text-gray-500 mb-1">
+                    Replying to {parentMessage.user?.display_name || 'Unknown'}: {parentMessage.content.slice(0, 30)}
+                  </div>
+                )}
                 <div
                   className={cn(
                     'relative peer rounded-xl px-3 py-2 break-words space-y-1',

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -19,12 +19,14 @@ export const prepareMessageData = (
   userId: string,
   content: string,
   messageType: 'text' | 'command' | 'audio' | 'image' | 'file',
-  fileUrl?: string
+  fileUrl?: string,
+  replyTo?: string
 ) => ({
   user_id: userId,
   content: messageType === 'audio' ? '' : content.trim(),
   message_type: messageType,
   file_url: fileUrl,
+  ...(replyTo ? { reply_to: replyTo } : {}),
   ...(messageType === 'audio' ? { audio_url: content.trim() } : {}),
 });
 
@@ -34,6 +36,7 @@ export const insertMessage = async (messageData: {
   message_type: 'text' | 'command' | 'audio' | 'image' | 'file';
   file_url?: string;
   audio_url?: string;
+  reply_to?: string;
 }) => {
   const start = performance.now();
   const workingClient = await getWorkingClient();
@@ -66,6 +69,7 @@ export const refreshSessionAndRetry = async (messageData: {
   message_type: 'text' | 'command' | 'audio' | 'image' | 'file';
   file_url?: string;
   audio_url?: string;
+  reply_to?: string;
 }) => {
   const refreshPromise = refreshSessionLocked();
   const refreshTimeout = new Promise((_, reject) =>
@@ -562,7 +566,8 @@ function useProvideMessages(): MessagesContextValue {
   const sendMessage = useCallback(async (
     content: string,
     messageType: 'text' | 'command' | 'audio' | 'image' | 'file' = 'text',
-    fileUrl?: string
+    fileUrl?: string,
+    replyTo?: string
   ) => {
     const timestamp = new Date().toISOString();
     const logPrefix = `🚀 [MESSAGES] [${timestamp}] sendMessage`;
@@ -588,7 +593,13 @@ function useProvideMessages(): MessagesContextValue {
       throw tokenErr;
     }
 
-    const messageData = prepareMessageData(user.id, content, messageType, fileUrl);
+    const messageData = prepareMessageData(
+      user.id,
+      content,
+      messageType,
+      fileUrl,
+      replyTo
+    );
 
     const attemptSend = async () => {
       let { data, error } = await insertMessage(messageData);


### PR DESCRIPTION
## Summary
- allow specifying reply target when preparing and sending messages
- display parent message context and show/hide threaded replies
- add reply-to UI in message input and chat view
- update unit tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd14b23008327a67372a308f30def