### PR TITLE
Fix mobile notification sound handling

### DIFF
--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -481,8 +481,19 @@ function useProvideMessages(): MessagesContextValue {
                     const newList = prev.map(msg =>
                       msg.id === updatedMessage.id ? (updatedMessage as Message) : msg
                     )
-                    if (changed && updatedMessage.user_id !== user.id) {
-                      playReaction()
+                    if (changed) {
+                      const prevUsers = prevMessage.reactions || {}
+                      const currUsers = updatedMessage.reactions || {}
+                      const changedByCurrent = Object.keys({ ...prevUsers, ...currUsers }).some(e => {
+                        const before = prevUsers[e]?.users || []
+                        const after = currUsers[e]?.users || []
+                        const beforeHas = before.includes(user.id)
+                        const afterHas = after.includes(user.id)
+                        return beforeHas !== afterHas
+                      })
+                      if (!changedByCurrent) {
+                        playReaction()
+                      }
                     }
                     return newList
                   }
@@ -780,8 +791,6 @@ function useProvideMessages(): MessagesContextValue {
       if (error) {
         throw error;
       }
-
-      playReaction();
       
     } catch (error) {
       throw error;

--- a/src/hooks/useSoundEffects.tsx
+++ b/src/hooks/useSoundEffects.tsx
@@ -96,6 +96,28 @@ function useProvideSoundEffects(): SoundEffectsContextValue {
     reaction.volume = 0.5
     reaction.load()
     reactionAudioRef.current = reaction
+
+    // Unlock audio playback on first user interaction (required on mobile)
+    const unlock = () => {
+      ;[messageAudioRef.current, reactionAudioRef.current].forEach(a => {
+        if (!a) return
+        try {
+          a.play().catch(() => {})
+          a.pause()
+          a.currentTime = 0
+        } catch {
+          // ignore errors
+        }
+      })
+      document.removeEventListener('touchstart', unlock)
+      document.removeEventListener('click', unlock)
+    }
+    document.addEventListener('touchstart', unlock, { once: true })
+    document.addEventListener('click', unlock, { once: true })
+    return () => {
+      document.removeEventListener('touchstart', unlock)
+      document.removeEventListener('click', unlock)
+    }
   }, [urls])
 
   const play = useCallback(


### PR DESCRIPTION
## Summary
- unlock audio on first user interaction so message sounds work on mobile
- avoid playing reaction sound for the sender

## Testing
- `npm test` *(fails: Module '@types/react' can only be default-imported using the esModuleInterop flag)*

------
https://chatgpt.com/codex/tasks/task_e_687abbe76d648327b2fe4bf99371c0d3