### PR TITLE
Switch notify-message to FCM HTTP v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ VITE_OPENAI_KEY=your_openai_api_key
 
 # For Supabase Edge Functions (set this in your Supabase dashboard under Edge Functions secrets)
 # OPENAI_KEY=your_openai_api_key
-# FCM_SERVER_KEY=your_fcm_server_key
+# FCM_SERVICE_ACCOUNT={"type":"service_account",...}
 # SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 
 # Optional: Presence update interval in milliseconds (default: 30000)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ VITE_SUPABASE_URL=<your Supabase project URL>
 VITE_SUPABASE_ANON_KEY=<your Supabase anon key>
 VITE_PRESENCE_INTERVAL_MS=30000 # optional
 VITE_OPENAI_KEY=<your OpenAI API key> # for /summary and suggestions and tone analysis
-FCM_SERVER_KEY=<your Firebase server key> # for push notifications
+FCM_SERVICE_ACCOUNT=<Firebase service account JSON> # for push notifications
 SUPABASE_SERVICE_ROLE_KEY=<your Supabase service role key>
 
 --- ## Getting Started

--- a/supabase/functions/notify-message/index.ts
+++ b/supabase/functions/notify-message/index.ts
@@ -7,6 +7,73 @@ interface Payload {
   type: string
 }
 
+function base64UrlEncode(data: Uint8Array) {
+  return btoa(String.fromCharCode(...data))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const lines = pem.trim().split('\n')
+  const base64 = lines.slice(1, -1).join('')
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes.buffer
+}
+
+async function getAccessToken(serviceAccount: {
+  client_email: string
+  private_key: string
+}) {
+  const header = { alg: 'RS256', typ: 'JWT' }
+  const iat = Math.floor(Date.now() / 1000)
+  const payload = {
+    iss: serviceAccount.client_email,
+    scope: 'https://www.googleapis.com/auth/firebase.messaging',
+    aud: 'https://oauth2.googleapis.com/token',
+    iat,
+    exp: iat + 3600,
+  }
+  const encoder = new TextEncoder()
+  const encodedHeader = base64UrlEncode(
+    encoder.encode(JSON.stringify(header)),
+  )
+  const encodedPayload = base64UrlEncode(
+    encoder.encode(JSON.stringify(payload)),
+  )
+  const unsigned = `${encodedHeader}.${encodedPayload}`
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    pemToArrayBuffer(serviceAccount.private_key),
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signature = new Uint8Array(
+    await crypto.subtle.sign(
+      'RSASSA-PKCS1-v1_5',
+      key,
+      encoder.encode(unsigned),
+    ),
+  )
+  const jwt = `${unsigned}.${base64UrlEncode(signature)}`
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=${jwt}`,
+  })
+  if (!res.ok) {
+    const err = await res.text()
+    throw new Error(`Token request failed: ${err}`)
+  }
+  const data = await res.json()
+  return data.access_token as string
+}
+
 serve(async (req) => {
   if (req.method !== 'POST') {
     return new Response('Method not allowed', { status: 405 })
@@ -20,12 +87,14 @@ serve(async (req) => {
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL')
   const serviceRole = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
-  const fcmKey = Deno.env.get('FCM_SERVER_KEY')
+  const serviceAccountJson = Deno.env.get('FCM_SERVICE_ACCOUNT')
 
-  if (!supabaseUrl || !serviceRole || !fcmKey) {
+  if (!supabaseUrl || !serviceRole || !serviceAccountJson) {
     console.error('Missing environment configuration')
     return new Response('Server configuration error', { status: 500 })
   }
+
+  const serviceAccount = JSON.parse(serviceAccountJson)
 
   const supabase = createClient(supabaseUrl, serviceRole)
   let recipientIds: string[] = []
@@ -38,7 +107,9 @@ serve(async (req) => {
       .single()
 
     if (data) {
-      recipientIds = (data.participants as string[]).filter((id) => id !== payload.record.sender_id)
+      recipientIds = (data.participants as string[]).filter(
+        (id) => id !== payload.record.sender_id,
+      )
     }
   } else if (payload.table === 'messages') {
     const { data } = await supabase
@@ -46,7 +117,9 @@ serve(async (req) => {
       .select('id')
 
     if (data) {
-      recipientIds = data.map((u) => u.id).filter((id) => id !== payload.record.user_id)
+      recipientIds = data.map((u) => u.id).filter(
+        (id) => id !== payload.record.user_id,
+      )
     }
   }
 
@@ -63,26 +136,41 @@ serve(async (req) => {
     return new Response('ok')
   }
 
-  const body = {
-    registration_ids: tokens.map((t) => t.token),
-    notification: {
-      title: 'New message',
-      body: payload.record.content,
-    },
-    data: {
-      table: payload.table,
-      id: payload.record.id,
-    },
+  let accessToken: string
+  try {
+    accessToken = await getAccessToken(serviceAccount)
+  } catch (err) {
+    console.error('Failed to obtain access token', err)
+    return new Response('Server configuration error', { status: 500 })
   }
 
-  await fetch('https://fcm.googleapis.com/fcm/send', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `key=${fcmKey}`,
-    },
-    body: JSON.stringify(body),
-  })
+  for (const t of tokens) {
+    const body = {
+      message: {
+        token: t.token,
+        notification: {
+          title: 'New message',
+          body: payload.record.content,
+        },
+        data: {
+          table: payload.table,
+          id: String(payload.record.id),
+        },
+      },
+    }
+
+    await fetch(
+      `https://fcm.googleapis.com/v1/projects/${serviceAccount.project_id}/messages:send`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json; UTF-8',
+          'Authorization': `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(body),
+      },
+    )
+  }
 
   return new Response('ok')
 })


### PR DESCRIPTION
## Summary
- update env example and README to use service account for Firebase Cloud Messaging
- rework `notify-message` edge function to use FCM HTTP v1 via OAuth2

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687159368ff48327ab6c7d9d6ed8a504