### PR TITLE
Add message arrival sounds

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -7,6 +7,8 @@ import { MessageInput } from './MessageInput'
 import { PinnedMessagesBar } from './PinnedMessagesBar'
 import { useFailedMessages } from '../../hooks/useFailedMessages'
 import { MobileChatFooter } from '../layout/MobileChatFooter'
+import { useSoundEffects } from '../../hooks/useSoundEffects'
+import { useMessageArrivalSound } from '../../hooks/useMessageArrivalSound'
 import toast from 'react-hot-toast'
 import { ClientResetIndicator } from '../ui/ClientResetIndicator'
 import { useClientReset } from '../../hooks/ClientResetContext'
@@ -24,6 +26,8 @@ interface ChatViewProps {
 export const ChatView: React.FC<ChatViewProps> = ({ onToggleSidebar, currentView, onViewChange }) => {
   const { messages, sendMessage, sending, togglePin, toggleReaction } = useMessages()
   const pinnedMessages = messages.filter(m => m.pinned)
+  const { enabled: soundsEnabled, sound } = useSoundEffects()
+  useMessageArrivalSound(messages, soundsEnabled, sound)
   const { status: resetStatus, lastResetTime } = useClientReset()
   const { failedMessages, addFailedMessage, removeFailedMessage } = useFailedMessages('general')
 

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -22,6 +22,8 @@ import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { LoadingSpinner } from '../ui/LoadingSpinner'
 import { useTyping } from '../../hooks/useTyping'
 import toast from 'react-hot-toast'
+import { useSoundEffects } from '../../hooks/useSoundEffects'
+import { useMessageArrivalSound } from '../../hooks/useMessageArrivalSound'
 
 interface DirectMessagesViewProps {
   onToggleSidebar: () => void
@@ -55,6 +57,8 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   const [autoScroll, setAutoScroll] = useState(true)
   const [uploading, setUploading] = useState(false)
   const { typingUsers } = useTyping(currentConversation ? `dm-${currentConversation}` : 'none')
+  const { enabled: soundsEnabled, sound } = useSoundEffects()
+  useMessageArrivalSound(messages, soundsEnabled, sound)
 
   useEffect(() => {
     if (initialConversation && currentConversation !== initialConversation) {

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -5,7 +5,6 @@ import {
   Moon,
   Sun,
   Volume2,
-  VolumeX,
   Palette,
   Shield,
   Database,
@@ -22,6 +21,7 @@ import { useTheme, colorSchemes, ColorScheme } from '../../hooks/useTheme'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { useSuggestionsEnabled } from '../../hooks/useSuggestedReplies'
 import { useToneAnalysisEnabled } from '../../hooks/useToneAnalysisEnabled'
+import { useSoundEffects, MessageSound } from '../../hooks/useSoundEffects'
 
 interface SettingsViewProps {
   onToggleSidebar: () => void
@@ -29,7 +29,7 @@ interface SettingsViewProps {
 
 export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) => {
   const [notifications, setNotifications] = useState(true)
-  const [sounds, setSounds] = useState(true)
+  const { enabled: sounds, setEnabled: setSounds, sound, setSound } = useSoundEffects()
   const [showDangerZone, setShowDangerZone] = useState(false)
   const { scheme, setScheme } = useTheme()
   const isDesktop = useIsDesktop()
@@ -168,6 +168,21 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
                     </button>
                   </div>
                 ))}
+                {section.title === 'Audio' && (
+                  <div className="flex items-center justify-between pt-2">
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-gray-100">Message Sound</h3>
+                    </div>
+                    <select
+                      value={sound}
+                      onChange={e => setSound(e.target.value as MessageSound)}
+                      className="border rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    >
+                      <option value="chime">Chime</option>
+                      <option value="pop">Pop</option>
+                    </select>
+                  </div>
+                )}
               </div>
             </div>
           ))}

--- a/src/hooks/useMessageArrivalSound.ts
+++ b/src/hooks/useMessageArrivalSound.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react'
+import { useAuth } from './useAuth'
+import type { ChatMessage } from '../lib/supabase'
+import { playMessageSound } from '../lib/sounds'
+import type { MessageSound } from './useSoundEffects'
+
+export function useMessageArrivalSound(
+  messages: ChatMessage[],
+  enabled: boolean,
+  sound: MessageSound
+) {
+  const { user } = useAuth()
+  const lastId = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!enabled || messages.length === 0) return
+    const last = messages[messages.length - 1]
+    if (last.id !== lastId.current) {
+      const sender = (last as any).user_id ?? (last as any).sender_id
+      if (sender && sender !== user?.id) {
+        try {
+          playMessageSound(sound)
+        } catch {}
+      }
+      lastId.current = last.id
+    }
+  }, [messages, enabled, sound, user])
+}

--- a/src/hooks/useSoundEffects.ts
+++ b/src/hooks/useSoundEffects.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+
+export type MessageSound = 'chime' | 'pop'
+
+export function useSoundEffects() {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('soundsEnabled')
+      if (stored === null) return true
+      return stored === 'true'
+    }
+    return true
+  })
+
+  const [sound, setSound] = useState<MessageSound>(() => {
+    if (typeof localStorage !== 'undefined') {
+      return (localStorage.getItem('messageSound') as MessageSound) || 'chime'
+    }
+    return 'chime'
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('soundsEnabled', String(enabled))
+    } catch {}
+  }, [enabled])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('messageSound', sound)
+    } catch {}
+  }, [sound])
+
+  return { enabled, setEnabled, sound, setSound }
+}

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -1,0 +1,16 @@
+import type { MessageSound } from '../hooks/useSoundEffects'
+
+export function playMessageSound(sound: MessageSound) {
+  const AudioContext = (window as any).AudioContext || (window as any).webkitAudioContext
+  if (!AudioContext) return
+  const ctx = new AudioContext()
+  const oscillator = ctx.createOscillator()
+  const gain = ctx.createGain()
+  oscillator.type = 'sine'
+  oscillator.frequency.value = sound === 'chime' ? 660 : 440
+  gain.gain.value = 0.1
+  oscillator.connect(gain)
+  gain.connect(ctx.destination)
+  oscillator.start()
+  oscillator.stop(ctx.currentTime + 0.15)
+}


### PR DESCRIPTION
## Summary
- add `useSoundEffects` hook to persist sound settings
- add `useMessageArrivalSound` and `playMessageSound` utilities
- play a chime or pop when a new message arrives
- allow selecting the sound effect in settings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687034a3ca4c8327951e99497541c61c