### PR TITLE
AI replies linked

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -51,11 +51,13 @@ export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView
     replyToId?: string
   ) => {
     try {
-      await sendMessage(content, type, fileUrl, replyToId)
+      const msg = await sendMessage(content, type, fileUrl, replyToId)
       setReplyTo(null)
+      return msg
     } catch {
       toast.error('Failed to send message')
       addFailedMessage({ id: Date.now().toString(), type: type || 'text', content: content, dataUrl: fileUrl })
+      return null
     }
   }
 

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -143,7 +143,12 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       : null
 
     try {
-      await onSendMessage(finalMessage, 'text', undefined, replyingTo?.id)
+      const sent = await onSendMessage(
+        finalMessage,
+        'text',
+        undefined,
+        replyingTo?.id
+      )
       clear()
       setMessage('')
       stopTyping()
@@ -154,7 +159,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         try {
           const answer = await askQuestion(aiMatch)
           if (answer) {
-            await onSendMessage(answer, 'command')
+            await onSendMessage(answer, 'command', undefined, sent?.id)
           }
         } catch {
         }

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -265,7 +265,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                   className={cn(
                     'relative peer rounded-xl px-3 py-2 break-words space-y-1',
                     isAIMessage
-                      ? 'bg-[var(--color-accent-light)] border-l-4 border-[var(--color-accent)] text-gray-900 dark:text-gray-100'
+                      ? 'bg-[var(--color-accent-light)] border-l-4 border-[var(--color-accent)] text-black dark:text-black font-bold'
                       : bubbleStyle
                       ? ''
                       : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -35,13 +35,15 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
   const containerRef = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState(true)
   const [collapsed, setCollapsed] = useState<Set<string>>(() => {
-    // Start with all messages that have replies collapsed by default
     const initialCollapsed = new Set<string>()
     messages.forEach(m => {
-      if (m.reply_to) return // Skip reply messages
-      const hasReplies = messages.some(other => other.reply_to === m.id)
-      if (hasReplies) {
-        initialCollapsed.add(m.id)
+      if (m.reply_to) return
+      const replies = messages.filter(r => r.reply_to === m.id)
+      if (replies.length > 0) {
+        const allAI = replies.every(r => r.message_type === 'command')
+        if (!allAI) {
+          initialCollapsed.add(m.id)
+        }
       }
     })
     return initialCollapsed
@@ -71,10 +73,13 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     setCollapsed(prev => {
       const newCollapsed = new Set(prev)
       messages.forEach(m => {
-        if (m.reply_to) return // Skip reply messages
-        const hasReplies = messages.some(other => other.reply_to === m.id)
-        if (hasReplies && !prev.has(m.id)) {
-          newCollapsed.add(m.id) // Collapse new threads by default
+        if (m.reply_to) return
+        const replies = messages.filter(r => r.reply_to === m.id)
+        if (replies.length > 0 && !prev.has(m.id)) {
+          const allAI = replies.every(r => r.message_type === 'command')
+          if (!allAI) {
+            newCollapsed.add(m.id)
+          }
         }
       })
       return newCollapsed

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -34,7 +34,7 @@ interface DirectMessagesContextValue {
     content: string,
     messageType?: 'text' | 'command' | 'audio' | 'image' | 'file',
     fileUrl?: string
-  ) => Promise<void>;
+  ) => Promise<DMMessage | null>;
   markAsRead: (conversationId: string) => Promise<void>;
   loadOlderMessages: () => Promise<void>;
 }
@@ -422,9 +422,9 @@ export function useConversationMessages(conversationId: string | null) {
       content: string,
       messageType: 'text' | 'command' | 'audio' | 'image' | 'file' = 'text',
       fileUrl?: string
-    ) => {
+    ): Promise<DMMessage | null> => {
     
-      if (!user || !conversationId || !content.trim()) return;
+      if (!user || !conversationId || !content.trim()) return null;
 
       setSending(true);
       try {
@@ -476,7 +476,9 @@ export function useConversationMessages(conversationId: string | null) {
         if (finalData) {
           // Optimistically add the sent message
           setMessages(prev => [...prev, finalData as DMMessage]);
+          return finalData as DMMessage;
         }
+        return null;
       } catch (error) {
         throw error;
       } finally {


### PR DESCRIPTION
## Summary
- link AI messages to the question using `reply_to`
- open AI threads by default in MessageList
- style AI replies in bold black text
- return inserted message objects from sendMessage helpers

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6870022bffc48327aeb42b29ffbce26c