### PR TITLE
Fix typing indicator channel for DMs

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -119,6 +119,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
         }}
         sending={sending}
         uploading={uploading}
+        typingChannel="general"
       />
 
       {/* Desktop Message Input */}
@@ -127,6 +128,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
           onSendMessage={handleSendMessage}
           placeholder="Type a message"
           cacheKey="general"
+          typingChannel="general"
           onUploadStatusChange={setUploading}
           messages={messages}
           replyingTo={replyTo || undefined}
@@ -144,6 +146,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
           placeholder="Type a message"
           className="border-t"
           cacheKey="general"
+          typingChannel="general"
           onUploadStatusChange={setUploading}
           messages={messages}
           replyingTo={replyTo || undefined}

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -28,6 +28,7 @@ interface MessageInputProps {
   messages?: ChatMessage[]
   replyingTo?: { id: string; content: string }
   onCancelReply?: () => void
+  typingChannel?: string | null
 }
 
 export const MessageInput: React.FC<MessageInputProps> = ({
@@ -39,7 +40,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   onUploadStatusChange = () => {},
   messages = [],
   replyingTo,
-  onCancelReply
+  onCancelReply,
+  typingChannel = 'general'
 }) => {
   const { draft, setDraft, clear } = useDraft(cacheKey)
   const [message, setMessage] = useState(draft)
@@ -50,7 +52,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const [recording, setRecording] = useState(false)
   const [recordingDuration, setRecordingDuration] = useState(0)
   const recordingIntervalRef = useRef<NodeJS.Timeout | null>(null)
-  const { startTyping, stopTyping } = useTyping('general')
+  const { startTyping, stopTyping } = useTyping(typingChannel)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const emojiPickerRef = useRef<HTMLDivElement>(null)
   const attachmentMenuRef = useRef<HTMLDivElement>(null)

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -17,9 +17,10 @@ interface MessageListProps {
   onResend?: (msg: FailedMessage) => void
   sending?: boolean
   uploading?: boolean
+  typingChannel?: string | null
 }
 
-export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessages = [], onResend, sending = false, uploading = false }) => {
+export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessages = [], onResend, sending = false, uploading = false, typingChannel = 'general' }) => {
   const {
     messages,
     loading,
@@ -31,7 +32,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     loadingMore,
     hasMore
   } = useMessages()
-  const { typingUsers } = useTyping('general')
+  const { typingUsers } = useTyping(typingChannel)
   const containerRef = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState(true)
   const [collapsed, setCollapsed] = useState<Set<string>>(() => {

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -20,6 +20,7 @@ import { useFailedMessages } from '../../hooks/useFailedMessages'
 import { formatTime, shouldGroupMessage, getReadableTextColor } from '../../lib/utils'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { LoadingSpinner } from '../ui/LoadingSpinner'
+import { useTyping } from '../../hooks/useTyping'
 import toast from 'react-hot-toast'
 
 interface DirectMessagesViewProps {
@@ -53,6 +54,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   const messagesRef = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState(true)
   const [uploading, setUploading] = useState(false)
+  const { typingUsers } = useTyping(currentConversation ? `dm-${currentConversation}` : null)
 
   useEffect(() => {
     if (initialConversation && currentConversation !== initialConversation) {
@@ -410,6 +412,27 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 </div>
               )}
 
+              <AnimatePresence>
+                {typingUsers.length > 0 && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                    className="mt-2 flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400"
+                  >
+                    <div className="flex space-x-1">
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }} />
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }} />
+                    </div>
+                    <span>
+                      {typingUsers.map(u => u.display_name).join(', ')}
+                      {typingUsers.length === 1 ? ' is' : ' are'} typing...
+                    </span>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
               {!autoScroll && (
                 <button
                   type="button"
@@ -428,6 +451,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 onSendMessage={handleSendMessage}
                 placeholder={`Message @${currentConv.other_user?.username}...`}
                 cacheKey={`dm-${currentConversation}`}
+                typingChannel={`dm-${currentConversation}`}
                 onUploadStatusChange={setUploading}
                 messages={messages}
               />
@@ -443,6 +467,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 placeholder={`Message @${currentConv.other_user?.username}...`}
                 className="border-t"
                 cacheKey={`dm-${currentConversation}`}
+                typingChannel={`dm-${currentConversation}`}
                 onUploadStatusChange={setUploading}
                 messages={messages}
               />


### PR DESCRIPTION
## Summary
- isolate typing indicators by channel
- support per-channel typing events in MessageList and MessageInput
- show typing indicators for DM conversations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff739192083279cacd7cf7527b3e3