### PR TITLE
Fix duplicate key warning in MessageList

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -234,8 +234,8 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
       )}
 
 
-      {groupedMessages.map(group => (
-        <React.Fragment key={group.date}>
+      {groupedMessages.map((group, idx) => (
+        <React.Fragment key={`${group.date}-${idx}`}>
           <div className="flex items-center my-2">
             <hr className="flex-grow border-t border-gray-300 dark:border-gray-700" />
             <span className="mx-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">{group.date}</span>


### PR DESCRIPTION
## Summary
- ensure grouped messages use a unique key by including index

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68715be536d08327812b588cde63b4f1