### PR TITLE
Add tone analysis toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ npm run dev
 
 # AI suggested replies
 OpenAI-powered reply suggestions appear above the message box. Toggle this feature in **Settings → AI → Suggested Replies**.
+Tone indicators next to messages can be disabled under **Settings → AI → Tone Indicators**.
 --- ## Testing & CI/CD ### Testing Stack
 Jest for unit tests
 React Testing Library for DOM interaction

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -23,6 +23,7 @@ import toast from 'react-hot-toast'
 import type { EmojiClickData } from '../../types'
 import { useEmojiPicker } from '../../hooks/useEmojiPicker'
 import { useToneAnalysis } from '../../hooks/useToneAnalysis'
+import { useToneAnalysisEnabled } from '../../hooks/useToneAnalysisEnabled'
 
 const QUICK_REACTIONS = ['👍', '❤️', '😂', '🎉', '🙏']
 
@@ -55,6 +56,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     const [showQuickReactions, setShowQuickReactions] = useState(false)
     const reactionTimeoutRef = useRef<NodeJS.Timeout | null>(null)
     const analyzeTone = useToneAnalysis()
+    const { enabled: toneEnabled } = useToneAnalysisEnabled()
 
     const isGrouped = shouldGroupMessage(message, previousMessage)
     const isOwner = profile?.id === message.user_id
@@ -63,7 +65,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     const bubbleStyle = bubbleColor
       ? { backgroundColor: bubbleColor, color: getReadableTextColor(bubbleColor) }
       : undefined
-    const { tone } = analyzeTone(message.content)
+    const { tone } = toneEnabled ? analyzeTone(message.content) : { tone: 'neutral' }
     const toneEmoji = tone === 'positive' ? '😊' : tone === 'negative' ? '☹️' : '😐'
 
     const handleMouseEnterReactions = () => {
@@ -284,9 +286,11 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                   ) : (
                     <span>
                       {message.content}
-                      <span data-testid="tone-indicator" className="ml-1">
-                        {toneEmoji}
-                      </span>
+                      {toneEnabled && (
+                        <span data-testid="tone-indicator" className="ml-1">
+                          {toneEmoji}
+                        </span>
+                      )}
                     </span>
                   )}
                 </div>

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -21,6 +21,7 @@ import toast from 'react-hot-toast'
 import { useTheme, colorSchemes, ColorScheme } from '../../hooks/useTheme'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { useSuggestionsEnabled } from '../../hooks/useSuggestedReplies'
+import { useToneAnalysisEnabled } from '../../hooks/useToneAnalysisEnabled'
 
 interface SettingsViewProps {
   onToggleSidebar: () => void
@@ -34,6 +35,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
   const isDesktop = useIsDesktop()
   const { signOut } = useAuth()
   const { enabled: suggestionsEnabled, setEnabled: setSuggestionsEnabled } = useSuggestionsEnabled()
+  const { enabled: toneEnabled, setEnabled: setToneEnabled } = useToneAnalysisEnabled()
 
   const handleExportData = () => {
     toast.success('Data export started - you will receive an email when ready')
@@ -86,6 +88,12 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
           description: 'Show AI generated reply suggestions',
           enabled: suggestionsEnabled,
           onChange: setSuggestionsEnabled
+        },
+        {
+          label: 'Tone Indicators',
+          description: 'Show emoji tone of each message',
+          enabled: toneEnabled,
+          onChange: setToneEnabled
         }
       ]
     }

--- a/src/hooks/useToneAnalysisEnabled.ts
+++ b/src/hooks/useToneAnalysisEnabled.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+export function useToneAnalysisEnabled() {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('toneAnalysisEnabled')
+      if (stored === null) return true
+      return stored === 'true'
+    }
+    return true
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('toneAnalysisEnabled', String(enabled))
+    } catch {
+      // ignore
+    }
+  }, [enabled])
+
+  return { enabled, setEnabled }
+}

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -2,6 +2,11 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { MessageItem } from '../src/components/chat/MessageItem'
 import type { Message } from '../src/lib/supabase'
+import { useToneAnalysisEnabled } from '../src/hooks/useToneAnalysisEnabled'
+
+jest.mock('../src/hooks/useToneAnalysisEnabled')
+
+const mockedToneEnabled = useToneAnalysisEnabled as jest.MockedFunction<typeof useToneAnalysisEnabled>
 
 const baseMessage = {
   id: 'm1',
@@ -26,6 +31,10 @@ const baseMessage = {
     updated_at: ''
   }
 } as unknown as Message
+
+beforeEach(() => {
+  mockedToneEnabled.mockReturnValue({ enabled: true, setEnabled: jest.fn() })
+})
 
 test('renders image message', () => {
   render(
@@ -171,4 +180,26 @@ test('shows tone indicator emoji', () => {
 
   const indicator = screen.getByTestId('tone-indicator')
   expect(indicator).toHaveTextContent('😊')
+})
+
+test('hides tone indicator when disabled', () => {
+  mockedToneEnabled.mockReturnValue({ enabled: false, setEnabled: jest.fn() })
+  const textMessage = {
+    ...baseMessage,
+    message_type: 'text',
+    content: 'hello there',
+  } as Message
+
+  render(
+    <MessageItem
+      message={textMessage}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+      containerRef={React.createRef()}
+    />
+  )
+
+  expect(screen.queryByTestId('tone-indicator')).toBeNull()
 })

--- a/tests/useToneAnalysisEnabled.test.tsx
+++ b/tests/useToneAnalysisEnabled.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook, act } from '@testing-library/react'
+import { useToneAnalysisEnabled } from '../src/hooks/useToneAnalysisEnabled'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+test('defaults to enabled', () => {
+  const { result } = renderHook(() => useToneAnalysisEnabled())
+  expect(result.current.enabled).toBe(true)
+})
+
+test('toggle updates localStorage', () => {
+  const { result } = renderHook(() => useToneAnalysisEnabled())
+  act(() => {
+    result.current.setEnabled(false)
+  })
+  expect(localStorage.getItem('toneAnalysisEnabled')).toBe('false')
+  expect(result.current.enabled).toBe(false)
+})


### PR DESCRIPTION
## Summary
- allow enabling/disabling tone detection via new `useToneAnalysisEnabled` hook
- expose toggle in Settings under AI section
- respect preference when showing tone indicator
- document toggle in README
- add unit tests for the new hook and tone indicator behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe6a88be883278b65b3eec0c67e74