### PR TITLE
Add message arrival sounds

### DIFF
--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -5,7 +5,6 @@ import {
   Moon,
   Sun,
   Volume2,
-  VolumeX,
   Palette,
   Shield,
   Database,
@@ -23,6 +22,7 @@ import { usePushNotifications } from '../../hooks/usePushNotifications'
 import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { useSuggestionsEnabled } from '../../hooks/useSuggestedReplies'
 import { useToneAnalysisEnabled } from '../../hooks/useToneAnalysisEnabled'
+import { useMessageSounds, MessageSound } from '../../hooks/useMessageSounds'
 
 interface SettingsViewProps {
   onToggleSidebar: () => void
@@ -31,7 +31,12 @@ interface SettingsViewProps {
 export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) => {
   const { enabled: notifications, setEnabled: setNotifications } =
     usePushNotifications()
-  const [sounds, setSounds] = useState(true)
+  const {
+    enabled: sounds,
+    setEnabled: setSounds,
+    sound,
+    setSound,
+  } = useMessageSounds()
   const [showDangerZone, setShowDangerZone] = useState(false)
   const { scheme, setScheme } = useTheme()
   const isDesktop = useIsDesktop()
@@ -152,7 +157,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
                         {setting.description}
                       </p>
                     </div>
-                    
+
                     <button
                       onClick={() => setting.onChange(!setting.enabled)}
                       className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
@@ -170,6 +175,23 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
                     </button>
                   </div>
                 ))}
+                {section.title === 'Audio' && (
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="font-medium text-gray-900 dark:text-gray-100">Message Sound</h3>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">Choose the notification sound</p>
+                    </div>
+                    <select
+                      value={sound}
+                      onChange={(e) => setSound(e.target.value as MessageSound)}
+                      className="bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 text-sm rounded-md p-1"
+                      aria-label="Select message sound"
+                    >
+                      <option value="chime">Chime</option>
+                      <option value="pop">Pop</option>
+                    </select>
+                  </div>
+                )}
               </div>
             </div>
           ))}

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -18,6 +18,7 @@ import {
   refreshSessionLocked,
 } from '../lib/supabase';
 import { MESSAGE_FETCH_LIMIT } from '../config';
+import { useMessageSounds } from './useMessageSounds';
 import { useAuth } from './useAuth';
 import { useVisibilityRefresh } from './useVisibilityRefresh';
 
@@ -46,6 +47,7 @@ function useProvideDirectMessages(): DirectMessagesContextValue {
   const [loading, setLoading] = useState(true);
   const [currentConversation, setCurrentConversation] = useState<string | null>(null);
   const { user } = useAuth();
+  const { play } = useMessageSounds();
 
   // Reset function for page refocus
   const resetWithFreshClient = useCallback(async () => {
@@ -121,6 +123,7 @@ function useProvideDirectMessages(): DirectMessagesContextValue {
             missing = true
             return prev
           })
+          if (payload.new.sender_id !== user.id) play()
           if (missing) {
             fetchDMConversations().then(setConversations)
           }

--- a/src/hooks/useMessageSounds.ts
+++ b/src/hooks/useMessageSounds.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState, useCallback } from 'react'
+
+export type MessageSound = 'chime' | 'pop'
+
+export function useMessageSounds() {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('messageSoundsEnabled')
+      if (stored === null) return true
+      return stored === 'true'
+    }
+    return true
+  })
+
+  const [sound, setSound] = useState<MessageSound>(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('messageSoundChoice') as MessageSound | null
+      if (stored === 'chime' || stored === 'pop') return stored
+    }
+    return 'chime'
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('messageSoundsEnabled', String(enabled))
+    } catch {}
+  }, [enabled])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('messageSoundChoice', sound)
+    } catch {}
+  }, [sound])
+
+  const play = useCallback(() => {
+    if (!enabled) return
+    const audio = new Audio(`/sounds/${sound}.wav`)
+    audio.play().catch(() => {})
+  }, [enabled, sound])
+
+  return { enabled, setEnabled, sound, setSound, play }
+}

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -11,6 +11,7 @@ import { MESSAGE_FETCH_LIMIT } from '../config';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import { useAuth } from './useAuth';
 import { useVisibilityRefresh } from './useVisibilityRefresh';
+import { useMessageSounds } from './useMessageSounds';
 
 const STORED_MESSAGE_LIMIT = 200;
 
@@ -137,6 +138,7 @@ function useProvideMessages(): MessagesContextValue {
   const [hasMore, setHasMore] = useState(true);
   const { user } = useAuth();
   const channelRef = useRef<RealtimeChannel | null>(null);
+  const { play } = useMessageSounds();
   const subscribeRef = useRef<() => RealtimeChannel>();
   const clientResetRef = useRef<() => Promise<void>>();
 
@@ -417,13 +419,14 @@ function useProvideMessages(): MessagesContextValue {
                 if (exists) {
                   return prev;
                 }
-                
+
                 // Add new message to the end
                 const updated = [...prev, newMessage as Message];
-                
+
                 // Force a new array reference to ensure React detects the change
                 return updated.slice();
               });
+              if (!isFromCurrentUser) play();
             }
           } catch (error) {
             throw error;
@@ -441,6 +444,7 @@ function useProvideMessages(): MessagesContextValue {
             if (exists) return prev;
             return [...prev, newMessage];
           });
+          if (!isFromCurrentUser) play();
         })
         .on(
           'postgres_changes',

--- a/tests/useMessageSounds.test.tsx
+++ b/tests/useMessageSounds.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act } from '@testing-library/react'
+import { useMessageSounds } from '../src/hooks/useMessageSounds'
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+test('defaults to enabled with chime', () => {
+  const { result } = renderHook(() => useMessageSounds())
+  expect(result.current.enabled).toBe(true)
+  expect(result.current.sound).toBe('chime')
+})
+
+test('updates settings in localStorage', () => {
+  const { result } = renderHook(() => useMessageSounds())
+  act(() => {
+    result.current.setEnabled(false)
+    result.current.setSound('pop')
+  })
+  expect(localStorage.getItem('messageSoundsEnabled')).toBe('false')
+  expect(localStorage.getItem('messageSoundChoice')).toBe('pop')
+})


### PR DESCRIPTION
## Summary
- persist sound effect settings with a dedicated `useMessageSounds` hook
- select which notification sound to play in the settings screen
- play the chosen sound for new chat messages and DMs
- add unit tests for the hook
- remove bundled audio files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_687112ba58c0832782d08ecf27497326