### PR TITLE
Fix notification sound playback

### DIFF
--- a/src/hooks/useSoundEffects.tsx
+++ b/src/hooks/useSoundEffects.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+} from 'react'
 import { getWorkingClient } from '../lib/supabase'
 
 interface SoundEffectsContextValue {
@@ -8,11 +15,13 @@ interface SoundEffectsContextValue {
   playReaction: () => void
 }
 
-const SoundEffectsContext = createContext<SoundEffectsContextValue | undefined>(undefined)
+const SoundEffectsContext = createContext<SoundEffectsContextValue | undefined>(
+  undefined,
+)
 
 const defaultUrls = {
   message: '/sounds/message.mp3',
-  reaction: '/sounds/reaction.mp3'
+  reaction: '/sounds/reaction.mp3',
 }
 
 function useProvideSoundEffects(): SoundEffectsContextValue {
@@ -26,6 +35,18 @@ function useProvideSoundEffects(): SoundEffectsContextValue {
   })
 
   const [urls, setUrls] = useState(defaultUrls)
+  const audioCache = useRef<Map<string, HTMLAudioElement>>(new Map())
+
+  const preloadAudio = useCallback((url: string) => {
+    if (!url || audioCache.current.has(url)) return
+    try {
+      const audio = new Audio(url)
+      audio.preload = 'auto'
+      audioCache.current.set(url, audio)
+    } catch {
+      // ignore preload errors
+    }
+  }, [])
 
   useEffect(() => {
     try {
@@ -34,6 +55,11 @@ function useProvideSoundEffects(): SoundEffectsContextValue {
       // ignore storage errors
     }
   }, [enabled])
+
+  useEffect(() => {
+    preloadAudio(urls.message)
+    preloadAudio(urls.reaction)
+  }, [urls, preloadAudio])
 
   useEffect(() => {
     ;(async () => {
@@ -60,30 +86,52 @@ function useProvideSoundEffects(): SoundEffectsContextValue {
     (url: string) => {
       if (!enabled || !url) return
       try {
-        const audio = new Audio(url)
+        let audio = audioCache.current.get(url)
+        if (!audio) {
+          audio = new Audio(url)
+          audio.preload = 'auto'
+          audioCache.current.set(url, audio)
+        }
+        audio.currentTime = 0
         audio.play().catch(() => {})
       } catch {
         // ignore playback errors
       }
     },
-    [enabled, urls]
+    [enabled],
   )
 
-  const playMessage = useCallback(() => play(urls.message), [play, urls])
-  const playReaction = useCallback(() => play(urls.reaction), [play, urls])
+  const playMessage = useCallback(
+    () => play(urls.message),
+    [play, urls.message],
+  )
+  const playReaction = useCallback(
+    () => play(urls.reaction),
+    [play, urls.reaction],
+  )
 
   return { enabled, setEnabled, playMessage, playReaction }
 }
 
-export function SoundEffectsProvider({ children }: { children: React.ReactNode }) {
+export function SoundEffectsProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
   const value = useProvideSoundEffects()
-  return <SoundEffectsContext.Provider value={value}>{children}</SoundEffectsContext.Provider>
+  return (
+    <SoundEffectsContext.Provider value={value}>
+      {children}
+    </SoundEffectsContext.Provider>
+  )
 }
 
 export function useSoundEffects() {
   const ctx = useContext(SoundEffectsContext)
   if (!ctx) {
-    throw new Error('useSoundEffects must be used within a SoundEffectsProvider')
+    throw new Error(
+      'useSoundEffects must be used within a SoundEffectsProvider',
+    )
   }
   return ctx
 }


### PR DESCRIPTION
## Summary
- preload notification sounds once fetched from Supabase
- cache loaded audio elements so playback works reliably

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails: TS errors and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687ab70cf340832798f4dbd02c66b2d5