### PR TITLE
Fix jump button and show headers

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -68,7 +68,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ currentView, onViewChange })
       className="flex flex-col h-full bg-gray-50 dark:bg-gray-900 text-sm"
     >
       {/* Header */}
-      <div className="hidden md:block flex-shrink-0 px-6 py-5 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+      <div className="flex-shrink-0 px-6 py-5 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             {/* Menu button removed on mobile */}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -142,7 +142,8 @@ export const MessageList: React.FC<MessageListProps> = ({ onReply, failedMessage
   const scrollToBottom = useCallback(() => {
     if (containerRef.current) {
       containerRef.current.scrollTo({
-        top: containerRef.current.scrollHeight
+        top: containerRef.current.scrollHeight,
+        behavior: 'smooth'
       })
       setAutoScroll(true)
     }

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -119,7 +119,8 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({ onToggle
   const scrollToBottom = useCallback(() => {
     if (messagesRef.current) {
       messagesRef.current.scrollTo({
-        top: messagesRef.current.scrollHeight
+        top: messagesRef.current.scrollHeight,
+        behavior: 'smooth'
       })
       setAutoScroll(true)
     }


### PR DESCRIPTION
## Summary
- restore jump-to-bottom smooth scroll behavior
- ensure chat header visible on mobile

## Testing
- `npm run lint`
- `npm test` *(fails: ts-jest config issues)*

------
https://chatgpt.com/codex/tasks/task_e_687aaa056a34832798f3de0dc86e8d73