### PR TITLE
[codex] Stabilize session recovery and smoke coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,15 @@ VITE_WEB_PUSH_PUBLIC_KEY=your_web_push_public_key
 # CORS Configuration Required
 # In your Supabase dashboard, go to Settings > API > CORS
 # Add your development URL (e.g., http://localhost:5173) to allowed origins
+
+# Optional: stable Playwright smoke accounts.
+# If omitted, `npm run qa:smoke` will create disposable accounts automatically.
+# PLAYWRIGHT_ACCOUNT_1_EMAIL=smoke-user-1@example.com
+# PLAYWRIGHT_ACCOUNT_1_PASSWORD=change_me
+# PLAYWRIGHT_ACCOUNT_1_USERNAME=smokeuser1
+# PLAYWRIGHT_ACCOUNT_1_DISPLAY_NAME=Smoke User 1
+# PLAYWRIGHT_ACCOUNT_2_EMAIL=smoke-user-2@example.com
+# PLAYWRIGHT_ACCOUNT_2_PASSWORD=change_me
+# PLAYWRIGHT_ACCOUNT_2_USERNAME=smokeuser2
+# PLAYWRIGHT_ACCOUNT_2_DISPLAY_NAME=Smoke User 2
+# PLAYWRIGHT_BASE_URL=http://127.0.0.1:4174

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,45 @@ Use `--runInBand` on Windows to reduce flakiness and keep output easier to read.
 
 ### Playwright Debugging
 
-This repo does not keep Playwright specs as the main workflow. For ad hoc browser debugging, use inline Node scripts with the installed `playwright` package or the Codex Playwright wrapper.
+This repo does not keep Playwright specs as the main workflow. Prefer the repo smoke runner for dependable browser checks, then fall back to inline scripts or the Codex Playwright wrapper for custom debugging.
+
+Primary smoke command:
+
+```powershell
+npm run qa:smoke
+```
+
+Headed mode:
+
+```powershell
+npm run qa:smoke:headed
+```
+
+Run a specific scenario:
+
+```powershell
+npm run qa:smoke:dm
+```
+
+Run the resume/background-send repro:
+
+```powershell
+npm run qa:smoke:resume
+```
+
+For custom flags, call the script directly:
+
+```powershell
+node scripts/playwright-smoke.mjs --scenario=auth,dm --run-name=my-check
+```
+
+Run the broader end-to-end sweep:
+
+```powershell
+npm run qa:smoke:full
+```
+
+If you have changed the app code and need a fresh preview build instead of reusing an already-running server, add `--no-reuse-server`.
 
 Recommended local visual-debug loop:
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -60,11 +60,82 @@ npx vite preview --host 127.0.0.1 --port 4174
 
 ## Playwright Usage
 
-This repo keeps Playwright as an installed tool for ad hoc debugging rather than as the main test-runner workflow.
+This repo keeps Playwright as a smoke and debugging tool rather than as the main assertion-heavy test runner.
+
+### Repo Smoke Runner
+
+Use the repo-local runner when you want a dependable browser pass with managed preview startup, screenshots, logs, and repeatable flows:
+
+```powershell
+npm run qa:smoke
+```
+
+Headed mode:
+
+```powershell
+npm run qa:smoke:headed
+```
+
+Run a specific scenario:
+
+```powershell
+npm run qa:smoke:dm
+```
+
+Run the resume/background-send repro:
+
+```powershell
+npm run qa:smoke:resume
+```
+
+Run the broader end-to-end sweep:
+
+```powershell
+npm run qa:smoke:full
+```
+
+For custom flags, call the script directly:
+
+```powershell
+node scripts/playwright-smoke.mjs --scenario=auth,dm --run-name=my-check --base-url=http://127.0.0.1:4174
+```
+
+Useful direct-script flags:
+
+- `--scenario=auth,dm,mobile-dm-back`
+- `--scenario=auth,resume-send`
+- `--headed`
+- `--base-url=http://127.0.0.1:4174`
+- `--no-reuse-server`
+- `--skip-build`
+- `--run-name=my-check`
+
+What the smoke runner does by default:
+
+- reuses `http://127.0.0.1:4174` if it is already up
+- otherwise runs `vite build` and starts `vite preview`
+- signs in with `PLAYWRIGHT_ACCOUNT_*` credentials if present
+- otherwise creates disposable Supabase users for a clean DM run
+- saves screenshots, logs, storage state, and a JSON summary under `output/playwright/<run-name>/`
+
+When you have changed app code and want the latest build instead of the already-running preview, add `--no-reuse-server`.
+
+Current smoke scenarios:
+
+- `auth`: both accounts land in the authenticated app shell
+- `group-chat`: verifies general chat send, reactions, image upload, file upload, and voice upload between two accounts
+- `settings`: checks desktop notification/settings UI, preference toggles, and push registration on a persistent browser profile
+- `dm`: starts or opens a DM, sends a real message, verifies read-clearing after reload
+- `resume-send`: simulates a background/foreground cycle, then verifies group-chat and DM sends still complete
+- `profile-visual`: captures the desktop profile screen for visual review
+- `mobile-dm-back`: validates the mobile DM thread back flow
+- `mobile-settings-visual`: checks the mobile settings layout and notification toggle geometry
+
+Disposable accounts are the most deterministic option. Reused env-backed accounts can carry old threads and unread state from earlier runs.
 
 ### Headed Smoke Script Pattern
 
-Use an inline Node script with the installed `playwright` package:
+For one-off exploration, inline scripts are still fine:
 
 ```powershell
 @'
@@ -88,6 +159,7 @@ output/playwright/<run-name>/
 
 Examples:
 
+- `output/playwright/smoke-20260422/`
 - `output/playwright/dm-realtime-debug/`
 - `output/playwright/final-mobile-product-pass/`
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,15 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest",
+    "qa:smoke": "node scripts/playwright-smoke.mjs",
+    "qa:smoke:headed": "node scripts/playwright-smoke.mjs --headed",
+    "qa:smoke:auth": "node scripts/playwright-smoke.mjs --scenario=auth",
+    "qa:smoke:dm": "node scripts/playwright-smoke.mjs --scenario=dm",
+    "qa:smoke:resume": "node scripts/playwright-smoke.mjs --scenario=resume-send",
+    "qa:smoke:mobile": "node scripts/playwright-smoke.mjs --scenario=mobile-dm-back",
+    "qa:smoke:full": "node scripts/playwright-smoke.mjs --scenario=full",
+    "qa:smoke:full:headed": "node scripts/playwright-smoke.mjs --scenario=full --headed"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",

--- a/scripts/playwright-smoke.mjs
+++ b/scripts/playwright-smoke.mjs
@@ -1,0 +1,1316 @@
+import { chromium, devices } from 'playwright'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { setTimeout as delay } from 'node:timers/promises'
+
+const DEFAULT_HOST = '127.0.0.1'
+const DEFAULT_PORT = 4174
+const DEFAULT_SCENARIO = 'core'
+const DEFAULT_TIMEOUT_MS = 20_000
+
+const scenarioSets = {
+  core: ['auth', 'dm', 'mobile-dm-back'],
+  full: ['auth', 'group-chat', 'settings', 'dm', 'resume-send', 'profile-visual', 'mobile-dm-back', 'mobile-settings-visual'],
+}
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+const taskKillCommand = process.platform === 'win32' ? 'taskkill' : null
+
+const args = parseArgs(process.argv.slice(2))
+const repoRoot = process.cwd()
+const envFileValues = await loadDotEnv(path.join(repoRoot, '.env'))
+const config = buildConfig(args, envFileValues)
+const artifactDir = path.join(repoRoot, config.artifactDir)
+const logsDir = path.join(artifactDir, 'logs')
+const fixturesDir = path.join(artifactDir, 'fixtures')
+const runLogPath = path.join(logsDir, 'run.log')
+const resultPath = path.join(artifactDir, 'summary.json')
+
+await mkdir(logsDir, { recursive: true })
+const fixtures = await createFixtures(fixturesDir)
+
+const runState = {
+  config,
+  repoRoot,
+  artifactDir,
+  logsDir,
+  fixturesDir,
+  fixtures,
+  runLogPath,
+  summary: {
+    startedAt: new Date().toISOString(),
+    baseUrl: config.baseUrl,
+    accountMode: config.accountMode,
+    fixtures,
+    scenarios: [],
+  },
+}
+
+let previewServer = null
+let browser = null
+let desktopA = null
+let desktopB = null
+let mobileA = null
+
+try {
+  logLine(`Artifacts: ${artifactDir}`)
+  logLine(`Scenarios: ${config.scenarios.join(', ')}`)
+
+  previewServer = await ensurePreviewServer(runState)
+  browser = await chromium.launch({
+    headless: config.headless,
+    slowMo: config.slowMo,
+  })
+
+  const accounts = buildAccounts(config)
+  desktopA = await createDesktopSession(browser, runState, accounts[0], 'account-1')
+  desktopB = await createDesktopSession(browser, runState, accounts[1], 'account-2', { persistent: true })
+
+  accounts[0] = desktopA.account
+  accounts[1] = desktopB.account
+
+  await writeJson(path.join(artifactDir, 'accounts.json'), {
+    accountMode: config.accountMode,
+    accounts,
+  })
+
+  for (const scenarioName of config.scenarios) {
+    await runScenario(runState, scenarioName, async () => {
+      if (scenarioName === 'auth') {
+        await scenarioAuth(runState, desktopA, desktopB)
+        return
+      }
+
+      if (scenarioName === 'dm') {
+        await scenarioDM(runState, desktopA, desktopB)
+        return
+      }
+
+      if (scenarioName === 'resume-send') {
+        await scenarioResumeSend(runState, desktopA, desktopB)
+        return
+      }
+
+      if (scenarioName === 'group-chat') {
+        await scenarioGroupChat(runState, desktopA, desktopB)
+        return
+      }
+
+      if (scenarioName === 'settings') {
+        await scenarioSettings(runState, desktopA, desktopB)
+        return
+      }
+
+      if (scenarioName === 'profile-visual') {
+        await scenarioProfileVisual(runState, desktopA)
+        return
+      }
+
+      if (scenarioName === 'mobile-dm-back') {
+        mobileA = await refreshMobileSession(browser, runState, desktopA.account, mobileA)
+        await scenarioMobileDmBack(runState, desktopA, desktopB, mobileA)
+        return
+      }
+
+      if (scenarioName === 'mobile-settings-visual') {
+        mobileA = await refreshMobileSession(browser, runState, desktopA.account, mobileA)
+        await scenarioMobileSettingsVisual(runState, mobileA)
+        return
+      }
+
+      throw new Error(`Unknown scenario: ${scenarioName}`)
+    })
+  }
+
+  runState.summary.finishedAt = new Date().toISOString()
+  runState.summary.status = 'passed'
+  await writeJson(resultPath, runState.summary)
+
+  console.log('')
+  console.log(`Smoke run passed. Summary: ${resultPath}`)
+} catch (error) {
+  runState.summary.finishedAt = new Date().toISOString()
+  runState.summary.status = 'failed'
+  runState.summary.error = serializeError(error)
+  await writeJson(resultPath, runState.summary)
+  console.error('')
+  console.error(`Smoke run failed. Summary: ${resultPath}`)
+  console.error(error instanceof Error ? error.stack || error.message : String(error))
+  process.exitCode = 1
+} finally {
+  await closeSession(mobileA)
+  await closeSession(desktopB)
+  await closeSession(desktopA)
+  if (browser) {
+    await browser.close().catch(() => {})
+  }
+  if (previewServer?.cleanup) {
+    await previewServer.cleanup()
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    headed: false,
+    slowMo: 0,
+    scenario: DEFAULT_SCENARIO,
+    baseUrl: null,
+    reuseServer: true,
+    skipBuild: false,
+    runName: null,
+    accountMode: null,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index]
+
+    if (current === '--headed') {
+      parsed.headed = true
+      continue
+    }
+
+    if (current === '--headless') {
+      parsed.headed = false
+      continue
+    }
+
+    if (current === '--skip-build') {
+      parsed.skipBuild = true
+      continue
+    }
+
+    if (current === '--no-reuse-server') {
+      parsed.reuseServer = false
+      continue
+    }
+
+    if (current.startsWith('--scenario=')) {
+      parsed.scenario = current.slice('--scenario='.length)
+      continue
+    }
+
+    if (current === '--scenario' && argv[index + 1]) {
+      parsed.scenario = argv[index + 1]
+      index += 1
+      continue
+    }
+
+    if (current.startsWith('--base-url=')) {
+      parsed.baseUrl = current.slice('--base-url='.length)
+      continue
+    }
+
+    if (current === '--base-url' && argv[index + 1]) {
+      parsed.baseUrl = argv[index + 1]
+      index += 1
+      continue
+    }
+
+    if (current.startsWith('--slow-mo=')) {
+      parsed.slowMo = Number(current.slice('--slow-mo='.length)) || 0
+      continue
+    }
+
+    if (current === '--slow-mo' && argv[index + 1]) {
+      parsed.slowMo = Number(argv[index + 1]) || 0
+      index += 1
+      continue
+    }
+
+    if (current.startsWith('--run-name=')) {
+      parsed.runName = current.slice('--run-name='.length)
+      continue
+    }
+
+    if (current === '--run-name' && argv[index + 1]) {
+      parsed.runName = argv[index + 1]
+      index += 1
+      continue
+    }
+
+    if (current.startsWith('--account-mode=')) {
+      parsed.accountMode = current.slice('--account-mode='.length)
+      continue
+    }
+
+    if (current === '--account-mode' && argv[index + 1]) {
+      parsed.accountMode = argv[index + 1]
+      index += 1
+      continue
+    }
+  }
+
+  return parsed
+}
+
+function buildConfig(parsedArgs, envValues) {
+  const baseUrl = parsedArgs.baseUrl || envValues.PLAYWRIGHT_BASE_URL || `http://${DEFAULT_HOST}:${DEFAULT_PORT}`
+  const base = new URL(baseUrl)
+  const runName = slugify(parsedArgs.runName || `smoke-${timestampToken()}`)
+  const scenarios = resolveScenarios(parsedArgs.scenario)
+  const accountMode = resolveAccountMode(parsedArgs.accountMode, envValues)
+
+  return {
+    baseUrl: base.toString().replace(/\/$/, ''),
+    host: base.hostname,
+    port: Number(base.port || DEFAULT_PORT),
+    headless: !parsedArgs.headed,
+    slowMo: parsedArgs.slowMo,
+    reuseServer: parsedArgs.reuseServer,
+    skipBuild: parsedArgs.skipBuild,
+    scenarios,
+    accountMode,
+    artifactDir: path.join('output', 'playwright', runName),
+    envValues,
+  }
+}
+
+function resolveScenarios(rawScenario) {
+  const chunks = rawScenario
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean)
+
+  const resolved = []
+
+  for (const chunk of chunks) {
+    if (scenarioSets[chunk]) {
+      resolved.push(...scenarioSets[chunk])
+      continue
+    }
+
+    resolved.push(chunk)
+  }
+
+  return [...new Set(resolved)]
+}
+
+function resolveAccountMode(explicitMode, envValues) {
+  if (explicitMode) {
+    return explicitMode
+  }
+
+  const hasEnvAccounts = Boolean(
+    getEnvValue(envValues, ['PLAYWRIGHT_ACCOUNT_1_EMAIL', 'PLAYWRIGHT_ACCOUNT1_EMAIL']) &&
+    getEnvValue(envValues, ['PLAYWRIGHT_ACCOUNT_1_PASSWORD', 'PLAYWRIGHT_ACCOUNT1_PASSWORD']) &&
+    getEnvValue(envValues, ['PLAYWRIGHT_ACCOUNT_2_EMAIL', 'PLAYWRIGHT_ACCOUNT2_EMAIL']) &&
+    getEnvValue(envValues, ['PLAYWRIGHT_ACCOUNT_2_PASSWORD', 'PLAYWRIGHT_ACCOUNT2_PASSWORD'])
+  )
+
+  return hasEnvAccounts ? 'env' : 'disposable'
+}
+
+async function loadDotEnv(filePath) {
+  if (!existsSync(filePath)) {
+    return {}
+  }
+
+  const raw = await readFile(filePath, 'utf8')
+  const values = {}
+
+  for (const line of raw.split(/\r?\n/u)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+
+    const equalsIndex = trimmed.indexOf('=')
+    if (equalsIndex <= 0) {
+      continue
+    }
+
+    const key = trimmed.slice(0, equalsIndex).trim()
+    let value = trimmed.slice(equalsIndex + 1).trim()
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+
+    values[key] = value
+  }
+
+  return values
+}
+
+function getEnvValue(envValues, names, fallback = '') {
+  for (const name of names) {
+    const candidate = process.env[name] ?? envValues[name]
+    if (candidate) {
+      return candidate
+    }
+  }
+
+  return fallback
+}
+
+function buildAccounts(config) {
+  if (config.accountMode === 'env') {
+    return [
+      buildEnvAccount(config.envValues, 1),
+      buildEnvAccount(config.envValues, 2),
+    ]
+  }
+
+  const seed = timestampToken()
+
+  return [
+    {
+      label: 'account-1',
+      strategy: 'signup',
+      email: `shadowchat-smoke-${seed}-a@example.com`,
+      password: 'ShadowChat!123456',
+      username: `smokea${seed}`.slice(0, 24),
+      displayName: 'Smoke User A',
+    },
+    {
+      label: 'account-2',
+      strategy: 'signup',
+      email: `shadowchat-smoke-${seed}-b@example.com`,
+      password: 'ShadowChat!123456',
+      username: `smokeb${seed}`.slice(0, 24),
+      displayName: 'Smoke User B',
+    },
+  ]
+}
+
+function buildEnvAccount(envValues, index) {
+  const prefix = [`PLAYWRIGHT_ACCOUNT_${index}_`, `PLAYWRIGHT_ACCOUNT${index}_`]
+  const email = getEnvValue(envValues, prefix.map(value => `${value}EMAIL`))
+  const password = getEnvValue(envValues, prefix.map(value => `${value}PASSWORD`))
+
+  if (!email || !password) {
+    throw new Error(`Missing Playwright account ${index} credentials in .env or process env`)
+  }
+
+  return {
+    label: `account-${index}`,
+    strategy: 'signin',
+    email,
+    password,
+    username: getEnvValue(envValues, prefix.map(value => `${value}USERNAME`)),
+    displayName: getEnvValue(envValues, prefix.map(value => `${value}DISPLAY_NAME`)),
+  }
+}
+
+async function ensurePreviewServer(state) {
+  if (state.config.reuseServer && await waitForUrl(state.config.baseUrl, 1_500)) {
+    logLine(`Reusing preview server at ${state.config.baseUrl}`)
+    return {
+      reused: true,
+      cleanup: async () => {},
+    }
+  }
+
+  if (!state.config.skipBuild) {
+    await runLoggedCommand({
+      command: npmCommand,
+      args: ['run', 'build'],
+      cwd: state.repoRoot,
+      logPath: path.join(state.logsDir, 'build.log'),
+      label: 'vite build',
+    })
+  }
+
+  const previewLogPath = path.join(state.logsDir, 'preview.log')
+  const child = spawn(npxCommand, [
+    'vite',
+    'preview',
+    '--host',
+    state.config.host,
+    '--port',
+    String(state.config.port),
+    '--strictPort',
+  ], {
+    cwd: state.repoRoot,
+    shell: process.platform === 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  child.stdout.on('data', chunk => void appendFile(previewLogPath, chunk))
+  child.stderr.on('data', chunk => void appendFile(previewLogPath, chunk))
+
+  const ready = await waitForUrl(state.config.baseUrl, DEFAULT_TIMEOUT_MS)
+  if (!ready) {
+    await stopChildProcess(child)
+    throw new Error(`Preview server did not start at ${state.config.baseUrl}`)
+  }
+
+  logLine(`Started preview server at ${state.config.baseUrl}`)
+
+  return {
+    reused: false,
+    cleanup: async () => {
+      await stopChildProcess(child)
+    },
+  }
+}
+
+async function createDesktopSession(browserInstance, state, account, folderName, options = {}) {
+  let context
+
+  if (options.persistent) {
+    const profileDir = path.join(state.artifactDir, 'profiles', folderName)
+    await mkdir(profileDir, { recursive: true })
+    context = await chromium.launchPersistentContext(profileDir, {
+      headless: state.config.headless,
+      slowMo: state.config.slowMo,
+      viewport: { width: 1440, height: 960 },
+      ignoreHTTPSErrors: true,
+    })
+  } else {
+    context = await browserInstance.newContext({
+      viewport: { width: 1440, height: 960 },
+      ignoreHTTPSErrors: true,
+    })
+  }
+
+  await installBrowserMocks(context)
+  const page = context.pages()[0] || await context.newPage()
+  attachDiagnostics(page, path.join(state.logsDir, `${folderName}.log`), folderName)
+  const hydratedAccount = await authenticateAccount(page, state, account, folderName)
+
+  return {
+    account: hydratedAccount,
+    context,
+    page,
+    folderName,
+    persistent: Boolean(options.persistent),
+  }
+}
+
+async function refreshMobileSession(browserInstance, state, account, existingSession) {
+  await closeSession(existingSession)
+
+  const storageStateDir = path.join(state.artifactDir, 'storage')
+  const storageStatePath = path.join(storageStateDir, `${account.label}.json`)
+  await mkdir(storageStateDir, { recursive: true })
+  await writeStorageState(browserInstance, state, account, storageStatePath)
+
+  const context = await browserInstance.newContext({
+    ...devices['iPhone 13'],
+    storageState: storageStatePath,
+    ignoreHTTPSErrors: true,
+  })
+  await installBrowserMocks(context)
+  const page = await context.newPage()
+  attachDiagnostics(page, path.join(state.logsDir, 'mobile-account-1.log'), 'mobile-account-1')
+  await page.goto(state.config.baseUrl, { waitUntil: 'domcontentloaded' })
+  await waitForChatView(page)
+
+  return {
+    account,
+    context,
+    page,
+    folderName: 'mobile-account-1',
+  }
+}
+
+async function writeStorageState(browserInstance, state, account, storageStatePath) {
+  const scratchContext = await browserInstance.newContext({
+    viewport: { width: 1440, height: 960 },
+    ignoreHTTPSErrors: true,
+  })
+  await installBrowserMocks(scratchContext)
+  const scratchPage = await scratchContext.newPage()
+  attachDiagnostics(scratchPage, path.join(state.logsDir, `${account.label}-storage.log`), `${account.label}-storage`)
+
+  try {
+    await authenticateAccount(scratchPage, state, {
+      ...account,
+      strategy: 'signin',
+    }, `${account.label}-storage`)
+    await scratchContext.storageState({ path: storageStatePath })
+  } finally {
+    await scratchContext.close().catch(() => {})
+  }
+}
+
+async function authenticateAccount(page, state, account, label) {
+  await page.goto(state.config.baseUrl, { waitUntil: 'domcontentloaded' })
+  await waitForBootSurface(page)
+
+  if (await isChatVisible(page)) {
+    const profile = await readVisibleProfile(page).catch(() => null)
+    return {
+      ...account,
+      ...profile,
+      strategy: 'signin',
+    }
+  }
+
+  if (account.strategy === 'signup') {
+    await ensureSignupView(page)
+    await fillInput(page, 'Full Name', account.displayName)
+    await fillInput(page, 'Username', account.username)
+    await fillInput(page, 'Email', account.email)
+    await fillInput(page, 'Password', account.password)
+    await page.getByRole('button', { name: 'Create Account' }).click()
+
+    const landedInChat = await waitForEither(
+      [
+        async () => isChatVisible(page),
+        async () => page.getByText('Please check your email to confirm your account.').isVisible().catch(() => false),
+      ],
+      DEFAULT_TIMEOUT_MS
+    )
+
+    if (!landedInChat || !(await isChatVisible(page))) {
+      throw new Error(`Signup for ${label} completed without an active session. Use PLAYWRIGHT_ACCOUNT_* env vars if email confirmation is required.`)
+    }
+  } else {
+    await ensureSigninView(page)
+    await fillInput(page, 'Email', account.email)
+    await fillInput(page, 'Password', account.password)
+    await page.getByRole('button', { name: 'Sign In' }).click()
+    await waitForChatView(page)
+  }
+
+  const profile = await readVisibleProfile(page)
+  await capture(page, state.artifactDir, `${label}-ready`)
+
+  return {
+    ...account,
+    ...profile,
+    strategy: 'signin',
+  }
+}
+
+async function scenarioAuth(state, sessionA, sessionB) {
+  await waitForChatView(sessionA.page)
+  await waitForChatView(sessionB.page)
+
+  await capture(sessionA.page, state.artifactDir, 'auth-account-1-chat')
+  await capture(sessionB.page, state.artifactDir, 'auth-account-2-chat')
+}
+
+async function scenarioGroupChat(state, sessionA, sessionB) {
+  await goToChat(sessionA.page)
+  await goToChat(sessionB.page)
+
+  const messageText = `Group smoke ${timestampToken()}`
+  const audioCountBeforeB = await sessionB.page.locator('audio').count()
+  const fileName = path.basename(state.fixtures.filePath)
+  const imageName = path.basename(state.fixtures.imagePath)
+
+  await sendVisibleMessage(sessionA.page, messageText)
+  await expectVisibleText(sessionB.page, messageText, DEFAULT_TIMEOUT_MS)
+
+  await reactToMessage(sessionB.page, messageText, '\u{1F44D}')
+  await expectReactionOnMessage(sessionA.page, messageText, '\u{1F44D}', 1)
+  await expectReactionOnMessage(sessionB.page, messageText, '\u{1F44D}', 1)
+
+  await uploadImageAttachment(sessionA.page, state.fixtures.imagePath)
+  await waitForLoadedImage(sessionA.page, imageName)
+  await waitForLoadedImage(sessionB.page, imageName)
+
+  await uploadFileAttachment(sessionA.page, state.fixtures.filePath)
+  await expectVisibleText(sessionB.page, fileName, DEFAULT_TIMEOUT_MS)
+
+  await recordVoiceMessage(sessionA.page)
+  await waitForAudioCount(sessionB.page, audioCountBeforeB + 1)
+
+  await capture(sessionA.page, state.artifactDir, 'group-chat-sender')
+  await capture(sessionB.page, state.artifactDir, 'group-chat-recipient')
+}
+
+async function scenarioSettings(state, _sessionA, sessionB) {
+  await sessionB.context.grantPermissions(['notifications'], { origin: state.config.baseUrl })
+  await sessionB.page.reload({ waitUntil: 'domcontentloaded' })
+  await waitForChatView(sessionB.page)
+  await goToSettings(sessionB.page)
+
+  await assertSwitchGeometry(sessionB.page, 'Toggle Push Notifications', 'Toggle Sound Effects')
+  await capture(sessionB.page, state.artifactDir, 'settings-desktop-before-modal')
+
+  await sessionB.page.getByRole('button', { name: 'Notification Setup' }).click()
+  await sessionB.page.getByText('Setup Steps').waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+  await capture(sessionB.page, state.artifactDir, 'settings-notification-modal')
+  await sessionB.page.getByRole('button', { name: 'Close' }).click()
+  await sessionB.page.getByText('Setup Steps').waitFor({ state: 'hidden', timeout: DEFAULT_TIMEOUT_MS })
+
+  await toggleSwitch(sessionB.page, 'Toggle Reactions')
+  await expectSwitchState(sessionB.page, 'Toggle Reactions', true)
+  await toggleSwitch(sessionB.page, 'Toggle Reactions')
+  await expectSwitchState(sessionB.page, 'Toggle Reactions', false)
+
+  const pushSwitchLabel = 'Toggle Push Notifications'
+  if (!(await isSwitchChecked(sessionB.page, pushSwitchLabel))) {
+    await toggleSwitch(sessionB.page, pushSwitchLabel)
+  }
+  const pushEnabled = await waitForEither(
+    [
+      async () => isSwitchChecked(sessionB.page, pushSwitchLabel),
+      async () => sessionB.page.getByText('Enabled on this device').isVisible().catch(() => false),
+    ],
+    15_000
+  )
+
+  if (await sessionB.page.getByRole('button', { name: 'Close' }).isVisible().catch(() => false)) {
+    await sessionB.page.getByRole('button', { name: 'Close' }).click()
+    await sessionB.page.getByText('Setup Steps').waitFor({ state: 'hidden', timeout: DEFAULT_TIMEOUT_MS }).catch(() => {})
+  }
+
+  if (pushEnabled) {
+    await sessionB.page.getByRole('button', { name: 'Refresh Status' }).first().click()
+    await expectVisibleText(sessionB.page, 'Enabled on this device', 30_000)
+    await expectSwitchState(sessionB.page, pushSwitchLabel, true)
+  } else {
+    logLine('Push registration did not complete in this browser mode; settings UI and modal flow were still verified.')
+  }
+  await capture(sessionB.page, state.artifactDir, 'settings-desktop-final')
+}
+
+async function scenarioDM(state, sessionA, sessionB) {
+  await ensureConversationIsReady(state, sessionA, sessionB)
+
+  const messageText = `Smoke ping ${timestampToken()}`
+  const sidebarUnreadBaseline = await readSidebarDmLabel(sessionB.page)
+
+  await goToChat(sessionB.page)
+  await goToDirectMessages(sessionA.page)
+  await openConversationWithUser(sessionA.page, sessionB.account, state)
+  await sendThreadMessage(sessionA.page, messageText)
+  await capture(sessionA.page, state.artifactDir, 'dm-sender-thread')
+
+  await waitForSidebarUnreadChange(sessionB.page, sidebarUnreadBaseline)
+  await goToDirectMessages(sessionB.page)
+  await openConversationWithUser(sessionB.page, sessionA.account, state)
+  await expectVisibleText(sessionB.page, messageText, DEFAULT_TIMEOUT_MS)
+  await expectVisibleText(sessionB.page, '0 unread', DEFAULT_TIMEOUT_MS)
+  await sessionB.page.reload({ waitUntil: 'domcontentloaded' })
+  await waitForDmView(sessionB.page)
+  await expectVisibleText(sessionB.page, '0 unread', DEFAULT_TIMEOUT_MS)
+  await capture(sessionB.page, state.artifactDir, 'dm-recipient-after-reload')
+}
+
+async function scenarioResumeSend(state, sessionA, sessionB) {
+  await goToChat(sessionA.page)
+  await goToChat(sessionB.page)
+
+  await simulateVisibilityResume(sessionA.page)
+
+  const chatMessage = `Resume chat ${timestampToken()}`
+  await sendVisibleMessage(sessionA.page, chatMessage)
+  await expectVisibleText(sessionB.page, chatMessage, DEFAULT_TIMEOUT_MS)
+  await capture(sessionA.page, state.artifactDir, 'resume-chat-sender')
+  await capture(sessionB.page, state.artifactDir, 'resume-chat-recipient')
+
+  await ensureConversationIsReady(state, sessionA, sessionB)
+  await goToDirectMessages(sessionA.page)
+  await openConversationWithUser(sessionA.page, sessionB.account, state)
+
+  await simulateVisibilityResume(sessionA.page)
+
+  const dmMessage = `Resume dm ${timestampToken()}`
+  await sendThreadMessage(sessionA.page, dmMessage)
+
+  await goToDirectMessages(sessionB.page)
+  await openConversationWithUser(sessionB.page, sessionA.account, state)
+  await expectVisibleText(sessionB.page, dmMessage, DEFAULT_TIMEOUT_MS)
+  await capture(sessionA.page, state.artifactDir, 'resume-dm-sender')
+  await capture(sessionB.page, state.artifactDir, 'resume-dm-recipient')
+}
+
+async function scenarioProfileVisual(state, sessionA) {
+  await goToProfile(sessionA.page)
+  await capture(sessionA.page, state.artifactDir, 'profile-desktop')
+}
+
+async function scenarioMobileDmBack(state, sessionA, sessionB, mobileSession) {
+  await ensureConversationIsReady(state, sessionA, sessionB)
+  await waitForChatView(mobileSession.page)
+
+  await mobileSession.page.getByRole('button', { name: /^DMs$/ }).click()
+  await waitForDmView(mobileSession.page)
+  await openConversationWithUser(mobileSession.page, sessionB.account, state)
+  await mobileSession.page.getByRole('button', { name: 'Back' }).first().click()
+  await expectVisibleText(mobileSession.page, 'Direct Messages', DEFAULT_TIMEOUT_MS)
+  await mobileSession.page.getByRole('button', { name: 'Back' }).click()
+  await waitForChatView(mobileSession.page)
+  await capture(mobileSession.page, state.artifactDir, 'mobile-dm-back')
+}
+
+async function scenarioMobileSettingsVisual(state, mobileSession) {
+  await waitForChatView(mobileSession.page)
+  await goToSettings(mobileSession.page)
+  await assertSwitchGeometry(mobileSession.page, 'Toggle Push Notifications', 'Toggle Sound Effects')
+  await capture(mobileSession.page, state.artifactDir, 'settings-mobile')
+}
+
+async function ensureConversationIsReady(state, sessionA, sessionB) {
+  await goToDirectMessages(sessionA.page)
+  await openConversationWithUser(sessionA.page, sessionB.account, state)
+  await goToDirectMessages(sessionB.page)
+  await maybeOpenConversationFromList(sessionB.page, sessionA.account)
+  await goToChat(sessionB.page)
+}
+
+async function goToDirectMessages(page) {
+  await page.getByRole('button', { name: /Direct Messages|DMs/i }).click()
+  await waitForDmView(page)
+}
+
+async function goToChat(page) {
+  await page.getByRole('button', { name: /^Chat$/ }).click()
+  await waitForChatView(page)
+}
+
+async function goToSettings(page) {
+  await page.getByRole('button', { name: /^Settings$/ }).click()
+  await waitForSettingsView(page)
+}
+
+async function goToProfile(page) {
+  await page.getByRole('button', { name: /^Profile$/ }).click()
+  await waitForProfileView(page)
+}
+
+async function waitForBootSurface(page) {
+  await page.waitForFunction(() => {
+    const text = document.body?.innerText || ''
+    return (
+      text.includes('Welcome Back') ||
+      text.includes('Join the Chat') ||
+      text.includes('General Chat') ||
+      text.includes('Direct Messages')
+    )
+  }, null, { timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function waitForChatView(page) {
+  await page.getByRole('heading', { name: 'General Chat' }).waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+  await page.locator('textarea:visible').first().waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function waitForDmView(page) {
+  await page.getByRole('heading', { name: 'Direct Messages' }).waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function waitForSettingsView(page) {
+  await page.getByRole('heading', { name: 'Settings' }).waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+  await page.getByRole('button', { name: 'Notification Setup' }).waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function waitForProfileView(page) {
+  await page.getByRole('button', { name: /Edit Profile|Cancel/i }).waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+  await page.getByText('Identity').waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function isChatVisible(page) {
+  return page.getByRole('heading', { name: 'General Chat' }).isVisible().catch(() => false)
+}
+
+async function ensureSignupView(page) {
+  if (await page.getByLabel('Full Name').isVisible().catch(() => false)) {
+    return
+  }
+
+  await page.getByRole('button', { name: /Sign up/i }).click()
+  await page.getByLabel('Full Name').waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function ensureSigninView(page) {
+  if (await page.getByRole('button', { name: 'Sign In' }).isVisible().catch(() => false)) {
+    return
+  }
+
+  await page.getByRole('button', { name: /Sign in/i }).click()
+  await page.getByRole('button', { name: 'Sign In' }).waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function fillInput(page, label, value) {
+  const fieldNames = {
+    'Full Name': 'full_name',
+    Username: 'username',
+    Email: 'email',
+    Password: 'password',
+  }
+
+  const fieldName = fieldNames[label]
+  const input = fieldName
+    ? page.locator(`input[name="${fieldName}"]`).first()
+    : page.getByLabel(label)
+  await input.click()
+  await input.fill(value)
+}
+
+async function readVisibleProfile(page) {
+  const usernameText = await page.getByText(/^@/).first().innerText()
+
+  return {
+    username: usernameText.trim().replace(/^@/u, ''),
+  }
+}
+
+async function openConversationWithUser(page, account, state) {
+  const row = page.getByRole('button', { name: new RegExp(`@${escapeRegExp(account.username)}`, 'i') }).first()
+  if (await row.isVisible().catch(() => false)) {
+    await row.click()
+    await waitForEitherThreadOrList(page, account)
+    return
+  }
+
+  await page.getByRole('button', { name: 'Start new conversation' }).click()
+  await page.getByPlaceholder('Search by username').fill(account.username)
+  const searchRow = page.getByRole('button', { name: new RegExp(`@${escapeRegExp(account.username)}`, 'i') }).first()
+  await searchRow.waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+  await searchRow.click()
+  await waitForEitherThreadOrList(page, account)
+  await capture(page, state.artifactDir, `open-thread-${account.username}`)
+}
+
+async function maybeOpenConversationFromList(page, account) {
+  const row = page.getByRole('button', { name: new RegExp(`@${escapeRegExp(account.username)}`, 'i') }).first()
+  if (await row.isVisible().catch(() => false)) {
+    await row.click()
+    await waitForEitherThreadOrList(page, account)
+  }
+}
+
+async function waitForEitherThreadOrList(page, account) {
+  await page.waitForFunction(expectedUsername => {
+    const text = document.body?.innerText || ''
+    return text.includes(`@${expectedUsername}`) || text.includes('Select a conversation')
+  }, account.username, { timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function simulateVisibilityResume(page) {
+  await page.evaluate(async () => {
+    const originalHidden = Object.getOwnPropertyDescriptor(document, 'hidden')
+    const originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState')
+
+    let hidden = true
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    })
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => (hidden ? 'hidden' : 'visible'),
+    })
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    await new Promise(resolve => setTimeout(resolve, 250))
+
+    hidden = false
+    document.dispatchEvent(new Event('visibilitychange'))
+    await new Promise(resolve => setTimeout(resolve, 1200))
+
+    if (originalHidden) {
+      Object.defineProperty(document, 'hidden', originalHidden)
+    } else {
+      delete document.hidden
+    }
+
+    if (originalVisibilityState) {
+      Object.defineProperty(document, 'visibilityState', originalVisibilityState)
+    } else {
+      delete document.visibilityState
+    }
+  })
+}
+
+async function sendThreadMessage(page, messageText) {
+  const composer = page.locator('textarea:visible').last()
+  await composer.click()
+  await composer.fill(messageText)
+  await page.locator('button[aria-label="Send message"]:visible').last().click()
+}
+
+async function sendVisibleMessage(page, messageText) {
+  const composer = page.locator('textarea:visible').last()
+  await composer.click()
+  await composer.fill(messageText)
+  await page.locator('button[aria-label="Send message"]:visible').last().click()
+}
+
+async function reactToMessage(page, messageText, emoji) {
+  const wrapper = getMessageWrapperByText(page, messageText)
+  await wrapper.hover()
+  await wrapper.getByRole('button', { name: 'Message actions' }).click()
+  if (emoji === '\u{1F44D}') {
+    await page.getByRole('button', { name: 'React with thumbs up' }).last().click()
+    return
+  }
+  await page.getByRole('button', { name: `React with ${emoji}` }).last().click()
+}
+
+async function expectReactionOnMessage(page, messageText, emoji, count) {
+  const wrapper = getMessageWrapperByText(page, messageText)
+  await wrapper.getByRole('button', { name: `Reaction ${emoji} count ${count}` }).waitFor({ timeout: DEFAULT_TIMEOUT_MS })
+}
+
+function getMessageWrapperByText(page, messageText) {
+  const messageNode = page.getByText(messageText, { exact: false }).last()
+  return messageNode.locator('xpath=ancestor::div[contains(@class,"group/message")]').first()
+}
+
+async function uploadImageAttachment(page, filePath) {
+  await page.locator('input[data-upload-kind="image"]').first().setInputFiles(filePath)
+  await page.locator('img[alt="uploaded image"]').last().waitFor({ timeout: 30_000 })
+}
+
+async function uploadFileAttachment(page, filePath) {
+  await page.locator('input[data-upload-kind="file"]').first().setInputFiles(filePath)
+  await expectVisibleText(page, path.basename(filePath), 30_000)
+}
+
+async function recordVoiceMessage(page) {
+  await page.getByRole('button', { name: 'Record audio' }).click()
+  await expectVisibleText(page, 'Recording...', DEFAULT_TIMEOUT_MS)
+  await page.getByRole('button', { name: 'Stop' }).click()
+  await page.locator('audio').last().waitFor({ timeout: 30_000 })
+}
+
+async function waitForLoadedImage(page, fileName) {
+  await page.waitForFunction(name => {
+    return Array.from(document.querySelectorAll('img[alt="uploaded image"]')).some(image => {
+      const img = image
+      return img.currentSrc.includes(name) && img.naturalWidth > 0
+    })
+  }, fileName, { timeout: 30_000 })
+}
+
+async function waitForAudioCount(page, expectedCount) {
+  await page.waitForFunction(count => {
+    return document.querySelectorAll('audio').length >= count
+  }, expectedCount, { timeout: 30_000 })
+}
+
+async function readSidebarDmLabel(page) {
+  const label = await page.getByRole('button', { name: /Direct Messages/i }).first().innerText()
+  return normalizeWhitespace(label)
+}
+
+async function toggleSwitch(page, label) {
+  await page.getByRole('switch', { name: label }).click()
+}
+
+async function isSwitchChecked(page, label) {
+  const value = await page.getByRole('switch', { name: label }).getAttribute('aria-checked')
+  return value === 'true'
+}
+
+async function expectSwitchState(page, label, expected) {
+  await page.waitForFunction(
+    ({ switchLabel, expectedState }) => {
+      const element = Array.from(document.querySelectorAll('[role="switch"]')).find(node =>
+        (node.getAttribute('aria-label') || '') === switchLabel
+      )
+      return element?.getAttribute('aria-checked') === String(expectedState)
+    },
+    { switchLabel: label, expectedState: expected },
+    { timeout: DEFAULT_TIMEOUT_MS }
+  )
+}
+
+async function assertSwitchGeometry(page, primaryLabel, referenceLabel) {
+  const primary = await page.getByRole('switch', { name: primaryLabel }).boundingBox()
+  const reference = await page.getByRole('switch', { name: referenceLabel }).boundingBox()
+
+  if (!primary || !reference) {
+    throw new Error('Could not measure settings switches for layout verification')
+  }
+
+  const widthDelta = Math.abs(primary.width - reference.width)
+  const heightDelta = Math.abs(primary.height - reference.height)
+
+  if (widthDelta > 2 || heightDelta > 2) {
+    throw new Error(`Switch geometry mismatch: ${primaryLabel} (${primary.width}x${primary.height}) vs ${referenceLabel} (${reference.width}x${reference.height})`)
+  }
+}
+
+async function waitForSidebarUnreadChange(page, previousLabel) {
+  await page.waitForFunction(expectedPrevious => {
+    const buttons = Array.from(document.querySelectorAll('button'))
+    const match = buttons.find(button => button.innerText.includes('Direct Messages'))
+    if (!match) {
+      return false
+    }
+
+    const current = match.innerText.replace(/\s+/gu, ' ').trim()
+    return current !== expectedPrevious && /\d+/u.test(current)
+  }, previousLabel, { timeout: DEFAULT_TIMEOUT_MS })
+}
+
+async function expectVisibleText(page, text, timeoutMs) {
+  await page.getByText(text, { exact: false }).first().waitFor({ timeout: timeoutMs })
+}
+
+async function waitForEither(checks, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    for (const check of checks) {
+      if (await check()) {
+        return true
+      }
+    }
+
+    await delay(250)
+  }
+
+  return false
+}
+
+async function capture(page, baseArtifactDir, label) {
+  const filePath = path.join(baseArtifactDir, `${slugify(label)}.png`)
+  await page.screenshot({ path: filePath, fullPage: true })
+  return filePath
+}
+
+function attachDiagnostics(page, logPath, label) {
+  page.on('console', async message => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      await appendFile(logPath, `[console:${label}:${message.type()}] ${message.text()}\n`)
+    }
+  })
+
+  page.on('pageerror', async error => {
+    await appendFile(logPath, `[pageerror:${label}] ${error.message}\n`)
+  })
+
+  page.on('requestfailed', async request => {
+    await appendFile(logPath, `[requestfailed:${label}] ${request.method()} ${request.url()} ${request.failure()?.errorText || 'unknown'}\n`)
+  })
+}
+
+async function runScenario(state, name, fn) {
+  const startedAt = new Date().toISOString()
+  logLine(`Starting scenario: ${name}`)
+
+  try {
+    await fn()
+    state.summary.scenarios.push({
+      name,
+      status: 'passed',
+      startedAt,
+      finishedAt: new Date().toISOString(),
+    })
+    logLine(`Passed scenario: ${name}`)
+  } catch (error) {
+    state.summary.scenarios.push({
+      name,
+      status: 'failed',
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      error: serializeError(error),
+    })
+    throw error
+  }
+}
+
+async function runLoggedCommand({ command, args, cwd, logPath, label }) {
+  await appendFile(logPath, `\n> ${command} ${args.join(' ')}\n`)
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      shell: process.platform === 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    child.stdout.on('data', chunk => void appendFile(logPath, chunk))
+    child.stderr.on('data', chunk => void appendFile(logPath, chunk))
+
+    child.on('error', reject)
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+
+      reject(new Error(`${label} failed with exit code ${code}`))
+    })
+  })
+}
+
+async function waitForUrl(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { method: 'GET' })
+      if (response.ok) {
+        return true
+      }
+    } catch {
+      // Server not ready yet.
+    }
+
+    await delay(300)
+  }
+
+  return false
+}
+
+async function stopChildProcess(child) {
+  if (!child || child.exitCode !== null) {
+    return
+  }
+
+  if (process.platform === 'win32' && taskKillCommand) {
+    await new Promise(resolve => {
+      const killer = spawn(taskKillCommand, ['/pid', String(child.pid), '/t', '/f'], {
+        shell: false,
+        stdio: 'ignore',
+      })
+      killer.on('exit', () => resolve())
+      killer.on('error', () => resolve())
+    })
+    return
+  }
+
+  child.kill('SIGTERM')
+  await new Promise(resolve => {
+    child.on('exit', () => resolve())
+    setTimeout(resolve, 2_000)
+  })
+}
+
+async function closeSession(session) {
+  if (!session?.context) {
+    return
+  }
+
+  await session.context.close().catch(() => {})
+}
+
+function serializeError(error) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    }
+  }
+
+  return {
+    message: String(error),
+  }
+}
+
+async function writeJson(filePath, value) {
+  await writeFile(filePath, JSON.stringify(value, null, 2), 'utf8')
+}
+
+async function createFixtures(targetDir) {
+  await mkdir(targetDir, { recursive: true })
+  const token = timestampToken()
+  const imagePath = path.join(targetDir, `smoke-image-${token}.svg`)
+  const filePath = path.join(targetDir, `smoke-note-${token}.txt`)
+
+  await writeFile(
+    imagePath,
+    `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="100" viewBox="0 0 160 100" role="img" aria-label="ShadowChat smoke image">
+  <defs>
+    <linearGradient id="bg" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#f7d67a" />
+      <stop offset="100%" stop-color="#8f6a37" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="100" rx="18" fill="#111315" />
+  <rect x="8" y="8" width="144" height="84" rx="14" fill="url(#bg)" opacity="0.9" />
+  <circle cx="44" cy="38" r="14" fill="#1a1f23" opacity="0.85" />
+  <path d="M24 76l28-22 18 14 28-30 38 38H24z" fill="#1a1f23" opacity="0.85" />
+  <text x="18" y="92" fill="#111315" font-family="Arial, sans-serif" font-size="12" font-weight="700">ShadowChat</text>
+</svg>`,
+    'utf8'
+  )
+  await writeFile(
+    filePath,
+    `ShadowChat smoke attachment ${token}\nThis file verifies generic upload rendering.\n`,
+    'utf8'
+  )
+
+  return { imagePath, filePath }
+}
+
+async function installBrowserMocks(context) {
+  await context.addInitScript(() => {
+    const fakeTrack = {
+      enabled: true,
+      kind: 'audio',
+      readyState: 'live',
+      stop() {},
+    }
+
+    const fakeStream = {
+      getTracks() {
+        return [fakeTrack]
+      },
+    }
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: async () => fakeStream,
+      },
+    })
+
+    class MockMediaRecorder {
+      constructor(stream) {
+        this.stream = stream
+        this.mimeType = 'audio/wav'
+        this.state = 'inactive'
+        this.ondataavailable = null
+        this.onstop = null
+      }
+
+      start() {
+        this.state = 'recording'
+      }
+
+      stop() {
+        this.state = 'inactive'
+        const wavBytes = Uint8Array.from([
+          82, 73, 70, 70, 44, 0, 0, 0, 87, 65, 86, 69, 102, 109, 116, 32,
+          16, 0, 0, 0, 1, 0, 1, 0, 68, 172, 0, 0, 136, 88, 1, 0,
+          2, 0, 16, 0, 100, 97, 116, 97, 8, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0,
+        ])
+        const blob = new Blob([wavBytes], { type: this.mimeType })
+        const event = { data: blob }
+        setTimeout(() => {
+          this.ondataavailable?.(event)
+          this.onstop?.()
+        }, 0)
+      }
+    }
+
+    window.MediaRecorder = MockMediaRecorder
+  })
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/^-+|-+$/gu, '')
+}
+
+function timestampToken() {
+  return new Date().toISOString().replace(/[-:.TZ]/gu, '').slice(0, 14)
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+}
+
+function normalizeWhitespace(value) {
+  return value.replace(/\s+/gu, ' ').trim()
+}
+
+function logLine(message) {
+  const line = `[${new Date().toISOString()}] ${message}\n`
+  process.stdout.write(line)
+  void appendFile(runLogPath, line)
+}

--- a/src/components/chat/FileAttachment.tsx
+++ b/src/components/chat/FileAttachment.tsx
@@ -20,7 +20,8 @@ export const FileAttachment: React.FC<FileAttachmentProps> = ({ url, meta }) => 
     // ignore
   }
 
-  const previewDocument = type === 'application/pdf' || type.startsWith('text/')
+  const previewDocument = type === 'application/pdf'
+  const previewText = type.startsWith('text/')
   const previewAudio = type.startsWith('audio/')
 
   return (
@@ -31,6 +32,11 @@ export const FileAttachment: React.FC<FileAttachmentProps> = ({ url, meta }) => 
           title={name}
           className="mb-2 h-48 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.02)]"
         />
+      )}
+      {previewText && (
+        <div className="mb-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] px-3 py-2 text-sm text-[var(--text-secondary)]">
+          Text files open cleanly from the attachment link below.
+        </div>
       )}
       {previewAudio && (
         <audio controls src={url} className="w-full mt-1 mb-2" />

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -89,14 +89,18 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   // Handle clicks outside attachment menu
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (attachmentMenuRef.current && !attachmentMenuRef.current.contains(event.target as Node)) {
+      if (
+        showAttachmentMenu &&
+        attachmentMenuRef.current &&
+        !attachmentMenuRef.current.contains(event.target as Node)
+      ) {
         setShowAttachmentMenu(false)
       }
     }
 
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  }, [showAttachmentMenu])
 
   // Track recording duration
   useEffect(() => {
@@ -227,43 +231,57 @@ export const MessageInput: React.FC<MessageInputProps> = ({
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
+    e.target.value = ''
     if (file) {
       onUploadStatusChange(true)
-      uploadChatFile(file)
-        .then(url => {
-          onSendMessage('', 'image', url, replyingTo?.id)
+      ;(async () => {
+        try {
+          const url = await uploadChatFile(file)
+          const sent = await onSendMessage('', 'image', url, replyingTo?.id)
+          if (sent === null) {
+            toast.error('Failed to send image')
+            return
+          }
           onCancelReply?.()
-        })
-        .catch(err => {
+        } catch (err) {
           console.error(err)
-        })
-        .finally(() => onUploadStatusChange(false))
+          toast.error('Failed to send image')
+        } finally {
+          onUploadStatusChange(false)
+        }
+      })()
     }
-    e.target.value = ''
   }
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
+    e.target.value = ''
     if (file) {
       onUploadStatusChange(true)
-      uploadChatFile(file)
-        .then(url => {
+      ;(async () => {
+        try {
+          const url = await uploadChatFile(file)
           const messageType = file.type.startsWith('image/') ? 'image' : 'file'
           const meta = JSON.stringify({ name: file.name, size: file.size, type: file.type })
-          onSendMessage(
+          const sent = await onSendMessage(
             messageType === 'image' ? '' : meta,
             messageType as any,
             url,
             replyingTo?.id
           )
+          if (sent === null) {
+            toast.error('Failed to send attachment')
+            return
+          }
           onCancelReply?.()
-        })
-        .catch(err => {
+        } catch (err) {
           console.error(err)
-        })
-        .finally(() => onUploadStatusChange(false))
+          toast.error('Failed to send attachment')
+        } finally {
+          onUploadStatusChange(false)
+        }
+      })()
     }
-    e.target.value = ''
   }
 
   const startRecording = async () => {
@@ -279,10 +297,15 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         try {
           onUploadStatusChange(true)
           const url = await uploadVoiceMessage(blob, mimeType)
-          onSendMessage(url, 'audio', undefined, replyingTo?.id)
+          const sent = await onSendMessage(url, 'audio', undefined, replyingTo?.id)
+          if (sent === null) {
+            toast.error('Failed to send voice message')
+            return
+          }
           onCancelReply?.()
         } catch (err) {
           console.error(err)
+          toast.error('Failed to send voice message')
         } finally {
           onUploadStatusChange(false)
           mediaStreamRef.current = null
@@ -454,12 +477,14 @@ export const MessageInput: React.FC<MessageInputProps> = ({
             accept="image/*"
             ref={imageInputRef}
             onChange={handleImageChange}
+            data-upload-kind="image"
             className="hidden"
           />
           <input
             type="file"
             ref={fileInputRef}
             onChange={handleFileChange}
+            data-upload-kind="file"
             className="hidden"
           />
         </div>

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -325,7 +325,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                     variant="ghost"
                     size="sm"
                     onClick={() => setShowActions(!showActions)}
-                    className="opacity-0 transition-opacity group-hover/message:opacity-70 hover:opacity-100 hover:text-[var(--text-gold)]"
+                    className="opacity-70 transition-opacity hover:opacity-100 hover:text-[var(--text-gold)] md:opacity-0 md:group-hover/message:opacity-70"
                     aria-label="Message actions"
                     type="button"
                   >
@@ -356,6 +356,31 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                           >
                             <Copy className="w-4 h-4" />
                             <span>Copy</span>
+                          </button>
+
+                          <button
+                            onClick={() => {
+                              void handleReaction('\u{1F44D}')
+                              setShowActions(false)
+                            }}
+                            className="flex w-full items-center space-x-2 px-3 py-2 text-left text-sm text-[var(--text-secondary)] transition-colors hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-primary)]"
+                            type="button"
+                            aria-label="React with thumbs up"
+                          >
+                            <span className="text-base leading-none">{'\u{1F44D}'}</span>
+                            <span>React</span>
+                          </button>
+
+                          <button
+                            onClick={() => {
+                              setShowReactionPicker(true)
+                              setShowActions(false)
+                            }}
+                            className="flex w-full items-center space-x-2 px-3 py-2 text-left text-sm text-[var(--text-secondary)] transition-colors hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-primary)]"
+                            type="button"
+                          >
+                            <Plus className="w-4 h-4" />
+                            <span>Add Reaction</span>
                           </button>
 
                           {onReply && (
@@ -433,6 +458,7 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                       onClick={() => handleReaction(e)}
                       className="text-base hover:scale-110 transition-transform"
                       type="button"
+                      aria-label={`React with ${normalizeEmojiValue(e)}`}
                     >
                       {e}
                     </button>
@@ -513,6 +539,7 @@ export const MessageReactions: React.FC<{
                 ? 'border-[var(--border-glow)] bg-[rgba(215,170,70,0.14)] text-[var(--text-gold)]'
                 : 'border-[var(--border-subtle)] bg-[rgba(255,255,255,0.04)] text-[var(--text-secondary)] hover:bg-[rgba(255,255,255,0.08)]'
             }`}
+            aria-label={`Reaction ${normalizeEmojiValue(emoji)} count ${data.count}`}
           >
             <span>{normalizeEmojiValue(emoji)}</span>
             <span className="text-[0.5em]">{data.count}</span>

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -57,7 +57,6 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({
   const [showNewConversation, setShowNewConversation] = useState(false)
   const [searchUsername, setSearchUsername] = useState('')
   const [startingUsername, setStartingUsername] = useState<string | null>(null)
-  const [lastConversation, setLastConversation] = useState<string | null>(null)
   const messagesRef = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState(true)
   const [uploading, setUploading] = useState(false)
@@ -132,7 +131,6 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({
   }
 
   const handleConversationSelect = (conversationId: string) => {
-    setLastConversation(conversationId)
     setCurrentConversation(conversationId)
     markAsRead(conversationId)
   }
@@ -201,13 +199,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => {
-                    if (lastConversation) {
-                      setCurrentConversation(lastConversation)
-                    } else {
-                      onViewChange('chat')
-                    }
-                  }}
+                  onClick={() => onViewChange('chat')}
                   className="mr-2"
                   aria-label="Back"
                 >

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -290,8 +290,11 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
                     </div>
                     
                     <button
+                      type="button"
                       onClick={() => void setting.onChange(!setting.enabled)}
-                      className={`relative inline-flex h-6 w-11 items-center rounded-full border transition-all ${
+                      role="switch"
+                      aria-checked={setting.enabled}
+                      className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full border transition-all ${
                         setting.enabled
                           ? 'border-[var(--border-glow)] bg-[linear-gradient(180deg,rgba(255,240,184,0.18),rgba(215,170,70,0.12)_36%,rgba(122,89,24,0.5)_100%)] shadow-[var(--shadow-gold-soft)]'
                           : 'border-[var(--border-subtle)] bg-[rgba(255,255,255,0.05)]'
@@ -369,8 +372,11 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
                           </div>
 
                           <button
+                            type="button"
                             onClick={() => void setting.onChange(!setting.enabled)}
                             disabled={pushSaving}
+                            role="switch"
+                            aria-checked={setting.enabled}
                             className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full border transition-all ${
                               setting.enabled
                                 ? 'border-[var(--border-glow)] bg-[linear-gradient(180deg,rgba(255,240,184,0.18),rgba(215,170,70,0.12)_36%,rgba(122,89,24,0.5)_100%)] shadow-[var(--shadow-gold-soft)]'

--- a/src/components/ui/RecordingIndicator.tsx
+++ b/src/components/ui/RecordingIndicator.tsx
@@ -11,15 +11,15 @@ export const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({ seconds,
   const formatTime = (s: number) => {
     const mins = Math.floor(s / 60)
     const secs = s % 60
-    return `${mins.toString().padStart(2,'0')}:${secs.toString().padStart(2,'0')}`
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
   }
 
   return (
-    <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg px-4 py-3 flex items-center space-x-3">
-      <Loader2 className="w-5 h-5 text-red-600 animate-spin" />
-      <span className="font-mono text-gray-900 dark:text-gray-100">{formatTime(seconds)}</span>
-      <span className="text-sm text-gray-700 dark:text-gray-300">Recording…</span>
-      <Button type="button" variant="ghost" size="sm" onClick={onStop} className="text-red-600">
+    <div className="fixed bottom-24 left-1/2 z-50 flex -translate-x-1/2 items-center space-x-3 rounded-[var(--radius-lg)] border border-[rgba(190,52,85,0.28)] bg-[linear-gradient(180deg,rgba(33,15,19,0.94),rgba(18,10,12,0.98))] px-4 py-3 shadow-[0_18px_40px_rgba(0,0,0,0.38)] backdrop-blur-xl">
+      <Loader2 className="h-5 w-5 animate-spin text-red-300" />
+      <span className="font-mono text-[var(--text-primary)]">{formatTime(seconds)}</span>
+      <span className="text-sm text-[var(--text-secondary)]">Recording...</span>
+      <Button type="button" variant="ghost" size="sm" onClick={onStop} className="text-red-300 hover:text-red-100">
         Stop
       </Button>
     </div>

--- a/src/components/ui/RecordingPopup.tsx
+++ b/src/components/ui/RecordingPopup.tsx
@@ -27,13 +27,13 @@ export const RecordingPopup: React.FC<RecordingPopupProps> = ({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="relative bg-white dark:bg-gray-800 p-6 rounded-xl shadow-xl flex flex-col items-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--bg-overlay)] px-4 backdrop-blur-md">
+      <div className="popup-surface relative flex w-full max-w-sm flex-col items-center rounded-[var(--radius-xl)] p-6 shadow-[var(--shadow-panel)]">
         <button
           type="button"
           onClick={onClose}
           aria-label="Close"
-          className="absolute top-2 right-2 text-gray-500"
+          className="popup-close absolute right-2 top-2 rounded-[var(--radius-sm)] p-2 text-[var(--text-muted)]"
         >
           <X className="w-5 h-5" />
         </button>
@@ -46,17 +46,17 @@ export const RecordingPopup: React.FC<RecordingPopupProps> = ({
           className="relative flex items-center justify-center w-24 h-24"
         >
           {recording && (
-            <div className="absolute inset-0 rounded-full border-4 border-[var(--color-accent)] animate-spin" />
+            <div className="absolute inset-0 animate-spin rounded-full border-4 border-[var(--border-glow)]" />
           )}
           <button
             type="button"
             aria-label="Hold to record"
-            className="w-20 h-20 rounded-full bg-red-600 text-white flex items-center justify-center"
+            className="flex h-20 w-20 items-center justify-center rounded-full border border-[rgba(190,52,85,0.42)] bg-[linear-gradient(180deg,rgba(190,52,85,0.32),rgba(87,14,28,0.88))] text-red-50 shadow-[0_10px_30px_rgba(0,0,0,0.3)]"
           >
             {recording ? <Loader2 className="w-6 h-6 animate-spin" /> : 'Hold'}
           </button>
         </div>
-        <span className="mt-4 font-mono text-gray-900 dark:text-gray-100">
+        <span className="mt-4 font-mono text-[var(--text-primary)]">
           {formatTime(seconds)}
         </span>
       </div>

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
-import { supabase, User, updateUserPresence, getWorkingClient } from '../lib/supabase';
+import {
+  supabase,
+  User,
+  updateUserPresence,
+  getWorkingClient,
+  ensureSession,
+  getSessionWithTimeout,
+} from '../lib/supabase';
 import { PRESENCE_INTERVAL_MS } from '../config';
 import {
   signIn as authSignIn,
@@ -47,8 +54,16 @@ function useProvideAuth() {
       
       
       try {
+        const sessionReady = await ensureSession();
+        if (!sessionReady) {
+          if (mountedRef.current) {
+            setUser(null);
+          }
+          return;
+        }
+
         const workingClient = await getWorkingClient();
-        const { data: { session }, error: sessionError } = await workingClient.auth.getSession();
+        const { data: { session }, error: sessionError } = await getSessionWithTimeout(workingClient);
         // Ensure realtime uses the latest access token
         workingClient.realtime.setAuth(session?.access_token || '');
         

--- a/src/hooks/useClientResetStatus.ts
+++ b/src/hooks/useClientResetStatus.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { recreateSupabaseClient, forceSessionRestore, getWorkingClient, promoteFallbackToMain } from '../lib/supabase'
+import {
+  recreateSupabaseClient,
+  forceSessionRestore,
+  getWorkingClient,
+  promoteFallbackToMain,
+  ensureSession,
+} from '../lib/supabase'
 
 // Promise used to queue reset requests across hook instances
 let resetPromise: Promise<boolean> | null = null
@@ -31,10 +37,10 @@ export function useClientResetStatus() {
         }
 
         // Step 3: Verify the working client is ready
-        const workingClient = await getWorkingClient()
-        const { data: { session }, error } = await workingClient.auth.getSession()
+        const sessionReady = await ensureSession()
 
-        if (!error && session) {
+        if (sessionReady) {
+          const workingClient = await getWorkingClient()
 
           // Step 4: Test basic database connectivity
           try {
@@ -67,35 +73,15 @@ export function useClientResetStatus() {
   }, [])
 
   useEffect(() => {
-    const handleVisibilityChange = async () => {
+    const handleVisibilityChange = () => {
       if (!document.hidden) {
-        setStatus('resetting')
         setLastResetTime(new Date())
-
-        // Perform the actual comprehensive reset
-        const resetSuccess = await performComprehensiveReset()
-        
-        if (resetSuccess) {
-          setStatus('success')
-          
-          // Auto-hide after 3 seconds
-          setTimeout(() => {
-            setStatus('idle')
-          }, 3000)
-        } else {
-          setStatus('error')
-          
-          // Auto-hide after 5 seconds
-          setTimeout(() => {
-            setStatus('idle')
-          }, 5000)
-        }
       }
     }
 
     document.addEventListener('visibilitychange', handleVisibilityChange)
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
-  }, [performComprehensiveReset])
+  }, [])
 
   const manualReset = useCallback(async () => {
     setStatus('resetting')

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -16,6 +16,7 @@ import {
   getOrCreateDMConversation,
   markDMMessagesRead,
   fetchDMConversations,
+  ensureSession,
   refreshSessionLocked,
   resetRealtimeConnection,
 } from '../lib/supabase';
@@ -384,6 +385,88 @@ export function useConversationMessages(conversationId: string | null) {
   const subscribeRef = useRef<() => RealtimeChannel>();
   const clientResetRef = useRef<() => Promise<void>>();
 
+  const insertConversationMessage = useCallback(
+    async (
+      payload: {
+        conversation_id: string;
+        sender_id: string;
+        content: string;
+        message_type: 'text' | 'command' | 'audio' | 'image' | 'file';
+        file_url?: string;
+        audio_url?: string;
+      }
+    ) => {
+      const workingClient = await getWorkingClient();
+      const insertPromise = workingClient
+        .from('dm_messages')
+        .insert(payload)
+        .select(`
+            *,
+            sender:users!sender_id(*)
+          `)
+        .single();
+
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('DM message insert timeout after 10 seconds')),
+          10000
+        )
+      );
+
+      return Promise.race([insertPromise, timeoutPromise]) as Promise<{
+        data: DMMessage | null;
+        error: any;
+      }>;
+    },
+    []
+  );
+
+  const markVisibleMessagesRead = useCallback(
+    async (pendingMessages: DMMessage[]) => {
+      if (!conversationId || !user) return
+
+      const unreadIds = pendingMessages
+        .filter(
+          message =>
+            message.sender_id !== user.id &&
+            !(message.read_by ?? []).includes(user.id)
+        )
+        .map(message => message.id)
+
+      if (unreadIds.length === 0) {
+        return
+      }
+
+      const readAt = new Date().toISOString()
+      const unreadIdSet = new Set(unreadIds)
+
+      await markDMMessagesRead(conversationId)
+
+      setMessages(prev =>
+        prev.map(message => {
+          if (!unreadIdSet.has(message.id)) {
+            return message
+          }
+
+          const readBy = message.read_by ?? []
+          if (readBy.includes(user.id)) {
+            return {
+              ...message,
+              read_at: message.read_at ?? readAt,
+            }
+          }
+
+          return {
+            ...message,
+            read_at: message.read_at ?? readAt,
+            read_by: [...readBy, user.id],
+          }
+        })
+      )
+    },
+    [conversationId, user]
+  )
+
   const handleVisible = useCallback(() => {
     const channel = channelRef.current;
     const realtimeClient = getRealtimeClient();
@@ -446,18 +529,10 @@ export function useConversationMessages(conversationId: string | null) {
 
       if (error) {
       } else {
+        const fetchedMessages = ((data || []) as unknown as DMMessage[]).reverse()
         setHasMore((data?.length || 0) === MESSAGE_FETCH_LIMIT);
-        setMessages(((data || []) as unknown as DMMessage[]).reverse());
-        
-        // Mark messages as read
-        if (user) {
-          await workingClient
-            .from('dm_messages')
-            .update({ read_at: new Date().toISOString() })
-            .eq('conversation_id', conversationId)
-            .neq('sender_id', user.id)
-            .is('read_at', null);
-        }
+        setMessages(fetchedMessages);
+        await markVisibleMessagesRead(fetchedMessages)
       }
       setLoading(false);
     };
@@ -466,7 +541,7 @@ export function useConversationMessages(conversationId: string | null) {
     clientResetRef.current = resetWithFreshClient;
     
     fetchMessages();
-  }, [conversationId, user]);
+  }, [conversationId, markVisibleMessagesRead, user]);
 
   const loadOlderMessages = useCallback(async () => {
     if (loadingMore || !hasMore || !conversationId) return;
@@ -547,10 +622,7 @@ export function useConversationMessages(conversationId: string | null) {
               // Mark as read if not sent by current user
               if (user && message.sender_id !== user.id) {
                 playMessage();
-                await workingClient
-                  .from('dm_messages')
-                  .update({ read_at: new Date().toISOString() })
-                  .eq('id', message.id);
+                await markVisibleMessagesRead([message])
               }
             }
           }
@@ -637,7 +709,7 @@ export function useConversationMessages(conversationId: string | null) {
       }
       channelRef.current = null;
     };
-  }, [conversationId, user, playMessage]);
+  }, [conversationId, markVisibleMessagesRead, user, playMessage]);
 
   const sendMessage = useCallback(
     async (
@@ -652,48 +724,38 @@ export function useConversationMessages(conversationId: string | null) {
 
       setSending(true);
       try {
-        const workingClient = await getWorkingClient();
-        
-        const { data, error } = await workingClient
-          .from('dm_messages')
-          .insert({
-            conversation_id: conversationId,
-            sender_id: user.id,
-            content: messageType === 'audio' ? '' : trimmedContent,
-            message_type: messageType,
-            file_url: fileUrl,
-            ...(messageType === 'audio' ? { audio_url: trimmedContent } : {}),
-          })
-          .select(`
-            *,
-            sender:users!sender_id(*)
-          `)
-          .single();
+        const sessionValid = await ensureSession();
+        if (!sessionValid) {
+          throw new Error('Authentication session is invalid or expired. Please refresh the page and try again.');
+        }
+
+        const insertPayload = {
+          conversation_id: conversationId,
+          sender_id: user.id,
+          content: messageType === 'audio' ? '' : trimmedContent,
+          message_type: messageType,
+          file_url: fileUrl,
+          ...(messageType === 'audio' ? { audio_url: trimmedContent } : {}),
+        };
+
+        const { data, error } = await insertConversationMessage(insertPayload);
 
         let finalData = data as unknown;
         let finalError = error as any;
         if (finalError) {
           if (finalError.status === 401 || /jwt|token|expired/i.test(finalError.message ?? '')) {
-            const { error: refreshError } = await refreshSessionLocked();
-            if (!refreshError) {
-              const retryClient = await getWorkingClient();
-              const retry = await retryClient
-                .from('dm_messages')
-                .insert({
-                  conversation_id: conversationId,
-                  sender_id: user.id,
-                  content: messageType === 'audio' ? '' : trimmedContent,
-                  message_type: messageType,
-                  file_url: fileUrl,
-                  ...(messageType === 'audio' ? { audio_url: trimmedContent } : {}),
-                })
-                .select(`
-                  *,
-                  sender:users!sender_id(*)
-                `)
-                .single();
+            const forcedSessionValid = await ensureSession(true);
+            if (forcedSessionValid) {
+              const retry = await insertConversationMessage(insertPayload);
               finalData = retry.data as unknown;
               finalError = retry.error;
+            } else {
+              const { error: refreshError } = await refreshSessionLocked();
+              if (!refreshError) {
+                const retry = await insertConversationMessage(insertPayload);
+                finalData = retry.data as unknown;
+                finalError = retry.error;
+              }
             }
           }
           if (finalError) throw finalError;
@@ -716,7 +778,7 @@ export function useConversationMessages(conversationId: string | null) {
       } finally {
         setSending(false);
       }
-    }, [user, conversationId]);
+    }, [user, conversationId, insertConversationMessage]);
 
   return {
     messages,

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -620,14 +620,6 @@ function useProvideMessages(): MessagesContextValue {
       throw new Error('Authentication session is invalid or expired. Please refresh the page and try again.');
     }
 
-    // Log current session tokens and user details for debugging
-    try {
-      const workingClient = await getWorkingClient();
-      const { data: { session } } = await workingClient.auth.getSession();
-    } catch (tokenErr) {
-      throw tokenErr;
-    }
-
     const messageData = prepareMessageData(
       user.id,
       content,

--- a/src/hooks/useVisibilityRefresh.ts
+++ b/src/hooks/useVisibilityRefresh.ts
@@ -10,8 +10,9 @@ export function useVisibilityRefresh(onVisible?: () => void, delayMs = 200) {
             await new Promise(res => setTimeout(res, delayMs))
           }
 
-          // The comprehensive reset is now handled by useClientResetStatus
-          // This just triggers the component callbacks for message refetch, etc.
+          // Keep resume handling lightweight here so message lists can refetch
+          // and realtime subscriptions can resubscribe without recreating auth
+          // state on every foreground event.
           onVisible?.()
           
           

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -5,6 +5,14 @@ import {
 } from './env'
 
 type AnySupabaseClient = any
+type SessionResponse = {
+  data: { session: any }
+  error: any
+}
+type RefreshSessionResponse = {
+  data: { session: any }
+  error: any
+}
 
 const loggingFetch: typeof fetch = async (input, init) => {
   return fetch(input, init)
@@ -167,6 +175,34 @@ const timeout = (ms: number) => new Promise((_, reject) =>
   setTimeout(() => reject(new Error(`Timeout after ${ms}ms`)), ms)
 )
 
+const SESSION_LOOKUP_TIMEOUT_MS = 4000
+const SESSION_REFRESH_TIMEOUT_MS = 10000
+
+export const withTimeout = async <T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string
+): Promise<T> => {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(message)), ms)
+    ),
+  ]) as Promise<T>
+}
+
+export const getSessionWithTimeout = async (
+  client?: AnySupabaseClient,
+  timeoutMs = SESSION_LOOKUP_TIMEOUT_MS
+): Promise<SessionResponse> => {
+  const targetClient = client ?? (await getWorkingClient())
+  return withTimeout(
+    targetClient.auth.getSession(),
+    timeoutMs,
+    `Session lookup timeout after ${timeoutMs}ms`
+  ) as Promise<SessionResponse>
+}
+
 // Promote fallback client to main client
 export const promoteFallbackToMain = async (): Promise<void> => {
   
@@ -281,7 +317,19 @@ export const recreateSupabaseClient = async (): Promise<AnySupabaseClient> => {
 
   const restored = await restoreSessionIfNeeded(client)
   if (!restored) {
-    await ensureSession(true).catch(() => false)
+    const storedToken = getStoredRefreshToken()
+    if (storedToken) {
+      try {
+        const refreshResult = (await withTimeout(
+          client.auth.refreshSession(),
+          SESSION_REFRESH_TIMEOUT_MS,
+          `Session refresh timeout after ${SESSION_REFRESH_TIMEOUT_MS}ms`
+        )) as RefreshSessionResponse
+        client.realtime?.setAuth?.(refreshResult.data?.session?.access_token || '')
+      } catch {
+        // ignore refresh failures during client recreation
+      }
+    }
   }
 
   try {
@@ -332,7 +380,7 @@ export const forceSessionRestore = async (): Promise<boolean> => {
     const workingClient = await getWorkingClient()
     
     // First check if we already have a session
-    const { data: { session }, error } = await workingClient.auth.getSession()
+    const { data: { session }, error } = await getSessionWithTimeout(workingClient)
     if (!error && session) {
       return true
     }
@@ -358,14 +406,101 @@ export const clearRefreshSessionPromise = () => {
   refreshSessionPromise = null
 }
 
+export const recoverSessionAfterResume = async (): Promise<boolean> => {
+  if (typeof navigator !== 'undefined' && !navigator.onLine) {
+    return false
+  }
+
+  const storedToken = getStoredRefreshToken()
+
+  const attemptRecovery = async (client: AnySupabaseClient) => {
+    const restored = await restoreSessionIfNeeded(client)
+    if (restored) {
+      try {
+        const { data: { session } } = await getSessionWithTimeout(client)
+        client.realtime.setAuth(session?.access_token || '')
+      } catch {
+        // ignore lookup failures after a successful local restore
+      }
+      try {
+        client.realtime.connect?.()
+      } catch {
+        // ignore reconnect failures
+      }
+      return true
+    }
+
+    if (!storedToken) {
+      return false
+    }
+
+    try {
+      const refreshResult = (await withTimeout(
+        client.auth.refreshSession(),
+        SESSION_REFRESH_TIMEOUT_MS,
+        `Session refresh timeout after ${SESSION_REFRESH_TIMEOUT_MS}ms`
+      )) as RefreshSessionResponse
+
+      if (refreshResult.data?.session) {
+        client.realtime.setAuth(refreshResult.data.session.access_token || '')
+        try {
+          client.realtime.connect?.()
+        } catch {
+          // ignore reconnect failures
+        }
+        return true
+      }
+    } catch {
+      // ignore refresh failures and fall through to a client recreation
+    }
+
+    return false
+  }
+
+  try {
+    const currentClient = await getWorkingClient()
+    if (await attemptRecovery(currentClient)) {
+      return true
+    }
+  } catch {
+    // ignore and try a client recreation below
+  }
+
+  try {
+    await recreateSupabaseClient()
+    const refreshedClient = await getWorkingClient()
+    return attemptRecovery(refreshedClient)
+  } catch {
+    return false
+  }
+}
+
 export const refreshSessionLocked = async () => {
   if (!refreshSessionPromise) {
     if (typeof navigator !== 'undefined' && !navigator.onLine) {
       return Promise.reject(new Error('Offline: cannot refresh session'))
     }
 
-    const workingClient = await getWorkingClient()
-    const { data: { session }, error } = await workingClient.auth.getSession()
+    let workingClient = await getWorkingClient()
+    let session: any = null
+    let error: any = null
+
+    try {
+      const sessionResult = await getSessionWithTimeout(workingClient)
+      session = sessionResult.data.session
+      error = sessionResult.error
+    } catch (sessionError) {
+      const recovered = await recoverSessionAfterResume()
+      if (!recovered) {
+        return Promise.reject(sessionError)
+      }
+
+      workingClient = await getWorkingClient()
+      const sessionResult = await getSessionWithTimeout(workingClient)
+      session = sessionResult.data.session
+      error = sessionResult.error
+    }
+
     const storedToken = getStoredRefreshToken()
     
     if (!session && !storedToken) {
@@ -391,13 +526,11 @@ export const refreshSessionLocked = async () => {
       .catch((err: any) => {
         throw err
       })
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error('Session refresh timeout after 10 seconds')),
-        10000
-      )
-    )
-    refreshSessionPromise = (Promise.race([refresh, timeoutPromise]) as Promise<{
+    refreshSessionPromise = (withTimeout(
+      refresh,
+      SESSION_REFRESH_TIMEOUT_MS,
+      `Session refresh timeout after ${SESSION_REFRESH_TIMEOUT_MS}ms`
+    ) as Promise<{
       data: any
       error: any
     }>)
@@ -425,7 +558,7 @@ export const resetRealtimeConnection = async () => {
     return
   }
   
-  const { data: { session } } = await currentClient.auth.getSession()
+  const { data: { session } } = await getSessionWithTimeout(currentClient)
   
   // Clean up existing channels on current client
   try {
@@ -709,15 +842,40 @@ export const fetchAllUsers = async (options?: { signal?: AbortSignal }) => {
 // Helper function to ensure valid session before database operations
 export const ensureSession = async (force = false) => {
   try {
-    const workingClient = await getWorkingClient()
-    const { data: { session }, error } = await workingClient.auth.getSession()
+    let workingClient = await getWorkingClient()
+    let session: any = null
+    let error: any = null
+
+    try {
+      const sessionResult = await getSessionWithTimeout(workingClient)
+      session = sessionResult.data.session
+      error = sessionResult.error
+    } catch {
+      const recovered = await recoverSessionAfterResume()
+      if (!recovered) {
+        return false
+      }
+      workingClient = await getWorkingClient()
+      const sessionResult = await getSessionWithTimeout(workingClient)
+      session = sessionResult.data.session
+      error = sessionResult.error
+    }
 
     if (error) {
       return false
     }
 
     if (!session) {
-      return false
+      const recovered = await recoverSessionAfterResume()
+      if (!recovered) {
+        return false
+      }
+      const recoveredClient = await getWorkingClient()
+      const recoveredSessionResult = await getSessionWithTimeout(recoveredClient)
+      session = recoveredSessionResult.data.session
+      if (!session) {
+        return false
+      }
     }
     
     // Check if session is expired or about to expire (within 5 minutes)

--- a/supabase/migrations/20260421190000_fix_dm_message_reactions.sql
+++ b/supabase/migrations/20260421190000_fix_dm_message_reactions.sql
@@ -1,0 +1,230 @@
+/*
+  # Fix DM message reactions storage
+
+  1. Allow `message_reactions` rows to target either a group message or a DM.
+  2. Enforce exactly one target per reaction row.
+  3. Update reaction/stat RPCs so DM reactions use `dm_message_id`.
+*/
+
+ALTER TABLE public.message_reactions
+  ADD COLUMN IF NOT EXISTS dm_message_id uuid REFERENCES public.dm_messages(id) ON DELETE CASCADE;
+
+ALTER TABLE public.message_reactions
+  ALTER COLUMN message_id DROP NOT NULL;
+
+ALTER TABLE public.message_reactions
+  DROP CONSTRAINT IF EXISTS message_reactions_message_id_user_id_emoji_key;
+
+DROP INDEX IF EXISTS public.message_reactions_message_unique_idx;
+CREATE UNIQUE INDEX IF NOT EXISTS message_reactions_message_unique_idx
+  ON public.message_reactions (message_id, user_id, emoji)
+  WHERE message_id IS NOT NULL;
+
+DROP INDEX IF EXISTS public.message_reactions_dm_message_unique_idx;
+CREATE UNIQUE INDEX IF NOT EXISTS message_reactions_dm_message_unique_idx
+  ON public.message_reactions (dm_message_id, user_id, emoji)
+  WHERE dm_message_id IS NOT NULL;
+
+ALTER TABLE public.message_reactions
+  DROP CONSTRAINT IF EXISTS message_reactions_target_check;
+
+ALTER TABLE public.message_reactions
+  ADD CONSTRAINT message_reactions_target_check
+  CHECK (num_nonnulls(message_id, dm_message_id) = 1);
+
+CREATE OR REPLACE FUNCTION toggle_message_reaction_v2(
+  message_id uuid,
+  emoji text,
+  is_dm boolean DEFAULT false
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  current_user_id uuid;
+  existing_reaction_id uuid;
+  current_reactions jsonb;
+  emoji_data jsonb;
+  new_reactions jsonb;
+BEGIN
+  current_user_id := auth.uid();
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT id INTO existing_reaction_id
+  FROM public.message_reactions
+  WHERE (
+      (is_dm = false AND public.message_reactions.message_id = toggle_message_reaction_v2.message_id)
+      OR
+      (is_dm = true AND public.message_reactions.dm_message_id = toggle_message_reaction_v2.message_id)
+    )
+    AND public.message_reactions.user_id = current_user_id
+    AND public.message_reactions.emoji = toggle_message_reaction_v2.emoji;
+
+  IF existing_reaction_id IS NOT NULL THEN
+    DELETE FROM public.message_reactions WHERE id = existing_reaction_id;
+
+    IF is_dm THEN
+      SELECT reactions INTO current_reactions FROM public.dm_messages WHERE id = message_id;
+
+      emoji_data := current_reactions -> emoji;
+      IF emoji_data IS NOT NULL THEN
+        emoji_data := jsonb_build_object(
+          'count', GREATEST(0, (emoji_data->>'count')::int - 1),
+          'users', COALESCE(
+            (
+              SELECT jsonb_agg(user_id)
+              FROM jsonb_array_elements_text(emoji_data->'users') AS user_id
+              WHERE user_id::uuid != current_user_id
+            ),
+            '[]'::jsonb
+          )
+        );
+
+        IF (emoji_data->>'count')::int <= 0 THEN
+          new_reactions := current_reactions - emoji;
+        ELSE
+          new_reactions := current_reactions || jsonb_build_object(emoji, emoji_data);
+        END IF;
+
+        UPDATE public.dm_messages SET reactions = new_reactions WHERE id = message_id;
+      END IF;
+    ELSE
+      SELECT reactions INTO current_reactions FROM public.messages WHERE id = message_id;
+
+      emoji_data := current_reactions -> emoji;
+      IF emoji_data IS NOT NULL THEN
+        emoji_data := jsonb_build_object(
+          'count', GREATEST(0, (emoji_data->>'count')::int - 1),
+          'users', COALESCE(
+            (
+              SELECT jsonb_agg(user_id)
+              FROM jsonb_array_elements_text(emoji_data->'users') AS user_id
+              WHERE user_id::uuid != current_user_id
+            ),
+            '[]'::jsonb
+          )
+        );
+
+        IF (emoji_data->>'count')::int <= 0 THEN
+          new_reactions := current_reactions - emoji;
+        ELSE
+          new_reactions := current_reactions || jsonb_build_object(emoji, emoji_data);
+        END IF;
+
+        UPDATE public.messages SET reactions = new_reactions WHERE id = message_id;
+      END IF;
+    END IF;
+  ELSE
+    INSERT INTO public.message_reactions (message_id, dm_message_id, user_id, emoji)
+    VALUES (
+      CASE WHEN is_dm THEN NULL ELSE message_id END,
+      CASE WHEN is_dm THEN message_id ELSE NULL END,
+      current_user_id,
+      emoji
+    );
+
+    IF is_dm THEN
+      SELECT COALESCE(reactions, '{}'::jsonb) INTO current_reactions FROM public.dm_messages WHERE id = message_id;
+    ELSE
+      SELECT COALESCE(reactions, '{}'::jsonb) INTO current_reactions FROM public.messages WHERE id = message_id;
+    END IF;
+
+    emoji_data := current_reactions -> emoji;
+    IF emoji_data IS NULL THEN
+      emoji_data := jsonb_build_object(
+        'count', 1,
+        'users', jsonb_build_array(current_user_id)
+      );
+    ELSE
+      emoji_data := jsonb_build_object(
+        'count', (emoji_data->>'count')::int + 1,
+        'users', (emoji_data->'users') || jsonb_build_array(current_user_id)
+      );
+    END IF;
+
+    new_reactions := current_reactions || jsonb_build_object(emoji, emoji_data);
+
+    IF is_dm THEN
+      UPDATE public.dm_messages SET reactions = new_reactions WHERE id = message_id;
+    ELSE
+      UPDATE public.messages SET reactions = new_reactions WHERE id = message_id;
+    END IF;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION count_user_reactions(target_user_id uuid)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  reaction_count integer;
+BEGIN
+  SELECT COUNT(*)
+  INTO reaction_count
+  FROM public.message_reactions
+  WHERE user_id = target_user_id;
+
+  RETURN COALESCE(reaction_count, 0);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION count_reactions_to_user_messages_v2(target_user_id uuid)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  reaction_count integer;
+BEGIN
+  SELECT COUNT(mr.*)
+  INTO reaction_count
+  FROM public.message_reactions mr
+  INNER JOIN public.messages m ON mr.message_id = m.id
+  WHERE m.user_id = target_user_id;
+
+  RETURN COALESCE(reaction_count, 0);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION count_reactions_to_user_dm_messages_v2(target_user_id uuid)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  reaction_count integer;
+BEGIN
+  SELECT COUNT(mr.*)
+  INTO reaction_count
+  FROM public.message_reactions mr
+  INNER JOIN public.dm_messages dm ON mr.dm_message_id = dm.id
+  WHERE dm.sender_id = target_user_id;
+
+  RETURN COALESCE(reaction_count, 0);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION toggle_message_reaction(
+  message_id uuid,
+  emoji text,
+  is_dm boolean DEFAULT false
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  PERFORM toggle_message_reaction_v2(message_id, emoji, is_dm);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION toggle_message_reaction_v2(uuid, text, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION count_user_reactions(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION count_reactions_to_user_messages_v2(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION count_reactions_to_user_dm_messages_v2(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION toggle_message_reaction(uuid, text, boolean) TO authenticated;

--- a/tests/ErrorBoundary.test.tsx
+++ b/tests/ErrorBoundary.test.tsx
@@ -32,7 +32,6 @@ test('renders children after retry', () => {
   );
 
   expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
-  fireEvent.click(screen.getByRole('button', { name: /try again/i }));
 
   rerender(
     <ErrorBoundary>
@@ -40,6 +39,7 @@ test('renders children after retry', () => {
     </ErrorBoundary>
   );
 
+  fireEvent.click(screen.getByRole('button', { name: /try again/i }));
   expect(screen.getByText('Child')).toBeInTheDocument();
   (console.error as jest.Mock).mockRestore();
 });

--- a/tests/MessageInput.test.tsx
+++ b/tests/MessageInput.test.tsx
@@ -1,7 +1,16 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { MessageInput } from '../src/components/chat/MessageInput'
+import toast from 'react-hot-toast'
+
+jest.mock('react-hot-toast', () => {
+  const toastFn = jest.fn() as any
+  toastFn.error = jest.fn()
+  toastFn.success = jest.fn()
+  return { __esModule: true, default: toastFn }
+})
 
 jest.mock('../src/hooks/useTyping', () => ({
   useTyping: () => ({ startTyping: jest.fn(), stopTyping: jest.fn() })
@@ -17,6 +26,10 @@ jest.mock('../src/lib/supabase', () => ({
   uploadChatFile: jest.fn(),
   DEBUG: false,
 }))
+
+const { uploadChatFile } = jest.requireMock('../src/lib/supabase') as {
+  uploadChatFile: jest.Mock
+}
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -43,14 +56,50 @@ test('stops media stream tracks when recording stops', async () => {
   const user = userEvent.setup()
   render(<MessageInput onSendMessage={() => {}} />)
   const btn = screen.getByRole('button', { name: /record audio/i })
-  await user.click(btn)
-  await user.click(btn)
+
+  await act(async () => {
+    await user.click(btn)
+    await Promise.resolve()
+  })
+
+  await act(async () => {
+    await user.click(btn)
+    await Promise.resolve()
+  })
+
   expect(trackStop).toHaveBeenCalled()
 })
 
 test('shows slash commands menu when only slash is typed', async () => {
   render(<MessageInput onSendMessage={() => {}} />)
   const textarea = screen.getByRole('textbox')
-  await userEvent.type(textarea, '/')
+  await act(async () => {
+    fireEvent.change(textarea, { target: { value: '/' } })
+  })
   expect(screen.getByText(/Slash Commands/i)).toBeInTheDocument()
+})
+
+test('shows an error and keeps reply state when uploaded image send resolves to null', async () => {
+  uploadChatFile.mockResolvedValueOnce('https://example.com/file.png')
+  const onSendMessage = jest.fn().mockResolvedValue(null)
+  const onCancelReply = jest.fn()
+
+  const { container } = render(
+    <MessageInput
+      onSendMessage={onSendMessage}
+      replyingTo={{ id: 'parent', content: 'hello' }}
+      onCancelReply={onCancelReply}
+    />
+  )
+
+  const imageInput = container.querySelector('input[type="file"][accept="image/*"]') as HTMLInputElement
+  const file = new File(['image'], 'photo.png', { type: 'image/png' })
+
+  fireEvent.change(imageInput, { target: { files: [file] } })
+
+  await waitFor(() => {
+    expect(onSendMessage).toHaveBeenCalledWith('', 'image', 'https://example.com/file.png', 'parent')
+  })
+  expect(onCancelReply).not.toHaveBeenCalled()
+  expect((toast as any).error).toHaveBeenCalledWith('Failed to send image')
 })

--- a/tests/MessageInputRecording.test.tsx
+++ b/tests/MessageInputRecording.test.tsx
@@ -30,6 +30,7 @@ jest.mock('../src/hooks/useDraft', () => ({
 }))
 
 test('shows toast and resets when microphone access denied', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {})
   Object.defineProperty(navigator, 'mediaDevices', {
     value: { getUserMedia: jest.fn().mockRejectedValue(new Error('denied')) },
     configurable: true
@@ -45,4 +46,5 @@ test('shows toast and resets when microphone access denied', async () => {
 
   expect((toast as any).error).toHaveBeenCalledWith('Microphone access was denied')
   expect(screen.queryByText(/Recording/)).not.toBeInTheDocument()
+  ;(console.error as jest.Mock).mockRestore()
 })

--- a/tests/MessageInputSuggestions.test.tsx
+++ b/tests/MessageInputSuggestions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { MessageInput } from '../src/components/chat/MessageInput'
@@ -28,7 +28,8 @@ test('inserts suggestion on click', async () => {
   mockedHooks.mockReturnValue({ suggestions: ['hello there'], loading: false })
   render(<MessageInput onSendMessage={() => {}} messages={[]} />)
   const suggestion = screen.getByText('hello there')
-  const user = userEvent.setup()
-  await user.click(suggestion)
+  await act(async () => {
+    await userEvent.click(suggestion)
+  })
   expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('hello there')
 })

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -5,6 +5,15 @@ import { MessageItem } from '../src/components/chat/MessageItem'
 import type { Message } from '../src/lib/supabase'
 import { useToneAnalysisEnabled } from '../src/hooks/useToneAnalysisEnabled'
 
+jest.mock('../src/config', () => ({
+  PRESENCE_INTERVAL_MS: 30000,
+  MESSAGE_FETCH_LIMIT: 40,
+}))
+
+jest.mock('../src/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}))
+
 jest.mock('../src/hooks/useToneAnalysisEnabled')
 
 const mockedToneEnabled = useToneAnalysisEnabled as jest.MockedFunction<typeof useToneAnalysisEnabled>
@@ -144,9 +153,10 @@ test('icon buttons have aria-labels', () => {
   expect(addReaction).toBeInTheDocument()
 })
 
-test('applies user color to message bubble', () => {
+test('applies user color to the avatar', () => {
   const colored = {
     ...baseMessage,
+    message_type: 'text',
     content: 'hello',
     user: { ...baseMessage.user, color: '#ff0000' }
   } as Message
@@ -163,8 +173,8 @@ test('applies user color to message bubble', () => {
     />
   )
 
-  const msg = screen.getByText('hello')
-  expect(msg.parentElement).toHaveStyle('background-color: #ff0000')
+  const avatarInitial = screen.getByText('A')
+  expect(avatarInitial.parentElement).toHaveStyle('background-color: #ff0000')
 })
 
 test('shows tone indicator emoji', () => {
@@ -231,7 +241,7 @@ test('clicking reply preview triggers jump callback', async () => {
     />
   )
 
-  const btn = screen.getByRole('button', { name: /replying to/i })
+  const btn = screen.getByRole('button', { name: /view parent message/i })
   await userEvent.click(btn)
   expect(cb).toHaveBeenCalledWith('p1')
 })

--- a/tests/PinnedMessageItem.test.tsx
+++ b/tests/PinnedMessageItem.test.tsx
@@ -3,6 +3,15 @@ import React from 'react'
 import { PinnedMessageItem } from '../src/components/chat/PinnedMessageItem'
 import type { Message } from '../src/lib/supabase'
 
+jest.mock('../src/config', () => ({
+  PRESENCE_INTERVAL_MS: 30000,
+  MESSAGE_FETCH_LIMIT: 40,
+}))
+
+jest.mock('../src/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}))
+
 const message = {
   id: 'm1',
   user_id: 'u1',

--- a/tests/aiMention.test.tsx
+++ b/tests/aiMention.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MessageInput } from '../src/components/chat/MessageInput'
 import { askQuestion } from '../src/lib/ai'
@@ -27,10 +26,12 @@ test('ai mention sends query and posts response', async () => {
   render(<MessageInput onSendMessage={onSend} messages={[]} />)
 
   const textarea = screen.getByRole('textbox')
-  await userEvent.type(textarea, '@ai what is up?')
-  await userEvent.keyboard('{Enter}')
+  await act(async () => {
+    fireEvent.change(textarea, { target: { value: '@ai what is up?' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' })
+  })
 
   expect(askQuestion).toHaveBeenCalledWith('what is up?')
   await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2))
-  expect(onSend).toHaveBeenNthCalledWith(2, 'the answer', 'command')
+  expect(onSend).toHaveBeenNthCalledWith(2, 'the answer', 'command', undefined, undefined)
 })

--- a/tests/purgeOldAuthKeys.test.ts
+++ b/tests/purgeOldAuthKeys.test.ts
@@ -27,5 +27,15 @@ test('createFreshSupabaseClient purges previous keys', () => {
   const client = createFreshSupabaseClient();
   const key = (client as any).__storageKey;
   expect(localStorage.getItem(`${prefix}stale`)).toBeNull();
-  expect(localStorage.getItem(key)).not.toBeNull();
+  expect(key).toContain(prefix);
+  expect(createClient).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.any(String),
+    expect.objectContaining({
+      auth: expect.objectContaining({
+        storageKey: key,
+        persistSession: false,
+      }),
+    })
+  );
 });

--- a/tests/refreshSessionLocked.test.ts
+++ b/tests/refreshSessionLocked.test.ts
@@ -1,4 +1,9 @@
-import { refreshSessionLocked, supabase } from '../src/lib/supabase';
+import {
+  ensureSession,
+  localStorageKey,
+  refreshSessionLocked,
+  supabase,
+} from '../src/lib/supabase';
 
 beforeEach(() => {
   // @ts-ignore
@@ -16,4 +21,52 @@ test('sets realtime auth token after refresh', async () => {
   expect(supabase.auth.refreshSession).toHaveBeenCalled();
   expect(supabase.realtime.setAuth).toHaveBeenCalledWith('new-token');
   expect(result).toEqual({ data: { session: { access_token: 'new-token' } }, error: null });
+});
+
+test('ensureSession recovers when the first session lookup hangs after resume', async () => {
+  jest.useFakeTimers();
+
+  const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+  localStorage.setItem(
+    localStorageKey,
+    JSON.stringify({
+      currentSession: {
+        access_token: 'restored-token',
+        refresh_token: 'refresh-token',
+      },
+    })
+  );
+
+  let getSessionCalls = 0;
+  // @ts-ignore
+  supabase.auth.getSession = jest.fn(() => {
+    getSessionCalls += 1;
+    if (getSessionCalls === 1) {
+      return new Promise(() => undefined);
+    }
+
+    return Promise.resolve({
+      data: { session: { access_token: 'restored-token', expires_at: expiresAt } },
+      error: null,
+    });
+  });
+  // @ts-ignore
+  supabase.auth.setSession = jest.fn().mockResolvedValue({
+    data: { session: { access_token: 'restored-token', expires_at: expiresAt } },
+    error: null,
+  });
+  // @ts-ignore
+  supabase.realtime.setAuth = jest.fn();
+  // @ts-ignore
+  supabase.realtime.connect = jest.fn();
+
+  const pending = ensureSession();
+  await jest.advanceTimersByTimeAsync(4000);
+
+  await expect(pending).resolves.toBe(true);
+  expect(supabase.auth.setSession).toHaveBeenCalled();
+  expect(supabase.realtime.setAuth).toHaveBeenCalledWith('restored-token');
+
+  localStorage.removeItem(localStorageKey);
+  jest.useRealTimers();
 });

--- a/tests/summaryCommand.test.tsx
+++ b/tests/summaryCommand.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MessageInput } from '../src/components/chat/MessageInput'
 import { summarizeConversation } from '../src/lib/ai'
@@ -32,9 +31,13 @@ test('summary slash command calls API and sends result', async () => {
   )
 
   const textarea = screen.getByRole('textbox')
-  await userEvent.type(textarea, '/summary')
-  await userEvent.keyboard('{Enter}')
+  await act(async () => {
+    fireEvent.change(textarea, { target: { value: '/summary' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' })
+  })
 
   expect(summarizeConversation).toHaveBeenCalled()
-  await waitFor(() => expect(onSend).toHaveBeenCalledWith('summary text'))
+  await waitFor(() =>
+    expect(onSend).toHaveBeenCalledWith('summary text', 'text', undefined, undefined)
+  )
 })

--- a/tests/useAuth.test.tsx
+++ b/tests/useAuth.test.tsx
@@ -1,7 +1,11 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../src/hooks/useAuth';
 import { supabase } from '../src/lib/supabase';
 import * as auth from '../src/lib/auth';
+
+jest.mock('../src/config', () => ({
+  PRESENCE_INTERVAL_MS: 30000,
+}));
 
 jest.mock('../src/lib/supabase', () => {
   return {
@@ -16,6 +20,9 @@ jest.mock('../src/lib/supabase', () => {
         signOut: jest.fn(),
       },
     },
+    getWorkingClient: jest.fn(),
+    ensureSession: jest.fn(),
+    getSessionWithTimeout: jest.fn(),
     updateUserPresence: jest.fn(),
   };
 });
@@ -46,6 +53,25 @@ beforeEach(() => {
     maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
     rpc: jest.fn().mockReturnThis(),
   } as any));
+  const { getWorkingClient } = jest.requireMock('../src/lib/supabase') as { getWorkingClient: jest.Mock };
+  const {
+    ensureSession,
+    getSessionWithTimeout,
+  } = jest.requireMock('../src/lib/supabase') as {
+    ensureSession: jest.Mock;
+    getSessionWithTimeout: jest.Mock;
+  };
+  ensureSession.mockResolvedValue(false);
+  getSessionWithTimeout.mockResolvedValue({ data: { session: null }, error: null });
+  getWorkingClient.mockResolvedValue({
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null }, error: null }),
+      signOut: jest.fn().mockResolvedValue({ error: null }),
+    },
+    realtime: {
+      setAuth: jest.fn(),
+    },
+  });
 });
 
 test('signIn calls auth.signIn', async () => {
@@ -62,11 +88,37 @@ test('signIn calls auth.signIn', async () => {
   expect(result.current.error).toBeNull();
 });
 
+test('initial session bootstrap loads a user when recovery succeeds', async () => {
+  const profile = { id: '1', username: 'user' } as any;
+  authModule.getCurrentUser.mockResolvedValue(profile);
+
+  const {
+    ensureSession,
+    getSessionWithTimeout,
+  } = jest.requireMock('../src/lib/supabase') as {
+    ensureSession: jest.Mock;
+    getSessionWithTimeout: jest.Mock;
+  };
+  ensureSession.mockResolvedValue(true);
+  getSessionWithTimeout.mockResolvedValue({
+    data: { session: { access_token: 'token', user: { id: '1' } } },
+    error: null,
+  });
+
+  const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(authModule.getCurrentUser).toHaveBeenCalled();
+  expect(result.current.user).toEqual(profile);
+});
+
 test('signUp sets user when session returned', async () => {
   const profile = { id: '1' } as any;
   authModule.signUp.mockResolvedValue({ session: {}, profile, user: {} } as any);
 
   const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
 
   await act(async () => {
     await result.current.signUp('x@y.com', 'pw', { full_name: 'X', username: 'user' });
@@ -78,7 +130,7 @@ test('signUp sets user when session returned', async () => {
     username: 'user',
     displayName: 'X',
   });
-  expect(result.current.user).toEqual(profile);
+  await waitFor(() => expect(result.current.user).toEqual(profile));
 });
 
 test('signOut calls auth.signOut', async () => {
@@ -94,9 +146,19 @@ test('signOut calls auth.signOut', async () => {
 });
 
 test('uploadAvatar calls auth.uploadUserAvatar', async () => {
+  const profile = { id: '1' } as any;
+  authModule.signUp.mockResolvedValue({ session: {}, profile, user: {} } as any);
   authModule.uploadUserAvatar.mockResolvedValue('url');
 
   const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+
+  await act(async () => {
+    await result.current.signUp('x@y.com', 'pw', { full_name: 'X', username: 'user' });
+  });
+
+  await waitFor(() => expect(result.current.user).toEqual(profile));
 
   await act(async () => {
     await result.current.uploadAvatar(new File(['x'], 'a.png', { type: 'image/png' }));
@@ -106,9 +168,19 @@ test('uploadAvatar calls auth.uploadUserAvatar', async () => {
 });
 
 test('uploadBanner calls auth.uploadUserBanner', async () => {
+  const profile = { id: '1' } as any;
+  authModule.signUp.mockResolvedValue({ session: {}, profile, user: {} } as any);
   authModule.uploadUserBanner.mockResolvedValue('url');
 
   const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+
+  await act(async () => {
+    await result.current.signUp('x@y.com', 'pw', { full_name: 'X', username: 'user' });
+  });
+
+  await waitFor(() => expect(result.current.user).toEqual(profile));
 
   await act(async () => {
     await result.current.uploadBanner(new File(['x'], 'b.png', { type: 'image/png' }));

--- a/tests/useClientResetStatus.test.tsx
+++ b/tests/useClientResetStatus.test.tsx
@@ -4,7 +4,8 @@ import {
   recreateSupabaseClient,
   forceSessionRestore,
   getWorkingClient,
-  promoteFallbackToMain
+  promoteFallbackToMain,
+  ensureSession,
 } from '../src/lib/supabase'
 
 jest.mock('../src/lib/supabase', () => {
@@ -19,7 +20,8 @@ jest.mock('../src/lib/supabase', () => {
     recreateSupabaseClient: jest.fn().mockResolvedValue(undefined),
     forceSessionRestore: jest.fn().mockResolvedValue(true),
     getWorkingClient: jest.fn().mockResolvedValue(workingClient),
-    promoteFallbackToMain: jest.fn().mockResolvedValue(undefined)
+    promoteFallbackToMain: jest.fn().mockResolvedValue(undefined),
+    ensureSession: jest.fn().mockResolvedValue(true),
   }
 })
 
@@ -38,16 +40,14 @@ test('queues simultaneous manual resets', async () => {
   expect((recreateSupabaseClient as jest.Mock)).toHaveBeenCalledTimes(1)
 })
 
-test('visibility change does not trigger duplicate reset', async () => {
+test('visibility change no longer auto-triggers a comprehensive reset', async () => {
   const { result } = renderHook(() => useClientResetStatus())
 
   await act(async () => {
-    const p = result.current.manualReset()
     Object.defineProperty(document, 'hidden', { value: false, configurable: true })
     document.dispatchEvent(new Event('visibilitychange'))
-    await p
   })
 
-  expect((recreateSupabaseClient as jest.Mock)).toHaveBeenCalledTimes(1)
+  expect((recreateSupabaseClient as jest.Mock)).not.toHaveBeenCalled()
 })
 

--- a/tests/useDirectMessages.test.tsx
+++ b/tests/useDirectMessages.test.tsx
@@ -4,10 +4,39 @@ import { useAuth } from '../src/hooks/useAuth';
 import * as dmModule from '../src/hooks/useDirectMessages';
 import * as searchModule from '../src/hooks/useUserSearch';
 import * as allUsersModule from '../src/hooks/useAllUsers';
-import { supabase, getOrCreateDMConversation } from '../src/lib/supabase';
+import {
+  fetchDMConversations,
+  getOrCreateDMConversation,
+  getRealtimeClient,
+  getWorkingClient,
+  ensureSession,
+  markDMMessagesRead,
+  refreshSessionLocked,
+  resetRealtimeConnection,
+  supabase,
+} from '../src/lib/supabase';
 import { DirectMessagesView } from '../src/components/dms/DirectMessagesView';
+import { triggerDMPushNotification } from '../src/lib/push';
 
 jest.mock('../src/hooks/useAuth');
+jest.mock('../src/hooks/useVisibilityRefresh', () => ({
+  useVisibilityRefresh: jest.fn(),
+}));
+jest.mock('../src/hooks/useSoundEffects', () => ({
+  useSoundEffects: () => ({ playMessage: jest.fn() }),
+}));
+jest.mock('../src/hooks/useTyping', () => ({
+  useTyping: () => ({ typingUsers: [], startTyping: jest.fn(), stopTyping: jest.fn() }),
+}));
+jest.mock('../src/hooks/useIsDesktop', () => ({
+  useIsDesktop: jest.fn(() => true),
+}));
+jest.mock('../src/lib/push', () => ({
+  triggerDMPushNotification: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/config', () => ({
+  MESSAGE_FETCH_LIMIT: 40,
+}));
 jest.mock('../src/lib/supabase', () => {
   return {
     supabase: {
@@ -16,32 +45,80 @@ jest.mock('../src/lib/supabase', () => {
       removeChannel: jest.fn(),
       auth: { getSession: jest.fn(), refreshSession: jest.fn() },
     },
+    getWorkingClient: jest.fn(),
+    getRealtimeClient: jest.fn(),
     fetchDMConversations: jest.fn().mockResolvedValue([]),
     getOrCreateDMConversation: jest.fn(),
     markDMMessagesRead: jest.fn(),
+    ensureSession: jest.fn().mockResolvedValue(true),
+    refreshSessionLocked: jest.fn(),
+    resetRealtimeConnection: jest.fn(),
   };
 });
 
 type SupabaseMock = jest.Mocked<typeof supabase>;
+type WorkingClient = {
+  from: jest.Mock;
+  channel: jest.Mock;
+  removeChannel: jest.Mock;
+  auth: {
+    getSession: jest.Mock;
+    refreshSession: jest.Mock;
+  };
+};
+
+const createQuery = (overrides: Record<string, unknown> = {}) => {
+  const query: Record<string, any> = {
+    select: jest.fn(() => query),
+    single: jest.fn().mockResolvedValue({ data: [], error: null }),
+    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    order: jest.fn(() => query),
+    limit: jest.fn(() => query),
+    update: jest.fn(() => query),
+    delete: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    neq: jest.fn(() => query),
+    is: jest.fn(() => query),
+    insert: jest.fn(() => query),
+    contains: jest.fn(() => query),
+  };
+
+  Object.assign(query, overrides);
+  return query;
+};
+
+let workingClient: WorkingClient;
 
 beforeEach(() => {
   jest.resetAllMocks();
   (useAuth as jest.Mock).mockReturnValue({ user: { id: 'u1' } });
 
+  workingClient = {
+    from: jest.fn(() => createQuery()),
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn(),
+      send: jest.fn(),
+      state: 'joined',
+    })),
+    removeChannel: jest.fn(),
+    auth: {
+      getSession: jest.fn(),
+      refreshSession: jest.fn(),
+    },
+  };
+
+  (getWorkingClient as jest.Mock).mockResolvedValue(workingClient);
+  (getRealtimeClient as jest.Mock).mockReturnValue(workingClient);
+  (fetchDMConversations as jest.Mock).mockResolvedValue([]);
+  (markDMMessagesRead as jest.Mock).mockResolvedValue(undefined);
+  (ensureSession as jest.Mock).mockResolvedValue(true);
+  (refreshSessionLocked as jest.Mock).mockResolvedValue({ data: { session: {} }, error: null });
+  (resetRealtimeConnection as jest.Mock).mockResolvedValue(undefined);
+  (triggerDMPushNotification as jest.Mock).mockResolvedValue(undefined);
+
   const sb = supabase as SupabaseMock;
-  sb.from.mockImplementation(() => ({
-    insert: jest.fn().mockReturnThis(),
-    select: jest.fn().mockReturnThis(),
-    single: jest.fn().mockResolvedValue({ data: [], error: null }),
-    order: jest.fn().mockReturnThis(),
-    limit: jest.fn().mockReturnThis(),
-    update: jest.fn().mockReturnThis(),
-    delete: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    contains: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
-    rpc: jest.fn().mockReturnThis(),
-  } as any));
+  sb.from.mockImplementation(() => createQuery() as any);
   sb.channel.mockReturnValue({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: jest.fn(), state: 'joined' } as any);
   sb.removeChannel.mockResolvedValue();
 });
@@ -58,62 +135,29 @@ test('sendMessage retries on 401 error', async () => {
     }),
   }));
 
-  const sb = supabase as SupabaseMock;
-  sb.from.mockImplementation(() => ({
-    insert: jest.fn().mockReturnThis(),
-    select: jest.fn().mockReturnThis(),
-    single: jest.fn().mockResolvedValue({ data: [], error: null }),
-    order: jest.fn().mockReturnThis(),
-    limit: jest.fn().mockReturnThis(),
-    update: jest.fn().mockReturnThis(),
-    delete: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    contains: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
-    rpc: jest.fn().mockReturnThis(),
-  } as any));
-
   const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
 
   await act(async () => {
     result.current.setCurrentConversation('conv1');
   });
 
-  sb.from.mockClear();
-  (sb.from as jest.Mock).mockImplementationOnce(() => ({
-    insert: insertFail,
-    select: jest.fn().mockReturnThis(),
-    single: jest.fn().mockResolvedValue({ data: [], error: null }),
-    order: jest.fn().mockReturnThis(),
-    limit: jest.fn().mockReturnThis(),
-    update: jest.fn().mockReturnThis(),
-    delete: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    contains: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
-    rpc: jest.fn().mockReturnThis(),
-  } as any)).mockImplementationOnce(() => ({
-    insert: insertSuccess,
-    select: jest.fn().mockReturnThis(),
-    single: jest.fn().mockResolvedValue({ data: [], error: null }),
-    order: jest.fn().mockReturnThis(),
-    limit: jest.fn().mockReturnThis(),
-    update: jest.fn().mockReturnThis(),
-    delete: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    contains: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
-    rpc: jest.fn().mockReturnThis(),
-  } as any));
-
-  sb.auth.refreshSession.mockResolvedValue({ data: { session: {} }, error: null } as any);
+  workingClient.from.mockClear();
+  workingClient.from
+    .mockReturnValueOnce(createQuery({ insert: insertFail }) as any)
+    .mockReturnValueOnce(createQuery({ insert: insertSuccess }) as any);
+  (ensureSession as jest.Mock)
+    .mockResolvedValueOnce(true)
+    .mockResolvedValueOnce(true);
 
   await act(async () => {
     await result.current.sendMessage('hello');
   });
 
   expect(insertFail).toHaveBeenCalled();
-  expect(sb.auth.refreshSession).toHaveBeenCalled();
+  expect(ensureSession).toHaveBeenNthCalledWith(1);
+  expect(ensureSession).toHaveBeenNthCalledWith(2, true);
   expect(insertSuccess).toHaveBeenCalled();
 });
 
@@ -121,14 +165,17 @@ test('sends audio message with proper type', async () => {
   const insertFn = jest.fn(() => ({
     select: () => ({ single: () => Promise.resolve({ data: { id: '1' }, error: null }) })
   }));
-  const sb = supabase as SupabaseMock;
-  sb.from.mockReturnValueOnce({ insert: insertFn } as any);
 
   const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
 
   await act(async () => {
     result.current.setCurrentConversation('conv1');
   });
+
+  workingClient.from.mockClear();
+  workingClient.from.mockImplementationOnce(() => createQuery({ insert: insertFn }) as any);
 
   await act(async () => {
     await result.current.sendMessage('https://example.com/a.webm', 'audio');
@@ -137,32 +184,23 @@ test('sends audio message with proper type', async () => {
   expect(insertFn).toHaveBeenCalledWith({
     conversation_id: 'conv1',
     sender_id: 'u1',
-    content: 'https://example.com/a.webm',
+    content: '',
     message_type: 'audio',
+    audio_url: 'https://example.com/a.webm',
   });
 });
 
 test('startConversation sets currentConversation', async () => {
-  const sb = supabase as SupabaseMock;
   const maybeSingle = jest.fn().mockResolvedValue({ data: { id: 'u2' }, error: null });
-  sb.from.mockImplementationOnce(() => ({
-    insert: jest.fn().mockReturnThis(),
-    select: jest.fn().mockReturnThis(),
-    single: jest.fn().mockResolvedValue({ data: [], error: null }),
-    order: jest.fn().mockReturnThis(),
-    limit: jest.fn().mockReturnThis(),
-    update: jest.fn().mockReturnThis(),
-    delete: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    contains: jest.fn().mockReturnThis(),
-    maybeSingle,
-    rpc: jest.fn().mockReturnThis(),
-  } as any));
+  workingClient.from.mockImplementationOnce(() => createQuery({ maybeSingle }) as any);
 
   const conversation = { id: 'c1' } as any;
   (getOrCreateDMConversation as jest.Mock).mockResolvedValue(conversation);
+  (fetchDMConversations as jest.Mock).mockResolvedValue([{ id: 'c1' }]);
 
   const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
 
   await act(async () => {
     const id = await result.current.startConversation('bob');
@@ -174,24 +212,50 @@ test('startConversation sets currentConversation', async () => {
 });
 
 test('startConversation throws when user not found', async () => {
-  const sb = supabase as SupabaseMock;
-  sb.from.mockImplementationOnce(() => ({
-    insert: jest.fn().mockReturnThis(),
-    select: jest.fn().mockReturnThis(),
-    single: jest.fn().mockResolvedValue({ data: [], error: null }),
-    order: jest.fn().mockReturnThis(),
-    limit: jest.fn().mockReturnThis(),
-    update: jest.fn().mockReturnThis(),
-    delete: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    contains: jest.fn().mockReturnThis(),
+  workingClient.from.mockImplementationOnce(() => createQuery({
     maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
-    rpc: jest.fn().mockReturnThis(),
-  } as any));
+  }) as any);
 
   const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
 
+  await waitFor(() => expect(result.current.loading).toBe(false));
+
   await expect(result.current.startConversation('missing')).rejects.toThrow('User not found');
+});
+
+test('marks visible unread messages as read through the RPC helper', async () => {
+  const unreadMessage = {
+    id: 'm1',
+    conversation_id: 'conv1',
+    sender_id: 'u2',
+    content: 'hello',
+    message_type: 'text',
+    read_by: null,
+    created_at: '2026-04-21T12:00:00.000Z',
+    updated_at: '2026-04-21T12:00:00.000Z',
+    reactions: {},
+  };
+
+  workingClient.from.mockImplementation(() =>
+    createQuery({
+      select: jest.fn(function () { return this; }),
+      eq: jest.fn(function () { return this; }),
+      order: jest.fn(function () { return this; }),
+      limit: jest.fn().mockResolvedValue({ data: [unreadMessage], error: null }),
+    }) as any
+  );
+
+  const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+
+  await act(async () => {
+    result.current.setCurrentConversation('conv1');
+  });
+
+  await waitFor(() => {
+    expect(markDMMessagesRead).toHaveBeenCalledWith('conv1');
+  });
 });
 
 describe('DirectMessagesView user search', () => {
@@ -251,7 +315,7 @@ describe('DirectMessagesView user search', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /start new conversation/i }));
-    fireEvent.change(screen.getByPlaceholderText(/enter username/i), { target: { value: 'bob' } });
+    fireEvent.change(screen.getByPlaceholderText(/search by username/i), { target: { value: 'bob' } });
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /bob/i }));
@@ -262,7 +326,8 @@ describe('DirectMessagesView user search', () => {
   });
 
   test('shows user not found error', async () => {
-    searchSpy.mockReturnValueOnce({ results: [], loading: false, error: 'User not found' });
+    searchSpy.mockReturnValue({ results: [], loading: false, error: 'User not found' });
+    allSpy.mockReturnValue({ users: [], loading: false, error: null });
 
     render(
       <DirectMessagesView
@@ -273,7 +338,7 @@ describe('DirectMessagesView user search', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /start new conversation/i }));
-    fireEvent.change(screen.getByPlaceholderText(/enter username/i), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText(/search by username/i), { target: { value: 'alice' } });
 
     expect(await screen.findByText(/user not found/i)).toBeInTheDocument();
     expect(startConversationMock).not.toHaveBeenCalled();
@@ -300,5 +365,25 @@ describe('DirectMessagesView user search', () => {
 
     expect(screen.getByRole('button', { name: /bob/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /alice/i })).toBeInTheDocument();
+  });
+
+  test('mobile inbox back button returns to chat', async () => {
+    const onViewChange = jest.fn();
+    const { useIsDesktop } = jest.requireMock('../src/hooks/useIsDesktop') as {
+      useIsDesktop: jest.Mock
+    };
+    useIsDesktop.mockReturnValue(false);
+
+    render(
+      <DirectMessagesView
+        onToggleSidebar={() => {}}
+        currentView="dms"
+        onViewChange={onViewChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }));
+
+    expect(onViewChange).toHaveBeenCalledWith('chat');
   });
 });

--- a/tests/useMessages.test.tsx
+++ b/tests/useMessages.test.tsx
@@ -8,9 +8,28 @@ import {
 } from '../src/hooks/useMessages';
 import * as messagesModule from '../src/hooks/useMessages';
 import { useAuth } from '../src/hooks/useAuth';
-import { supabase, ensureSession } from '../src/lib/supabase';
+import {
+  supabase,
+  ensureSession,
+  getWorkingClient,
+  getRealtimeClient,
+  refreshSessionLocked,
+  resetRealtimeConnection,
+} from '../src/lib/supabase';
 
 jest.mock('../src/hooks/useAuth');
+jest.mock('../src/hooks/useVisibilityRefresh', () => ({
+  useVisibilityRefresh: jest.fn(),
+}));
+jest.mock('../src/hooks/useSoundEffects', () => ({
+  useSoundEffects: () => ({ playMessage: jest.fn(), playReaction: jest.fn() }),
+}));
+jest.mock('../src/lib/push', () => ({
+  triggerGroupPushNotification: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/config', () => ({
+  MESSAGE_FETCH_LIMIT: 40,
+}));
 jest.mock('../src/lib/supabase', () => {
   return {
     supabase: {
@@ -20,11 +39,74 @@ jest.mock('../src/lib/supabase', () => {
       rpc: jest.fn(),
       auth: { getSession: jest.fn(), refreshSession: jest.fn() },
     },
+    getWorkingClient: jest.fn(),
+    getRealtimeClient: jest.fn(),
+    refreshSessionLocked: jest.fn(),
+    resetRealtimeConnection: jest.fn(),
     ensureSession: jest.fn(),
   };
 });
 
 type SupabaseMock = jest.Mocked<typeof supabase>;
+type WorkingClient = {
+  from: jest.Mock;
+  channel: jest.Mock;
+  removeChannel: jest.Mock;
+  rpc: jest.Mock;
+  auth: {
+    getSession: jest.Mock;
+    refreshSession: jest.Mock;
+  };
+};
+
+const createQuery = (overrides: Record<string, unknown> = {}) => {
+  const query: Record<string, any> = {
+    insert: jest.fn(() => query),
+    select: jest.fn(() => query),
+    single: jest.fn().mockResolvedValue({ data: [], error: null }),
+    order: jest.fn(() => query),
+    limit: jest.fn(() => query),
+    update: jest.fn(() => query),
+    delete: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    rpc: jest.fn(() => query),
+  };
+
+  Object.assign(query, overrides);
+  return query;
+};
+
+let workingClient: WorkingClient;
+
+const configureWorkingClient = () => {
+  workingClient = {
+    from: jest.fn(() => createQuery()),
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn(),
+      send: jest.fn(),
+      state: 'joined',
+    })),
+    removeChannel: jest.fn(),
+    rpc: jest.fn(),
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: { access_token: 'token' } } }),
+      refreshSession: jest.fn(),
+    },
+  };
+
+  (getWorkingClient as jest.Mock).mockResolvedValue(workingClient);
+  (getRealtimeClient as jest.Mock).mockReturnValue(workingClient);
+  (refreshSessionLocked as jest.Mock).mockResolvedValue({
+    data: { session: {} },
+    error: null,
+  });
+  (resetRealtimeConnection as jest.Mock).mockResolvedValue(undefined);
+};
+
+beforeEach(() => {
+  configureWorkingClient();
+});
 
 describe('helper functions', () => {
   it('prepareMessageData trims content', () => {
@@ -44,7 +126,7 @@ describe('helper functions', () => {
 
   it('insertMessage inserts through supabase', async () => {
     const insertMock = jest.fn(() => ({ select: () => ({ single: () => Promise.resolve({ data: { id: '1' } as any, error: null }) }) }));
-    (supabase.from as jest.Mock).mockReturnValueOnce({ insert: insertMock } as any);
+    workingClient.from.mockReturnValueOnce(createQuery({ insert: insertMock }) as any);
 
     const { data, error } = await insertMessage({ user_id: 'u1', content: 'hi', message_type: 'text' });
     expect(insertMock).toHaveBeenCalledWith({ user_id: 'u1', content: 'hi', message_type: 'text' });
@@ -54,11 +136,10 @@ describe('helper functions', () => {
 
   it('refreshSessionAndRetry refreshes and retries insert', async () => {
     const insertSpy = jest.spyOn(messagesModule, 'insertMessage').mockResolvedValueOnce({ data: { id: '1' } as any, error: null });
-    (supabase.auth.refreshSession as jest.Mock).mockResolvedValue({ data: { session: {} }, error: null });
 
     const { data, error } = await refreshSessionAndRetry({ user_id: 'u1', content: 'hi', message_type: 'text' });
 
-    expect(supabase.auth.refreshSession).toHaveBeenCalled();
+    expect(refreshSessionLocked).toHaveBeenCalled();
     expect(insertSpy).toHaveBeenCalled();
     expect(data).toEqual({ id: '1' });
     expect(error).toBeNull();
@@ -70,24 +151,13 @@ describe('sendMessage', () => {
   const user = { id: 'user1' } as any;
   beforeEach(() => {
     jest.resetAllMocks();
+    configureWorkingClient();
     (useAuth as jest.Mock).mockReturnValue({ user });
 
     const sb = supabase as SupabaseMock;
 
     // default mock implementations
-    sb.from.mockImplementation(() => {
-      return {
-        insert: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        single: jest.fn().mockResolvedValue({ data: [], error: null }),
-        order: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        update: jest.fn().mockReturnThis(),
-        delete: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        rpc: jest.fn().mockReturnThis(),
-      } as any;
-    });
+    sb.from.mockImplementation(() => createQuery() as any);
     sb.channel.mockReturnValue({
       on: jest.fn().mockReturnThis(),
       subscribe: jest.fn(),
@@ -95,29 +165,16 @@ describe('sendMessage', () => {
     } as any);
     sb.removeChannel.mockResolvedValue();
     sb.auth = {
-      getSession: jest.fn(),
+      getSession: jest.fn().mockResolvedValue({ data: { session: { access_token: 'token' } } }),
       refreshSession: jest.fn(),
     } as any;
     (ensureSession as jest.Mock).mockResolvedValue(true);
   });
 
   it('calls ensureSession and inserts message', async () => {
-    const insertFn = jest.fn(() => ({
-      select: () => ({
-        single: () => Promise.resolve({ data: { id: '1' }, error: null }),
-      }),
-    }));
-    (supabase.from as jest.Mock).mockReturnValueOnce({
-      insert: insertFn,
-      select: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({ data: [], error: null }),
-      order: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      update: jest.fn().mockReturnThis(),
-      delete: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      rpc: jest.fn().mockReturnThis(),
-    } as any);
+    const insertSpy = jest
+      .spyOn(messagesModule, 'insertMessage')
+      .mockResolvedValueOnce({ data: { id: '1' } as any, error: null });
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
 
@@ -126,14 +183,14 @@ describe('sendMessage', () => {
     });
 
     expect(ensureSession).toHaveBeenCalled();
-    expect(insertFn).toHaveBeenCalled();
+    expect(insertSpy).toHaveBeenCalled();
+    insertSpy.mockRestore();
   });
 
   it('inserts message with reply_to', async () => {
-    const insertFn = jest.fn(() => ({
-      select: () => ({ single: () => Promise.resolve({ data: { id: '1' }, error: null }) })
-    }));
-    (supabase.from as jest.Mock).mockReturnValueOnce({ insert: insertFn } as any);
+    const insertSpy = jest
+      .spyOn(messagesModule, 'insertMessage')
+      .mockResolvedValueOnce({ data: { id: '1' } as any, error: null });
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
 
@@ -141,19 +198,19 @@ describe('sendMessage', () => {
       await result.current.sendMessage('hello', 'text', undefined, 'parent');
     });
 
-    expect(insertFn).toHaveBeenCalledWith({
+    expect(insertSpy).toHaveBeenCalledWith({
       user_id: user.id,
       content: 'hello',
       message_type: 'text',
       reply_to: 'parent'
     });
+    insertSpy.mockRestore();
   });
 
   it('inserts audio message with correct type', async () => {
-    const insertFn = jest.fn(() => ({
-      select: () => ({ single: () => Promise.resolve({ data: { id: '1' }, error: null }) })
-    }));
-    (supabase.from as jest.Mock).mockReturnValueOnce({ insert: insertFn } as any);
+    const insertSpy = jest
+      .spyOn(messagesModule, 'insertMessage')
+      .mockResolvedValueOnce({ data: { id: '1' } as any, error: null });
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
 
@@ -161,49 +218,25 @@ describe('sendMessage', () => {
       await result.current.sendMessage('https://example.com/audio.webm', 'audio');
     });
 
-    expect(insertFn).toHaveBeenCalledWith({
+    expect(insertSpy).toHaveBeenCalledWith({
       user_id: user.id,
       content: '',
       message_type: 'audio',
       audio_url: 'https://example.com/audio.webm',
     });
+    insertSpy.mockRestore();
   });
 
   it('refreshes session and retries on 401 insert error', async () => {
-    const insertFail = jest.fn(() => ({
-      select: () => ({
-        single: () => Promise.resolve({ data: null, error: { status: 401, message: 'unauthorized' } }),
-      }),
-    }));
-    const insertSuccess = jest.fn(() => ({
-      select: () => ({
-        single: () => Promise.resolve({ data: { id: '1' }, error: null }),
-      }),
-    }));
-
-    (supabase.from as jest.Mock).mockReturnValueOnce({
-      insert: insertFail,
-      select: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({ data: [], error: null }),
-      order: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      update: jest.fn().mockReturnThis(),
-      delete: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      rpc: jest.fn().mockReturnThis(),
-    } as any).mockReturnValueOnce({
-      insert: insertSuccess,
-      select: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({ data: [], error: null }),
-      order: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      update: jest.fn().mockReturnThis(),
-      delete: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      rpc: jest.fn().mockReturnThis(),
-    } as any);
-
-    (supabase.auth.refreshSession as jest.Mock).mockResolvedValue({ data: { session: {} }, error: null });
+    const insertSpy = jest
+      .spyOn(messagesModule, 'insertMessage')
+      .mockResolvedValueOnce({
+        data: null,
+        error: { status: 401, message: 'unauthorized' },
+      } as any);
+    const retrySpy = jest
+      .spyOn(messagesModule, 'refreshSessionAndRetry')
+      .mockResolvedValueOnce({ data: { id: '1' } as any, error: null });
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
 
@@ -211,9 +244,10 @@ describe('sendMessage', () => {
       await result.current.sendMessage('hello');
     });
 
-    expect(insertFail).toHaveBeenCalled();
-    expect(supabase.auth.refreshSession).toHaveBeenCalled();
-    expect(insertSuccess).toHaveBeenCalled();
+    expect(insertSpy).toHaveBeenCalled();
+    expect(retrySpy).toHaveBeenCalled();
+    insertSpy.mockRestore();
+    retrySpy.mockRestore();
   });
 });
 
@@ -221,52 +255,26 @@ describe('message actions', () => {
   const user = { id: 'user1' } as any;
   beforeEach(() => {
     jest.resetAllMocks();
+    configureWorkingClient();
     (useAuth as jest.Mock).mockReturnValue({ user });
-
-    const sb = supabase as SupabaseMock;
-
-    sb.from.mockImplementation(() => {
-      return {
-        insert: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        single: jest.fn().mockResolvedValue({ data: [], error: null }),
-        order: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        update: jest.fn().mockReturnThis(),
-        delete: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        rpc: jest.fn().mockReturnThis(),
-      } as any;
-    });
-    sb.channel.mockReturnValue({
-      on: jest.fn().mockReturnThis(),
-      subscribe: jest.fn(),
-      send: jest.fn(),
-    } as any);
-    sb.removeChannel.mockResolvedValue();
-    sb.auth = {
-      getSession: jest.fn(),
-      refreshSession: jest.fn(),
-    } as any;
     (ensureSession as jest.Mock).mockResolvedValue(true);
   });
 
   it('edits message', async () => {
-    const updateFn = jest.fn().mockReturnThis();
-    const eqFn = jest.fn().mockReturnThis();
-    (supabase.from as jest.Mock).mockReturnValueOnce({
-      insert: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({ data: [], error: null }),
-      order: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      update: updateFn,
-      delete: jest.fn().mockReturnThis(),
-      eq: eqFn,
-      rpc: jest.fn().mockReturnThis(),
-    } as any);
+    const query = createQuery();
+    const updateFn = jest.fn(() => query);
+    const eqFn = jest.fn(() => query);
+    query.update = updateFn;
+    query.eq = eqFn;
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    workingClient.from.mockClear();
+    workingClient.from.mockReturnValueOnce(query as any);
 
     await act(async () => {
       await result.current.editMessage('m1', 'hi');
@@ -278,21 +286,20 @@ describe('message actions', () => {
   });
 
   it('deletes message', async () => {
-    const deleteFn = jest.fn().mockReturnThis();
-    const eqFn = jest.fn().mockReturnThis();
-    (supabase.from as jest.Mock).mockReturnValueOnce({
-      insert: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({ data: [], error: null }),
-      order: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      update: jest.fn().mockReturnThis(),
-      delete: deleteFn,
-      eq: eqFn,
-      rpc: jest.fn().mockReturnThis(),
-    } as any);
+    const query = createQuery();
+    const deleteFn = jest.fn(() => query);
+    const eqFn = jest.fn(() => query);
+    query.delete = deleteFn;
+    query.eq = eqFn;
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    workingClient.from.mockClear();
+    workingClient.from.mockReturnValueOnce(query as any);
 
     await act(async () => {
       await result.current.deleteMessage('m1');
@@ -305,7 +312,7 @@ describe('message actions', () => {
 
   it('toggles reaction', async () => {
     const rpcFn = jest.fn().mockResolvedValue({ data: null, error: null });
-    (supabase.rpc as jest.Mock).mockImplementationOnce(rpcFn);
+    workingClient.rpc.mockImplementationOnce(rpcFn);
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
 
@@ -318,7 +325,7 @@ describe('message actions', () => {
 
   it('toggles pin state', async () => {
     const rpcFn = jest.fn().mockResolvedValue({ data: null, error: null });
-    (supabase.rpc as jest.Mock).mockImplementationOnce(rpcFn);
+    workingClient.rpc.mockImplementationOnce(rpcFn);
 
     const { result } = renderHook(() => useMessages(), { wrapper: MessagesProvider });
 

--- a/tests/useSuggestedReplies.test.tsx
+++ b/tests/useSuggestedReplies.test.tsx
@@ -15,8 +15,9 @@ beforeEach(() => {
 test('fetches suggestions when enabled', async () => {
   const mock = getSuggestedReplies as GetMock
   mock.mockResolvedValue(['hi'])
+  const messages = [{ id: '1', content: 'hello' } as any]
 
-  const { result } = renderHook(() => useSuggestedReplies([{ id: '1', content: 'hello' } as any], true))
+  const { result } = renderHook(() => useSuggestedReplies(messages, true))
 
   await act(async () => {
     await Promise.resolve()
@@ -28,8 +29,9 @@ test('fetches suggestions when enabled', async () => {
 
 test('does not fetch when disabled', async () => {
   const mock = getSuggestedReplies as GetMock
+  const messages = [{ id: '1', content: 'hello' } as any]
 
-  const { result } = renderHook(() => useSuggestedReplies([{ id: '1', content: 'hello' } as any], false))
+  const { result } = renderHook(() => useSuggestedReplies(messages, false))
 
   await act(async () => {
     await Promise.resolve()

--- a/tests/useTyping.test.tsx
+++ b/tests/useTyping.test.tsx
@@ -1,40 +1,55 @@
-import { renderHook, act } from '@testing-library/react';
-import { useTyping } from '../src/hooks/useTyping';
-import { useAuth } from '../src/hooks/useAuth';
-import { supabase } from '../src/lib/supabase';
+import { renderHook, act } from '@testing-library/react'
 
-jest.mock('../src/hooks/useAuth');
-jest.mock('../src/lib/supabase', () => {
-  return {
-    supabase: {
-      from: jest.fn(),
-      channel: jest.fn(),
-      removeChannel: jest.fn(),
-      auth: { getSession: jest.fn(), refreshSession: jest.fn() },
-    },
-  };
-});
+jest.mock('../src/hooks/useAuth', () => ({
+  useAuth: jest.fn(),
+}))
 
-type SupabaseMock = jest.Mocked<typeof supabase>;
+jest.mock('../src/lib/supabase', () => ({
+  getWorkingClient: jest.fn(),
+  getRealtimeClient: jest.fn(),
+}))
+
+import { useTyping } from '../src/hooks/useTyping'
+import { useAuth } from '../src/hooks/useAuth'
+import { getRealtimeClient, getWorkingClient } from '../src/lib/supabase'
+
+const buildChannel = (send = jest.fn()) => ({
+  on: jest.fn().mockReturnThis(),
+  subscribe: jest.fn().mockReturnThis(),
+  send,
+})
 
 beforeEach(() => {
-  jest.resetAllMocks();
-  (useAuth as jest.Mock).mockReturnValue({ user: { id: 'u1', username: 'u', display_name: 'U' } });
+  jest.resetAllMocks()
+  jest.useFakeTimers()
 
-  const sb = supabase as SupabaseMock;
-  sb.channel.mockReturnValue({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: jest.fn() } as any);
-  sb.removeChannel.mockResolvedValue();
-});
+  ;(useAuth as jest.Mock).mockReturnValue({
+    user: { id: 'u1', username: 'u', display_name: 'U' },
+  })
+})
+
+afterEach(() => {
+  jest.runOnlyPendingTimers()
+  jest.useRealTimers()
+})
 
 test('startTyping sends typing true broadcast', async () => {
-  const sendMock = jest.fn();
-  (supabase.channel as jest.Mock).mockReturnValueOnce({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: sendMock } as any);
+  const sendMock = jest.fn()
+  const channel = buildChannel(sendMock)
+  const client = { channel: jest.fn(() => channel), removeChannel: jest.fn() }
 
-  const { result } = renderHook(() => useTyping('general'));
+  ;(getWorkingClient as jest.Mock).mockResolvedValue(client)
+  ;(getRealtimeClient as jest.Mock).mockReturnValue(client)
+
+  const { result } = renderHook(() => useTyping('general'))
 
   await act(async () => {
-    await result.current.startTyping();
-  });
+    await Promise.resolve()
+  })
+
+  await act(async () => {
+    await result.current.startTyping()
+  })
 
   expect(sendMock).toHaveBeenCalledWith({
     type: 'broadcast',
@@ -43,21 +58,36 @@ test('startTyping sends typing true broadcast', async () => {
       user: { id: 'u1', username: 'u', display_name: 'U' },
       typing: true,
     },
-  });
-  expect(result.current.isTyping).toBe(true);
-});
+  })
+  expect(result.current.isTyping).toBe(true)
+})
 
 test('stopTyping sends typing false broadcast', async () => {
-  const sendMock = jest.fn();
-  (supabase.channel as jest.Mock).mockReturnValueOnce({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), send: sendMock } as any);
+  const sendMock = jest.fn()
+  const channel = buildChannel(sendMock)
+  const client = { channel: jest.fn(() => channel), removeChannel: jest.fn() }
 
-  const { result } = renderHook(() => useTyping('general'));
+  ;(getWorkingClient as jest.Mock).mockResolvedValue(client)
+  ;(getRealtimeClient as jest.Mock).mockReturnValue(client)
+
+  const { result } = renderHook(() => useTyping('general'))
 
   await act(async () => {
-    await result.current.startTyping();
-    await result.current.stopTyping();
-  });
+    await Promise.resolve()
+  })
 
-  expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({ payload: expect.objectContaining({ typing: false }) }));
-  expect(result.current.isTyping).toBe(false);
-});
+  await act(async () => {
+    await result.current.startTyping()
+  })
+
+  await act(async () => {
+    await result.current.stopTyping()
+  })
+
+  expect(sendMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      payload: expect.objectContaining({ typing: false }),
+    })
+  )
+  expect(result.current.isTyping).toBe(false)
+})

--- a/tests/useVisibilityRefresh.test.tsx
+++ b/tests/useVisibilityRefresh.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { useVisibilityRefresh } from '../src/hooks/useVisibilityRefresh'
 
-test('runs callback on visibility change when document becomes visible', () => {
+test('runs callback on visibility change when document becomes visible', async () => {
   jest.useFakeTimers()
   const cb = jest.fn()
   renderHook(() => useVisibilityRefresh(cb, 200))
@@ -9,7 +9,10 @@ test('runs callback on visibility change when document becomes visible', () => {
   act(() => {
     document.dispatchEvent(new Event('visibilitychange'))
   })
-  jest.runAllTimers()
+  await act(async () => {
+    jest.advanceTimersByTime(200)
+    await Promise.resolve()
+  })
   expect(cb).toHaveBeenCalled()
   jest.useRealTimers()
 })


### PR DESCRIPTION
## What changed

- stabilized chat and DM send flows around session recovery, unread handling, and resume behavior
- fixed several UI and interaction issues found during broader QA, including settings toggle alignment, reaction access, upload hooks, and recording surfaces
- added a dependable repo-local Playwright smoke runner with headed and scenario-based flows, including a resume/background-send regression path
- corrected DM reaction schema support and expanded automated test coverage across the touched areas

## Why

The most important production issue was a mobile/background resume bug where sending could get stuck indefinitely after the app returned to the foreground. The root cause was a race between aggressive client reset logic and the send/auth recovery path. This change makes session recovery timeout-bounded, removes the conflicting full reset on every visibility change, and verifies the flow with targeted browser automation.

## Impact

- sending after app resume is more dependable
- DM unread/read behavior is more consistent
- browser QA is much easier to rerun and observe
- the test suite is green and no longer timing out

## Validation

- `npm run lint`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npm run build`
- `npx jest --runInBand`
- `node scripts/playwright-smoke.mjs --scenario=auth,resume-send --headed --slow-mo=120 --no-reuse-server --run-name=resume-send-observed-3`
