### PR TITLE
Improve DM conversation flow

### DIFF
--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -156,15 +156,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                   <ArrowLeft className="w-4 h-4" />
                 </Button>
               )}
-              {isDesktop && (
-                <button
-                  onClick={onToggleSidebar}
-                  className="p-2 -ml-2 mr-2"
-                  aria-label="Toggle sidebar"
-                >
-                  <Menu className="w-5 h-5" />
-                </button>
-              )}
+              {/* Sidebar toggle removed */}
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
               Direct Messages
               </h2>
@@ -289,15 +281,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
             {/* Header */}
             <div className="flex-shrink-0 px-6 py-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center space-x-3">
-                {isDesktop && (
-                  <button
-                    onClick={onToggleSidebar}
-                    className="p-2 -ml-2"
-                    aria-label="Toggle sidebar"
-                  >
-                    <Menu className="w-5 h-5" />
-                  </button>
-                )}
+                {/* Sidebar toggle removed */}
                 <Button
                   variant="ghost"
                   size="sm"

--- a/src/components/dms/UserSearchSelect.tsx
+++ b/src/components/dms/UserSearchSelect.tsx
@@ -35,7 +35,7 @@ export const UserSearchSelect: React.FC<UserSearchSelectProps> = ({ value, onCha
           {!isLoading && list.map(u => (
             <button
               key={u.id}
-              onDoubleClick={() => onSelect(u)}
+              onClick={() => onSelect(u)}
               className="w-full flex items-center px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 text-left"
             >
               <Avatar src={u.avatar_url} alt={u.display_name} size="sm" color={u.color} status={u.status} showStatus />

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -179,6 +179,8 @@ function useProvideDirectMessages(): DirectMessagesContextValue {
 
     const conversation = await getOrCreateDMConversation(otherUser.id);
     if (conversation) {
+      const convs = await fetchDMConversations();
+      setConversations(convs);
       setCurrentConversation(conversation.id);
       return conversation.id as string;
     }


### PR DESCRIPTION
## Summary
- update DM hook to refresh conversations after starting one
- remove sidebar toggle buttons from DM view
- start conversations on single click

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687008cc226c8327a8bbe2943552285e