### PR TITLE
Fix jump-to-message scroll state

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -116,6 +116,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
         const el = document.getElementById(`message-${id}`)
         if (el) {
           el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+          setAutoScroll(false)
           el.classList.add('ring-2', 'ring-[var(--color-accent)]')
           setTimeout(() => {
             el.classList.remove('ring-2', 'ring-[var(--color-accent)]')


### PR DESCRIPTION
## Summary
- ensure jump to comment disables autoScroll so jump to latest works

## Testing
- `npm test` *(fails: Module can only be default imported using the esModuleInterop flag)*

------
https://chatgpt.com/codex/tasks/task_e_687a991bc0288327aa1f7ce43ed06cfd