### PR TITLE
Fix DM unread badge logic

### DIFF
--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { MessageSquare, Users, User, Settings } from 'lucide-react'
+import { useDirectMessages } from '../../hooks/useDirectMessages'
 
 interface MobileNavProps {
   currentView: 'chat' | 'dms' | 'profile' | 'settings'
@@ -8,11 +9,22 @@ interface MobileNavProps {
 }
 
 export function MobileNav({ currentView, onViewChange, className }: MobileNavProps) {
+  const { conversations } = useDirectMessages()
+  const totalUnread = conversations.reduce(
+    (sum, c) => sum + (c.unread_count || 0),
+    0
+  )
+
   const navItems = [
-    { id: 'chat' as const, icon: MessageSquare, label: 'Chat' },
-    { id: 'dms' as const, icon: Users, label: 'DMs' },
-    { id: 'profile' as const, icon: User, label: 'Profile' },
-    { id: 'settings' as const, icon: Settings, label: 'Settings' },
+    { id: 'chat' as const, icon: MessageSquare, label: 'Chat', badge: null },
+    {
+      id: 'dms' as const,
+      icon: Users,
+      label: 'DMs',
+      badge: totalUnread > 0 ? totalUnread : null,
+    },
+    { id: 'profile' as const, icon: User, label: 'Profile', badge: null },
+    { id: 'settings' as const, icon: Settings, label: 'Settings', badge: null },
   ]
 
   return (
@@ -23,7 +35,7 @@ export function MobileNav({ currentView, onViewChange, className }: MobileNavPro
     >
       <ul className="flex justify-around">
         {navItems.map(item => (
-          <li key={item.id}>
+          <li key={item.id} className="relative">
             <button
               onClick={() => onViewChange(item.id)}
               className={`flex flex-col items-center py-2 text-xs focus:outline-none w-full ${
@@ -32,7 +44,14 @@ export function MobileNav({ currentView, onViewChange, className }: MobileNavPro
                   : 'text-gray-500 dark:text-gray-400'
               }`}
             >
-              <item.icon className="w-5 h-5" />
+              <span className="relative">
+                <item.icon className="w-5 h-5" />
+                {item.badge && (
+                  <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] leading-none px-1 rounded-full">
+                    {item.badge}
+                  </span>
+                )}
+              </span>
               <span>{item.label}</span>
             </button>
           </li>

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -86,10 +86,11 @@ function useProvideDirectMessages(): DirectMessagesContextValue {
         },
         (payload) => {
           // Update conversations when new message arrives
+          let missing = false
           setConversations(prev => {
-            const convIndex = prev.findIndex(c => c.id === payload.new.conversation_id);
+            const convIndex = prev.findIndex(c => c.id === payload.new.conversation_id)
             if (convIndex >= 0) {
-              const updated = [...prev];
+              const updated = [...prev]
               updated[convIndex] = {
                 ...updated[convIndex],
                 last_message_at: payload.new.created_at,
@@ -103,17 +104,22 @@ function useProvideDirectMessages(): DirectMessagesContextValue {
                   edited_at: payload.new.edited_at,
                   created_at: payload.new.created_at,
                 },
-                unread_count: payload.new.sender_id !== user.id
-                  ? (updated[convIndex].unread_count || 0) + 1
-                  : updated[convIndex].unread_count,
-              };
+                unread_count:
+                  payload.new.sender_id !== user.id
+                    ? (updated[convIndex].unread_count || 0) + 1
+                    : updated[convIndex].unread_count,
+              }
               // Move to top
-              const [moved] = updated.splice(convIndex, 1);
-              updated.unshift(moved);
-              return updated;
+              const [moved] = updated.splice(convIndex, 1)
+              updated.unshift(moved)
+              return updated
             }
-            return prev;
-          });
+            missing = true
+            return prev
+          })
+          if (missing) {
+            fetchDMConversations().then(setConversations)
+          }
         }
       )
       .on(


### PR DESCRIPTION
## Summary
- show DM unread count in the mobile nav
- refresh conversation list when an unseen DM arrives

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700e9374e0832786bbbe225e09bdbb