### PR TITLE
Fix DM unread clearing when viewing conversation

### DIFF
--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -63,6 +63,15 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
     }
   }, [initialConversation, currentConversation, markAsRead])
 
+  // Ensure unread badge clears when the current conversation is viewed
+  useEffect(() => {
+    if (!currentConversation) return
+    const conv = conversations.find(c => c.id === currentConversation)
+    if (conv && conv.unread_count && conv.unread_count > 0) {
+      markAsRead(currentConversation)
+    }
+  }, [currentConversation, conversations, markAsRead])
+
   const handleUserSelect = async (user: { username: string }) => {
     try {
       const conversationId = await startConversation(user.username)


### PR DESCRIPTION
## Summary
- ensure unread badge resets when a DM conversation is open

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687015d324648327a0b5c670637455d4