### PR TITLE
Show slash commands on '/'

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -192,8 +192,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     setMessage(value)
     setDraft(value)
 
-    // Show slash commands if message starts with /
-    if (value.startsWith('/') && value.length > 1) {
+    // Show slash commands as soon as the user types '/'
+    if (value.startsWith('/')) {
       setShowSlashCommands(true)
     } else {
       setShowSlashCommands(false)

--- a/tests/MessageInput.test.tsx
+++ b/tests/MessageInput.test.tsx
@@ -47,3 +47,10 @@ test('stops media stream tracks when recording stops', async () => {
   await user.click(btn)
   expect(trackStop).toHaveBeenCalled()
 })
+
+test('shows slash commands menu when only slash is typed', async () => {
+  render(<MessageInput onSendMessage={() => {}} />)
+  const textarea = screen.getByRole('textbox')
+  await userEvent.type(textarea, '/')
+  expect(screen.getByText(/Slash Commands/i)).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- show slash commands dropdown when typing just `/`
- add unit test for the dropdown

## Testing
- `npx jest` *(fails: 403 Forbidden to download jest)*

------
https://chatgpt.com/codex/tasks/task_e_6870101ab2708327a46e83e617a6b48b