### PR TITLE
Add Firebase Cloud Messaging integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.4.1",
         "sentiment": "^5.0.2",
-        "tailwind-merge": "^2.2.0"
+        "tailwind-merge": "^2.2.0",
+        "firebase": "^10.12.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
     "tailwind-merge": "^2.2.0",
-    "sentiment": "^5.0.2"
+    "sentiment": "^5.0.2",
+    "firebase": "^10.12.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,20 @@
+importScripts('https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: 'AIzaSyDwEGv1PRl9GLZwE-QdCnXCEiFn-fRPZt0',
+  authDomain: 'shadowchat-99822.firebaseapp.com',
+  projectId: 'shadowchat-99822',
+  messagingSenderId: '255265121159',
+  appId: '1:255265121159:web:4806c7207776bd5af9a922',
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  console.log('[firebase-messaging-sw.js] Received background message ', payload);
+  self.registration.showNotification(payload.notification.title, {
+    body: payload.notification.body,
+    icon: '/icons/icon-192.png',
+  });
+});

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -19,6 +19,7 @@ import { Button } from '../ui/Button'
 import { useAuth } from '../../hooks/useAuth'
 import toast from 'react-hot-toast'
 import { useTheme, colorSchemes, ColorScheme } from '../../hooks/useTheme'
+import { usePushNotifications } from '../../hooks/usePushNotifications'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { useSuggestionsEnabled } from '../../hooks/useSuggestedReplies'
 import { useToneAnalysisEnabled } from '../../hooks/useToneAnalysisEnabled'
@@ -28,7 +29,8 @@ interface SettingsViewProps {
 }
 
 export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) => {
-  const [notifications, setNotifications] = useState(true)
+  const { enabled: notifications, setEnabled: setNotifications } =
+    usePushNotifications()
   const [sounds, setSounds] = useState(true)
   const [showDangerZone, setShowDangerZone] = useState(false)
   const { scheme, setScheme } = useTheme()

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+import { requestPushPermission, deletePushToken } from '../lib/firebaseMessaging'
+
+export function usePushNotifications() {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('pushNotifications')
+      return stored === 'true'
+    }
+    return false
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('pushNotifications', String(enabled))
+    } catch {
+      // ignore
+    }
+
+    if (enabled) {
+      requestPushPermission().catch(console.error)
+    } else {
+      deletePushToken().catch(() => {})
+    }
+  }, [enabled])
+
+  return { enabled, setEnabled }
+}

--- a/src/lib/firebaseMessaging.ts
+++ b/src/lib/firebaseMessaging.ts
@@ -1,0 +1,56 @@
+import { initializeApp } from 'firebase/app'
+import { getMessaging, getToken, onMessage, deleteToken } from 'firebase/messaging'
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyDwEGv1PRl9GLZwE-QdCnXCEiFn-fRPZt0',
+  authDomain: 'shadowchat-99822.firebaseapp.com',
+  projectId: 'shadowchat-99822',
+  storageBucket: 'shadowchat-99822.firebasestorage.app',
+  messagingSenderId: '255265121159',
+  appId: '1:255265121159:web:4806c7207776bd5af9a922',
+}
+
+const app = initializeApp(firebaseConfig)
+const messaging = getMessaging(app)
+
+let registration: ServiceWorkerRegistration | null = null
+
+async function ensureRegistration() {
+  if (registration) return registration
+  if ('serviceWorker' in navigator) {
+    registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js')
+    return registration
+  }
+  throw new Error('Service workers are not supported in this browser')
+}
+
+export const requestPushPermission = async () => {
+  try {
+    const reg = await ensureRegistration()
+    const token = await getToken(messaging, {
+      vapidKey: 'BCJ5-S1a_rhX_QJqB3pRAykTCpWFv1IhmUd1NSL0GgYp7-X0GkyO00lXGfPd3hFMP7HOwDWNh6iIustKcSNlfS8',
+      serviceWorkerRegistration: reg,
+    })
+
+    if (token) {
+      console.log('Push token:', token)
+      // TODO: Save token to Supabase `user_devices` table
+    } else {
+      console.log('No registration token available. Request permission to generate one.')
+    }
+  } catch (err) {
+    console.error('An error occurred while retrieving token.', err)
+  }
+}
+
+export const deletePushToken = async () => {
+  try {
+    await deleteToken(messaging)
+  } catch (err) {
+    console.error('Failed to delete push token', err)
+  }
+}
+
+export const onForegroundMessage = (callback: (payload: any) => void) => {
+  onMessage(messaging, callback)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,12 @@ import './index.css';
 import { AuthProvider } from './hooks/useAuth';
 import { ThemeProvider } from './hooks/useTheme';
 
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .register('/firebase-messaging-sw.js')
+    .catch((err) => console.error('Service worker registration failed', err));
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>


### PR DESCRIPTION
## Summary
- integrate Firebase for push notifications
- add service worker for FCM
- manage notification settings with new `usePushNotifications` hook
- register service worker during app bootstrap
- update settings view to toggle push notifications
- include Firebase dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870333c0d0483279b72c7f5d92f2caf