### PR TITLE
Add server-side OpenAI proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ View moderation logs
 VITE_SUPABASE_URL=<your Supabase project URL>
 VITE_SUPABASE_ANON_KEY=<your Supabase anon key>
 VITE_PRESENCE_INTERVAL_MS=30000 # optional
-VITE_OPENAI_KEY=<your OpenAI API key> # for /summary and suggestions and tone analysis
+# Set your OpenAI API key as a server-side environment variable used by the
+# `openai-proxy` edge function
+OPENAI_KEY=<your OpenAI API key>
 
 --- ## Getting Started
 

--- a/supabase/functions/openai-proxy/index.ts
+++ b/supabase/functions/openai-proxy/index.ts
@@ -1,0 +1,26 @@
+import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
+
+const OPENAI_KEY = Deno.env.get("OPENAI_KEY");
+
+if (!OPENAI_KEY) {
+  console.error("OPENAI_KEY not set");
+}
+
+serve(async (req: Request) => {
+  const body = await req.json();
+
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${OPENAI_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  return new Response(text, {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+});


### PR DESCRIPTION
## Summary
- create `openai-proxy` edge function for OpenAI calls
- call the new function from AI helpers
- remove client-side OpenAI key usage
- document server-side `OPENAI_KEY` setup

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fd370b3ac83279e58b6101dc62c81