### PR TITLE
Fix jump button not altering other page scroll

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -142,8 +142,7 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
   const scrollToBottom = useCallback(() => {
     if (containerRef.current) {
       containerRef.current.scrollTo({
-        top: containerRef.current.scrollHeight,
-        behavior: 'smooth'
+        top: containerRef.current.scrollHeight
       })
       setAutoScroll(true)
     }

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -119,8 +119,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   const scrollToBottom = useCallback(() => {
     if (messagesRef.current) {
       messagesRef.current.scrollTo({
-        top: messagesRef.current.scrollHeight,
-        behavior: 'smooth'
+        top: messagesRef.current.scrollHeight
       })
       setAutoScroll(true)
     }


### PR DESCRIPTION
## Summary
- prevent global scrolling when clicking jump to present

## Testing
- `npm test` *(fails: ts-jest compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687aa625953c83278bcd9c3aeaa5be88