### PR TITLE
Fix duplicate key warnings in MessageList

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -234,8 +234,8 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
       )}
 
 
-      {groupedMessages.map(group => (
-        <React.Fragment key={group.date}>
+      {groupedMessages.map((group, index) => (
+        <React.Fragment key={`${group.date}-${index}`}>
           <div className="flex items-center my-2">
             <hr className="flex-grow border-t border-gray-300 dark:border-gray-700" />
             <span className="mx-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">{group.date}</span>


### PR DESCRIPTION
## Summary
- ensure uniqueness for React Fragment keys in MessageList

## Testing
- `npm test` *(fails: Test suite failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_6871895e0490832791b15156faed2ee2