### PR TITLE
Fix scroll jump when loading older messages

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -127,7 +127,11 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     if (!el) return
     if (!loadingMore && prevHeightRef.current) {
       const diff = el.scrollHeight - prevHeightRef.current
-      el.scrollTop = prevScrollTopRef.current + diff
+      if (prevScrollTopRef.current <= 0) {
+        el.scrollTop = diff
+      } else {
+        el.scrollTop = prevScrollTopRef.current + diff
+      }
       prevHeightRef.current = 0
       prevScrollTopRef.current = 0
     }


### PR DESCRIPTION
## Summary
- maintain scroll position when prepending older messages

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm test` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872801909908327b2b4a83208f1deb5