### PR TITLE
Implement AI mention command

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -60,8 +60,9 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
 
     const isGrouped = shouldGroupMessage(message, previousMessage)
     const isOwner = profile?.id === message.user_id
+    const isAIMessage = message.message_type === 'command'
 
-    const bubbleColor = message.user?.color
+    const bubbleColor = isAIMessage ? undefined : message.user?.color
     const bubbleStyle = bubbleColor
       ? { backgroundColor: bubbleColor, color: getReadableTextColor(bubbleColor) }
       : undefined
@@ -263,7 +264,11 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                 <div
                   className={cn(
                     'relative peer rounded-xl px-3 py-2 break-words space-y-1',
-                    bubbleStyle ? '' : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+                    isAIMessage
+                      ? 'bg-[var(--color-accent-light)] border-l-4 border-[var(--color-accent)] text-gray-900 dark:text-gray-100'
+                      : bubbleStyle
+                      ? ''
+                      : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
                   )}
                   style={bubbleStyle}
                 >

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -69,3 +69,32 @@ export async function getSuggestedReplies(messages: ChatMessage[]): Promise<stri
 
   return content.split('\n').map((s: string) => s.trim()).filter(Boolean)
 }
+
+export async function askQuestion(question: string): Promise<string> {
+  if (!functionsUrl) {
+    throw new Error('Missing Supabase configuration')
+  }
+
+  const payload = {
+    model: 'gpt-3.5-turbo',
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You are a helpful assistant participating in a group chat. Provide a concise answer to the user question.'
+      },
+      { role: 'user', content: question }
+    ]
+  }
+
+  const res = await fetch(`${functionsUrl}/openai-chat`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  })
+
+  const data = await res.json()
+  return data.choices?.[0]?.message?.content?.trim() || ''
+}

--- a/tests/aiMention.test.tsx
+++ b/tests/aiMention.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MessageInput } from '../src/components/chat/MessageInput'
+import { askQuestion } from '../src/lib/ai'
+
+jest.mock('../src/lib/ai')
+
+jest.mock('../src/hooks/useTyping', () => ({
+  useTyping: () => ({ startTyping: jest.fn(), stopTyping: jest.fn() })
+}))
+
+jest.mock('../src/lib/supabase', () => ({
+  uploadVoiceMessage: jest.fn(),
+  uploadChatFile: jest.fn(),
+  DEBUG: false,
+}))
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('ai mention sends query and posts response', async () => {
+  const onSend = jest.fn()
+  ;(askQuestion as jest.Mock).mockResolvedValue('the answer')
+
+  render(<MessageInput onSendMessage={onSend} messages={[]} />)
+
+  const textarea = screen.getByRole('textbox')
+  await userEvent.type(textarea, '@ai what is up?')
+  await userEvent.keyboard('{Enter}')
+
+  expect(askQuestion).toHaveBeenCalledWith('what is up?')
+  await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2))
+  expect(onSend).toHaveBeenNthCalledWith(2, 'the answer', 'command')
+})


### PR DESCRIPTION
## Summary
- add `askQuestion` helper for OpenAI
- respond to `@ai` mentions in `MessageInput`
- highlight AI responses via `MessageItem`
- test AI mention behavior

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686ff6c5c86883279f57d39bb46ead2c