### PR TITLE
Fix thread jump scroll

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -111,14 +111,17 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
         return newSet
       })
 
-      const el = document.getElementById(`message-${id}`)
-      if (el) {
-        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-        el.classList.add('ring-2', 'ring-[var(--color-accent)]')
-        setTimeout(() => {
-          el.classList.remove('ring-2', 'ring-[var(--color-accent)]')
-        }, 2000)
-      }
+      // Wait for the DOM to update before scrolling
+      requestAnimationFrame(() => {
+        const el = document.getElementById(`message-${id}`)
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+          el.classList.add('ring-2', 'ring-[var(--color-accent)]')
+          setTimeout(() => {
+            el.classList.remove('ring-2', 'ring-[var(--color-accent)]')
+          }, 2000)
+        }
+      })
     },
     [messageMap]
   )


### PR DESCRIPTION
## Summary
- fix jumpToMessage scroll by waiting for DOM update

## Testing
- `npm run lint`
- `npm test` *(fails: React import issues, TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a951ff1c883278aa5268297964604