### PR TITLE
Fix OpenAI key naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 VITE_OPENAI_KEY=your_openai_api_key
 
 # For Supabase Edge Functions (set this in your Supabase dashboard under Edge Functions secrets)
-# OPENAI_API_KEY=your_openai_api_key
+# OPENAI_KEY=your_openai_api_key
 
 # Optional: Presence update interval in milliseconds (default: 30000)
 VITE_PRESENCE_INTERVAL_MS=30000

--- a/supabase/functions/openai-chat/index.ts
+++ b/supabase/functions/openai-chat/index.ts
@@ -14,7 +14,8 @@ serve(async (req) => {
   try {
     const { messages, model = 'gpt-3.5-turbo' } = await req.json()
 
-    const openaiApiKey = Deno.env.get('OPENAI_API_KEY')
+    const openaiApiKey =
+      Deno.env.get('OPENAI_KEY') || Deno.env.get('OPENAI_API_KEY')
     if (!openaiApiKey) {
       throw new Error('OpenAI API key not configured')
     }


### PR DESCRIPTION
## Summary
- support legacy `OPENAI_KEY` secret name in the edge function
- update `.env.example` to reference the old secret

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68700003d7e88327ad137db571cc5738