### PR TITLE
Extend theme schemes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
-    "tailwind-merge": "^2.2.0",
-    "sentiment": "^5.0.2"
+    "sentiment": "^5.0.2",
+    "tailwind-merge": "^2.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -38,6 +38,7 @@
     "globals": "^15.9.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.4",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.1.1",

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,6 +1,12 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 
-export type ColorScheme = 'indigo' | 'teal' | 'rose'
+export type ColorScheme =
+  | 'indigo'
+  | 'teal'
+  | 'rose'
+  | 'violet'
+  | 'orange'
+  | 'contrast'
 
 interface ThemeContextValue {
   scheme: ColorScheme
@@ -13,6 +19,9 @@ export const colorSchemes: Record<ColorScheme, { start: string; end: string }> =
   indigo: { start: '#6366f1', end: '#8b5cf6' },
   teal: { start: '#14b8a6', end: '#10b981' },
   rose: { start: '#f43f5e', end: '#d946ef' },
+  violet: { start: '#7c3aed', end: '#a855f7' },
+  orange: { start: '#f97316', end: '#fb923c' },
+  contrast: { start: '#000000', end: '#000000' },
 }
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -25,7 +34,9 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   useEffect(() => {
     document.documentElement.dataset.scheme = scheme
-    document.documentElement.classList.remove('indigo', 'teal', 'rose')
+    document.documentElement.classList.remove(
+      ...(Object.keys(colorSchemes) as ColorScheme[])
+    )
     document.documentElement.classList.add(scheme)
     localStorage.setItem('colorScheme', scheme)
   }, [scheme])

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,27 @@
   --color-accent-light: #fdf2f8;
 }
 
+:root[data-scheme='violet'] {
+  --color-primary-start: #7c3aed;
+  --color-primary-end: #a855f7;
+  --color-accent: #7c3aed;
+  --color-accent-light: #ede9fe;
+}
+
+:root[data-scheme='orange'] {
+  --color-primary-start: #f97316;
+  --color-primary-end: #fb923c;
+  --color-accent: #f97316;
+  --color-accent-light: #ffedd5;
+}
+
+:root[data-scheme='contrast'] {
+  --color-primary-start: #000000;
+  --color-primary-end: #000000;
+  --color-accent: #000000;
+  --color-accent-light: #ffffff;
+}
+
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }

--- a/tests/useTheme.test.tsx
+++ b/tests/useTheme.test.tsx
@@ -23,3 +23,13 @@ test('changing scheme updates document.classList', () => {
   expect(document.documentElement.classList.contains('teal')).toBe(true);
   expect(document.documentElement.classList.contains('indigo')).toBe(false);
 });
+
+test('supports additional color schemes', () => {
+  const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+
+  act(() => {
+    result.current.setScheme('violet');
+  });
+
+  expect(document.documentElement.classList.contains('violet')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- support more color schemes including violet, orange and contrast
- expose new scheme options in Settings
- test additional color scheme functionality
- add `jest-environment-jsdom` dependency for running tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails to run due to TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872756f25308327b171c80f860a811e