### PR TITLE
Add X-Client-Info header for OpenAI proxy preflight

### DIFF
--- a/supabase/functions/openai-proxy/index.ts
+++ b/supabase/functions/openai-proxy/index.ts
@@ -13,7 +13,7 @@ serve(async (req: Request) => {
       headers: {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Client-Info'
       }
     })
   }


### PR DESCRIPTION
## Summary
- allow `X-Client-Info` in `Access-Control-Allow-Headers` for the `openai-proxy` function

## Testing
- `npm test` *(fails: jest not found)*
- `supabase functions deploy openai-proxy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdd67bbb083278e712fadd16de318