### PR TITLE
Fix typing indicator visibility

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -29,6 +29,7 @@ interface MessageInputProps {
   messages?: ChatMessage[]
   replyingTo?: { id: string; content: string }
   onCancelReply?: () => void
+  typingChannel?: string
 }
 
 export const MessageInput: React.FC<MessageInputProps> = ({
@@ -41,6 +42,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   messages = [],
   replyingTo,
   onCancelReply
+  typingChannel = 'general',
 }) => {
   const { draft, setDraft, clear } = useDraft(cacheKey)
   const [message, setMessage] = useState(draft)
@@ -51,7 +53,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const [recording, setRecording] = useState(false)
   const [recordingDuration, setRecordingDuration] = useState(0)
   const recordingIntervalRef = useRef<NodeJS.Timeout | null>(null)
-  const { startTyping, stopTyping } = useTyping('general')
+  const { startTyping, stopTyping } = useTyping(typingChannel)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const emojiPickerRef = useRef<HTMLDivElement>(null)
   const attachmentMenuRef = useRef<HTMLDivElement>(null)

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -20,6 +20,7 @@ import { useFailedMessages } from '../../hooks/useFailedMessages'
 import { formatTime, shouldGroupMessage, getReadableTextColor } from '../../lib/utils'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { LoadingSpinner } from '../ui/LoadingSpinner'
+import { useTyping } from '../../hooks/useTyping'
 import toast from 'react-hot-toast'
 
 interface DirectMessagesViewProps {
@@ -53,6 +54,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   const messagesRef = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState(true)
   const [uploading, setUploading] = useState(false)
+  const { typingUsers } = useTyping(currentConversation ? `dm-${currentConversation}` : 'none')
 
   useEffect(() => {
     if (initialConversation && currentConversation !== initialConversation) {
@@ -410,6 +412,27 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 </div>
               )}
 
+              <AnimatePresence>
+                {typingUsers.length > 0 && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                    className="mt-2 flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400"
+                  >
+                    <div className="flex space-x-1">
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }} />
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }} />
+                    </div>
+                    <span>
+                      {typingUsers.map(u => u.display_name).join(', ')}
+                      {typingUsers.length === 1 ? ' is' : ' are'} typing...
+                    </span>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
               {!autoScroll && (
                 <button
                   type="button"
@@ -430,6 +453,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 cacheKey={`dm-${currentConversation}`}
                 onUploadStatusChange={setUploading}
                 messages={messages}
+                typingChannel={`dm-${currentConversation}`}
               />
             </div>
 
@@ -445,6 +469,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                 cacheKey={`dm-${currentConversation}`}
                 onUploadStatusChange={setUploading}
                 messages={messages}
+                typingChannel={`dm-${currentConversation}`}
               />
             </MobileChatFooter>
           </>

--- a/src/hooks/useTyping.ts
+++ b/src/hooks/useTyping.ts
@@ -29,25 +29,28 @@ export const useTyping = (channelName: string = 'general') => {
       // Listen for typing events
       channel
       .on('broadcast', { event: 'typing' }, (payload) => {
-        const { user, typing } = payload.payload
-        
+        const { user: typingUser, typing } = payload.payload
+
+        // Ignore events from the current user
+        if (typingUser.id === user?.id) return
+
         setTypingUsers(prev => {
           if (typing) {
             // Add user to typing list if not already there
-            if (!prev.find(u => u.id === user.id)) {
-              return [...prev, user]
+            if (!prev.find(u => u.id === typingUser.id)) {
+              return [...prev, typingUser]
             }
             return prev
           } else {
             // Remove user from typing list
-            return prev.filter(u => u.id !== user.id)
+            return prev.filter(u => u.id !== typingUser.id)
           }
         })
 
         // Auto-remove typing users after 3 seconds of inactivity
         if (typing) {
           setTimeout(() => {
-            setTypingUsers(prev => prev.filter(u => u.id !== user.id))
+            setTypingUsers(prev => prev.filter(u => u.id !== typingUser.id))
           }, 3000)
         }
       })


### PR DESCRIPTION
## Summary
- add `typingChannel` prop to `MessageInput`
- ignore own user events in `useTyping`
- scope typing indicators to DM conversations

## Testing
- `npm test` *(fails: `jest: not found`)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870040e85b08327b4d4c616a5a9118f