### PR TITLE
Fix loading spinner centering on mobile

### DIFF
--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -12,7 +12,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-purple-50">
+      <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-blue-50 to-purple-50">
         <div className="text-center space-y-4">
           <LoadingSpinner size="lg" />
           <p className="text-gray-600">Loading...</p>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -62,7 +62,7 @@ export function LoginForm() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[var(--color-accent-light)] via-white to-white">
+    <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-[var(--color-accent-light)] via-white to-white">
       <div className="max-w-md w-full mx-4">
         <div className="bg-white rounded-2xl shadow-2xl p-8 space-y-6">
           {/* Header */}


### PR DESCRIPTION
## Summary
- ensure the auth loading screen uses a dynamic viewport height
- ensure the login page uses a dynamic viewport height

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test` *(fails to run due to TypeScript config errors)*

------
https://chatgpt.com/codex/tasks/task_e_68727ddc505883278547b7bb292c53cd