### PR TITLE
Limit preview text and raise jump button z-index

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -337,7 +337,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
           type="button"
           onClick={scrollToBottom}
           aria-label="Jump to latest"
-          className="fixed bottom-[calc(env(safe-area-inset-bottom)_+_10rem)] md:bottom-32 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90"
+          className="fixed bottom-[calc(env(safe-area-inset-bottom)_+_10rem)] md:bottom-32 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90 z-50"
         >
           <ArrowDown className="w-5 h-5" />
         </button>

--- a/src/components/chat/ThreadReplyLink.tsx
+++ b/src/components/chat/ThreadReplyLink.tsx
@@ -32,15 +32,16 @@ export const ThreadReplyLink: React.FC<ThreadReplyLinkProps> = ({
           </span>
         </div>
         <div className="text-sm text-gray-700 dark:text-gray-300 break-words">
-          {message.content}
+          {message.content.slice(0, 40)}
+          {message.content.length > 40 ? '...' : ''}
         </div>
         <button
           type="button"
           onClick={() => onJumpToMessage(parent.id)}
           className="text-xs text-blue-600 dark:text-blue-400 mt-1 hover:underline"
         >
-          In reply to {parent.user?.display_name || 'Unknown'}: {parent.content.slice(0, 30)}
-          {parent.content.length > 30 ? '...' : ''}
+          In reply to {parent.user?.display_name || 'Unknown'}: {parent.content.slice(0, 40)}
+          {parent.content.length > 40 ? '...' : ''}
         </button>
       </div>
     </div>

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -432,7 +432,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
                   type="button"
                   onClick={scrollToBottom}
                   aria-label="Jump to latest"
-                  className="fixed bottom-[calc(env(safe-area-inset-bottom)_+_10rem)] md:bottom-32 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90"
+                  className="fixed bottom-[calc(env(safe-area-inset-bottom)_+_10rem)] md:bottom-32 right-4 bg-[var(--color-accent)] text-white p-2 rounded-full shadow-lg hover:bg-opacity-90 z-50"
                 >
                   <ArrowDown className="w-5 h-5" />
                 </button>


### PR DESCRIPTION
## Summary
- truncate reply previews to 40 characters
- keep jump to latest buttons above mobile footer

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm test` *(fails: ts-jest configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a892856988327b4585711208e4729