### PR TITLE
Fix jump to latest after comment link

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -116,7 +116,6 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
         const el = document.getElementById(`message-${id}`)
         if (el) {
           el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-          setAutoScroll(false)
           el.classList.add('ring-2', 'ring-[var(--color-accent)]')
           setTimeout(() => {
             el.classList.remove('ring-2', 'ring-[var(--color-accent)]')
@@ -142,7 +141,10 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
 
   const scrollToBottom = useCallback(() => {
     if (containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight
+      containerRef.current.scrollTo({
+        top: containerRef.current.scrollHeight,
+        behavior: 'smooth'
+      })
       setAutoScroll(true)
     }
   }, [])

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -118,7 +118,10 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
 
   const scrollToBottom = useCallback(() => {
     if (messagesRef.current) {
-      messagesRef.current.scrollTop = messagesRef.current.scrollHeight
+      messagesRef.current.scrollTo({
+        top: messagesRef.current.scrollHeight,
+        behavior: 'smooth'
+      })
       setAutoScroll(true)
     }
   }, [])


### PR DESCRIPTION
## Summary
- ensure scroll-to-bottom uses smooth scrolling
- stop forcing autoScroll false when jumping to a message

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9cf0f8908327b809d1e996b78a0d