### PR TITLE
Add FCM push notifications via edge function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ VITE_OPENAI_KEY=your_openai_api_key
 
 # For Supabase Edge Functions (set this in your Supabase dashboard under Edge Functions secrets)
 # OPENAI_KEY=your_openai_api_key
+# FCM_SERVER_KEY=your_fcm_server_key
+# SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 
 # Optional: Presence update interval in milliseconds (default: 30000)
 VITE_PRESENCE_INTERVAL_MS=30000

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ VITE_SUPABASE_URL=<your Supabase project URL>
 VITE_SUPABASE_ANON_KEY=<your Supabase anon key>
 VITE_PRESENCE_INTERVAL_MS=30000 # optional
 VITE_OPENAI_KEY=<your OpenAI API key> # for /summary and suggestions and tone analysis
+FCM_SERVER_KEY=<your Firebase server key> # for push notifications
+SUPABASE_SERVICE_ROLE_KEY=<your Supabase service role key>
 
 --- ## Getting Started
 

--- a/supabase/functions/notify-message/index.ts
+++ b/supabase/functions/notify-message/index.ts
@@ -1,0 +1,88 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+interface Payload {
+  table: string
+  record: Record<string, any>
+  type: string
+}
+
+serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 })
+  }
+
+  const payload = await req.json() as Payload
+
+  if (payload.type !== 'INSERT') {
+    return new Response('ignored')
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  const serviceRole = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+  const fcmKey = Deno.env.get('FCM_SERVER_KEY')
+
+  if (!supabaseUrl || !serviceRole || !fcmKey) {
+    console.error('Missing environment configuration')
+    return new Response('Server configuration error', { status: 500 })
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRole)
+  let recipientIds: string[] = []
+
+  if (payload.table === 'dm_messages') {
+    const { data } = await supabase
+      .from('dm_conversations')
+      .select('participants')
+      .eq('id', payload.record.conversation_id)
+      .single()
+
+    if (data) {
+      recipientIds = (data.participants as string[]).filter((id) => id !== payload.record.sender_id)
+    }
+  } else if (payload.table === 'messages') {
+    const { data } = await supabase
+      .from('users')
+      .select('id')
+
+    if (data) {
+      recipientIds = data.map((u) => u.id).filter((id) => id !== payload.record.user_id)
+    }
+  }
+
+  if (recipientIds.length === 0) {
+    return new Response('ok')
+  }
+
+  const { data: tokens } = await supabase
+    .from('user_devices')
+    .select('token')
+    .in('user_id', recipientIds)
+
+  if (!tokens || tokens.length === 0) {
+    return new Response('ok')
+  }
+
+  const body = {
+    registration_ids: tokens.map((t) => t.token),
+    notification: {
+      title: 'New message',
+      body: payload.record.content,
+    },
+    data: {
+      table: payload.table,
+      id: payload.record.id,
+    },
+  }
+
+  await fetch('https://fcm.googleapis.com/fcm/send', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `key=${fcmKey}`,
+    },
+    body: JSON.stringify(body),
+  })
+
+  return new Response('ok')
+})

--- a/supabase/migrations/20250707123000_message_notifications.sql
+++ b/supabase/migrations/20250707123000_message_notifications.sql
@@ -1,0 +1,39 @@
+/*
+  # Push Notification Triggers
+
+  Creates a trigger that calls the `notify-message` Edge Function whenever
+  a new row is inserted into the `messages` or `dm_messages` tables.
+*/
+
+-- Ensure network HTTP extension is available
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- Function to invoke the Edge Function via HTTP
+CREATE OR REPLACE FUNCTION notify_message_http()
+RETURNS trigger AS $$
+DECLARE
+  url text := 'https://<your-project-ref>.functions.supabase.co/notify-message';
+  payload text;
+BEGIN
+  payload := json_build_object(
+    'table', TG_TABLE_NAME,
+    'type', TG_OP,
+    'record', row_to_json(NEW)
+  )::text;
+
+  PERFORM
+    net.http_post(url, payload, 'application/json');
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS notify_messages_insert ON messages;
+CREATE TRIGGER notify_messages_insert
+  AFTER INSERT ON messages
+  FOR EACH ROW EXECUTE FUNCTION notify_message_http();
+
+DROP TRIGGER IF EXISTS notify_dm_messages_insert ON dm_messages;
+CREATE TRIGGER notify_dm_messages_insert
+  AFTER INSERT ON dm_messages
+  FOR EACH ROW EXECUTE FUNCTION notify_message_http();


### PR DESCRIPTION
## Summary
- add `notify-message` edge function for sending FCM pushes
- create migration to trigger edge function on new messages
- document env variables for Firebase server key & Supabase service role

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714a006fcc83279273a7e6277d3fce