### PR TITLE
Fix trimming when loading older messages

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -269,7 +269,9 @@ function useProvideMessages(): MessagesContextValue {
             );
           } catch {}
         }
-        setMessages(trimVisibleMessages(allMessagesRef.current));
+        // When loading older messages, display the full list instead of
+        // trimming to the newest messages so users can scroll back further
+        setMessages(allMessagesRef.current);
         setHasMore(data.length === MESSAGE_FETCH_LIMIT);
       } else {
         setHasMore(false);


### PR DESCRIPTION
## Summary
- keep older messages visible when loading earlier chat history

## Testing
- `npm test` *(fails: ts-jest configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_68727e8b5e2883279e9ec04cdc08b107