### PR TITLE
Add jump-to-thread feature

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -36,11 +36,12 @@ interface MessageItemProps {
   onDelete: (messageId: string) => Promise<void>
   onTogglePin: (messageId: string) => Promise<void>
   onToggleReaction: (messageId: string, emoji: string) => Promise<void>
+  onJumpToMessage?: (messageId: string) => void
   containerRef?: React.RefObject<HTMLDivElement>
 }
 
 export const MessageItem: React.FC<MessageItemProps> = React.memo(
-  ({ message, previousMessage, parentMessage, onReply, onEdit, onDelete, onTogglePin, onToggleReaction, containerRef }) => {
+  ({ message, previousMessage, parentMessage, onReply, onEdit, onDelete, onTogglePin, onToggleReaction, onJumpToMessage, containerRef }) => {
     const { profile } = useAuth()
     const [isEditing, setIsEditing] = useState(false)
     const [editContent, setEditContent] = useState(message.content)
@@ -194,6 +195,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
     return (
       <>
         <motion.div
+          id={`message-${message.id}`}
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           className={cn('group flex space-x-3 ml-2')}
@@ -257,9 +259,17 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
             <>
               <div className="relative inline-block max-w-full group/message">
                 {parentMessage && (
-                  <div className="text-xs text-gray-500 mb-1">
-                    Replying to {parentMessage.user?.display_name || 'Unknown'}: {parentMessage.content.slice(0, 30)}
-                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onJumpToMessage?.(parentMessage.id)}
+                    className="text-xs text-gray-500 mb-1 hover:underline text-left"
+                    aria-label="View parent message"
+                  >
+                    Replying to {parentMessage.user?.display_name || 'Unknown'}:
+                    {' '}
+                    {parentMessage.content.slice(0, 30)}
+                    {parentMessage.content.length > 30 ? '...' : ''}
+                  </button>
                 )}
                 <div
                   className={cn(

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -96,6 +96,22 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
     })
   }
 
+  const jumpToMessage = useCallback((id: string) => {
+    setCollapsed(prev => {
+      const newSet = new Set(prev)
+      newSet.delete(id)
+      return newSet
+    })
+    const el = document.getElementById(`message-${id}`)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      el.classList.add('ring-2', 'ring-[var(--color-accent)]')
+      setTimeout(() => {
+        el.classList.remove('ring-2', 'ring-[var(--color-accent)]')
+      }, 2000)
+    }
+  }, [])
+
   const handleScroll = useCallback(() => {
     const el = containerRef.current
     if (!el) return
@@ -183,6 +199,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
           onDelete={handleDelete}
           onTogglePin={togglePin}
           onToggleReaction={toggleReaction}
+          onJumpToMessage={jumpToMessage}
           containerRef={containerRef}
         />
         {replies.length > 0 && (

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { MessageItem } from '../src/components/chat/MessageItem'
 import type { Message } from '../src/lib/supabase'
@@ -44,6 +45,7 @@ test('renders image message', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
       containerRef={React.createRef()}
     />
   )
@@ -66,6 +68,7 @@ test('renders audio message', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
       containerRef={React.createRef()}
     />
   )
@@ -90,6 +93,7 @@ test('renders file message', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
       containerRef={React.createRef()}
     />
   )
@@ -114,6 +118,7 @@ test('renders audio file preview', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
       containerRef={React.createRef()}
     />
   )
@@ -130,6 +135,7 @@ test('icon buttons have aria-labels', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
       containerRef={React.createRef()}
     />
   )
@@ -152,6 +158,7 @@ test('applies user color to message bubble', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
       containerRef={React.createRef()}
     />
   )
@@ -174,6 +181,7 @@ test('shows tone indicator emoji', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
       containerRef={React.createRef()}
     />
   )
@@ -197,9 +205,33 @@ test('hides tone indicator when disabled', () => {
       onDelete={async () => {}}
       onTogglePin={async () => {}}
       onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
       containerRef={React.createRef()}
     />
   )
 
   expect(screen.queryByTestId('tone-indicator')).toBeNull()
+})
+
+test('clicking reply preview triggers jump callback', async () => {
+  const parent = { ...baseMessage, id: 'p1', content: 'parent', message_type: 'text' } as Message
+  const reply = { ...baseMessage, id: 'c1', content: 'child', message_type: 'text', reply_to: 'p1' } as Message
+  const cb = jest.fn()
+
+  render(
+    <MessageItem
+      message={reply}
+      parentMessage={parent}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+      onJumpToMessage={cb}
+      containerRef={React.createRef()}
+    />
+  )
+
+  const btn = screen.getByRole('button', { name: /replying to/i })
+  await userEvent.click(btn)
+  expect(cb).toHaveBeenCalledWith('p1')
 })


### PR DESCRIPTION
## Summary
- add `jumpToMessage` helper in `MessageList`
- link parent message preview to its thread in `MessageItem`
- test reply preview button calls jump handler

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm test` *(fails: TypeScript config errors and Out of Memory)*

------
https://chatgpt.com/codex/tasks/task_e_687a7a1a41108327ab1456cf1cb85bfc