### PR TITLE
[codex] Add inline chat video playback

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -15,6 +15,7 @@ import {
   SESSION_RECOVERY_EVENT,
   type SessionRecoveryResult,
 } from '../../lib/sessionRecovery'
+import type { ChatMessageType } from '../../lib/supabase'
 
 interface ChatViewProps {
   currentView: 'chat' | 'dms' | 'news' | 'settings'
@@ -53,7 +54,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ currentView, onViewChange, i
 
   const handleSendMessage = async (
     content: string,
-    type?: 'text' | 'command' | 'audio' | 'image' | 'file',
+    type?: ChatMessageType,
     fileUrl?: string,
     replyToId?: string
   ) => {

--- a/src/components/chat/FailedMessageItem.tsx
+++ b/src/components/chat/FailedMessageItem.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { FailedMessage } from '../../hooks/useFailedMessages'
 import { Button } from '../ui/Button'
 import { ImageModal } from '../ui/ImageModal'
+import { VideoAttachment } from './VideoAttachment'
 
 interface Props {
   message: FailedMessage
@@ -28,6 +29,9 @@ export const FailedMessageItem: React.FC<Props> = ({ message, onResend }) => {
               {message.fileName || 'Download file'}
             </a>
           </div>
+        )}
+        {message.type === 'video' && message.dataUrl && (
+          <VideoAttachment url={message.dataUrl} meta={message.content} />
         )}
         {message.type === 'audio' && message.dataUrl && (
           <audio controls src={message.dataUrl} className="max-w-xs" />

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -4,7 +4,7 @@ import { Send, Smile, Command, Plus, Mic, X } from 'lucide-react'
 import { useTyping } from '../../hooks/useTyping'
 import { Button } from '../ui/Button'
 import { processSlashCommand, slashCommands } from '../../lib/utils'
-import type { ChatMessage } from '../../lib/supabase'
+import type { ChatMessage, ChatMessageType } from '../../lib/supabase'
 import { uploadVoiceMessage, uploadChatFile } from '../../lib/supabase'
 import type { EmojiClickData } from '../../types'
 import { useEmojiPicker } from '../../hooks/useEmojiPicker'
@@ -34,7 +34,7 @@ const getEmojiPickerTheme = () =>
 interface MessageInputProps {
   onSendMessage: (
     content: string,
-    type?: 'text' | 'command' | 'audio' | 'image' | 'file',
+    type?: ChatMessageType,
     fileUrl?: string,
     replyTo?: string
   ) => Promise<ChatMessage | null | void> | ChatMessage | null | void
@@ -75,6 +75,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const emojiPickerRef = useRef<HTMLDivElement>(null)
   const attachmentMenuRef = useRef<HTMLDivElement>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
+  const videoInputRef = useRef<HTMLInputElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const mediaStreamRef = useRef<MediaStream | null>(null)
@@ -299,6 +300,11 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     setShowAttachmentMenu(false)
   }
 
+  const openVideoUpload = () => {
+    videoInputRef.current?.click()
+    setShowAttachmentMenu(false)
+  }
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     e.target.value = ''
@@ -323,6 +329,31 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }
 
+  const handleVideoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (file) {
+      onUploadStatusChange(true)
+      ;(async () => {
+        try {
+          const url = await uploadChatFile(file)
+          const meta = JSON.stringify({ name: file.name, size: file.size, type: file.type })
+          const sent = await onSendMessage(meta, 'video', url, replyingTo?.id)
+          if (sent === null) {
+            toast.error('Failed to send video')
+            return
+          }
+          onCancelReply?.()
+        } catch (err) {
+          console.error(err)
+          toast.error('Failed to send video')
+        } finally {
+          onUploadStatusChange(false)
+        }
+      })()
+    }
+  }
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     e.target.value = ''
@@ -331,11 +362,15 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       ;(async () => {
         try {
           const url = await uploadChatFile(file)
-          const messageType = file.type.startsWith('image/') ? 'image' : 'file'
+          const messageType: ChatMessageType = file.type.startsWith('image/')
+            ? 'image'
+            : file.type.startsWith('video/')
+              ? 'video'
+              : 'file'
           const meta = JSON.stringify({ name: file.name, size: file.size, type: file.type })
           const sent = await onSendMessage(
             messageType === 'image' ? '' : meta,
-            messageType as any,
+            messageType,
             url,
             replyingTo?.id
           )
@@ -518,6 +553,13 @@ export const MessageInput: React.FC<MessageInputProps> = ({
               </button>
               <button
                 type="button"
+                onClick={openVideoUpload}
+                className="block w-full px-3 py-1.5 text-left text-sm text-[var(--text-secondary)] transition-colors hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-primary)]"
+              >
+                Video
+              </button>
+              <button
+                type="button"
                 onClick={openFileUpload}
                 className="block w-full px-3 py-1.5 text-left text-sm text-[var(--text-secondary)] transition-colors hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-primary)]"
               >
@@ -551,6 +593,14 @@ export const MessageInput: React.FC<MessageInputProps> = ({
             ref={imageInputRef}
             onChange={handleImageChange}
             data-upload-kind="image"
+            className="hidden"
+          />
+          <input
+            type="file"
+            accept="video/*"
+            ref={videoInputRef}
+            onChange={handleVideoChange}
+            data-upload-kind="video"
             className="hidden"
           />
           <input

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -15,6 +15,7 @@ import { Avatar } from '../ui/Avatar'
 import { ImageModal } from '../ui/ImageModal'
 import { Button } from '../ui/Button'
 import { FileAttachment } from './FileAttachment'
+import { VideoAttachment } from './VideoAttachment'
 import { MessageRichText } from './MessageRichText'
 import { PublicProfileDialog } from '../profile/PublicProfileDialog'
 import { formatTime, shouldGroupMessage, cn, getReadableTextColor } from '../../lib/utils'
@@ -358,6 +359,8 @@ export const MessageItem: React.FC<MessageItemProps> = React.memo(
                       className="mt-1 max-w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] sm:max-w-xs"
                       onClick={() => setShowImageModal(true)}
                     />
+                  ) : message.message_type === 'video' && message.file_url ? (
+                    <VideoAttachment url={message.file_url} meta={message.content} />
                   ) : message.message_type === 'file' && message.file_url ? (
                     <FileAttachment url={message.file_url} meta={message.content} />
                   ) : (

--- a/src/components/chat/PinnedMessageItem.tsx
+++ b/src/components/chat/PinnedMessageItem.tsx
@@ -5,6 +5,7 @@ import type { Message } from '../../lib/supabase'
 import { useEmojiPicker } from '../../hooks/useEmojiPicker'
 import type { EmojiClickData } from '../../types'
 import { MessageReactions } from './MessageItem'
+import { VideoAttachment } from './VideoAttachment'
 import { cn } from '../../lib/utils'
 
 const QUICK_REACTIONS = ['\u{1F44D}', '\u2764\uFE0F', '\u{1F602}', '\u{1F389}', '\u{1F64F}']
@@ -72,6 +73,8 @@ export const PinnedMessageItem: React.FC<PinnedMessageItemProps> = ({
           <strong>{message.user?.display_name}:</strong>{' '}
           {message.message_type === 'audio' ? (
             <audio controls src={message.audio_url} className="mt-1 max-w-full" />
+          ) : message.message_type === 'video' && message.file_url ? (
+            <VideoAttachment url={message.file_url} meta={message.content} />
           ) : (
             message.content
           )}

--- a/src/components/chat/VideoAttachment.tsx
+++ b/src/components/chat/VideoAttachment.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Film } from 'lucide-react'
+import { formatBytes } from '../../lib/utils'
+
+interface VideoAttachmentProps {
+  url: string
+  meta?: string
+}
+
+export const VideoAttachment: React.FC<VideoAttachmentProps> = ({ url, meta }) => {
+  let name = 'video'
+  let size = 0
+  let type = 'video'
+
+  try {
+    const parsed = meta ? JSON.parse(meta) : {}
+    name = parsed.name || name
+    size = parsed.size || size
+    type = parsed.type || type
+  } catch {
+    // ignore malformed attachment metadata
+  }
+
+  return (
+    <div className="mt-1 w-[min(22rem,calc(100vw-7rem))] max-w-full space-y-2">
+      <video
+        controls
+        playsInline
+        preload="metadata"
+        src={url}
+        className="aspect-video w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-black object-contain shadow-[var(--shadow-panel)]"
+      />
+      <div className="glass-panel flex items-center gap-2 rounded-[var(--radius-md)] px-3 py-2 text-sm">
+        <Film className="h-4 w-4 flex-shrink-0 text-[var(--text-gold)]" />
+        <a
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+          download={name}
+          className="min-w-0 flex-1 truncate text-[var(--text-gold)] underline decoration-[rgba(215,170,70,0.45)] underline-offset-2"
+        >
+          {name}
+        </a>
+        {size > 0 && (
+          <span className="shrink-0 text-xs text-[var(--text-muted)]">
+            {formatBytes(size)}
+          </span>
+        )}
+        {type && <span className="sr-only">{type}</span>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/dms/DirectMessagesView.tsx
+++ b/src/components/dms/DirectMessagesView.tsx
@@ -16,6 +16,7 @@ import { MessageInput } from '../chat/MessageInput'
 import { MobileChatFooter } from '../layout/MobileChatFooter'
 import { FailedMessageItem } from '../chat/FailedMessageItem'
 import { FileAttachment } from '../chat/FileAttachment'
+import { VideoAttachment } from '../chat/VideoAttachment'
 import { MessageRichText } from '../chat/MessageRichText'
 import { PublicProfileDialog } from '../profile/PublicProfileDialog'
 import { useFailedMessages } from '../../hooks/useFailedMessages'
@@ -24,7 +25,7 @@ import { useIsDesktop } from '../../hooks/useIsDesktop'
 import { LoadingSpinner } from '../ui/LoadingSpinner'
 import { useTyping } from '../../hooks/useTyping'
 import toast from 'react-hot-toast'
-import type { BasicUser, User } from '../../lib/supabase'
+import type { BasicUser, ChatMessageType, User } from '../../lib/supabase'
 
 interface DirectMessagesViewProps {
   onToggleSidebar: () => void
@@ -138,7 +139,7 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({
 
   const handleSendMessage = async (
     content: string,
-    type?: 'text' | 'command' | 'audio' | 'image' | 'file',
+    type?: ChatMessageType,
     fileUrl?: string
   ) => {
     try {
@@ -602,6 +603,8 @@ export const DirectMessagesView: React.FC<DirectMessagesViewProps> = ({
                             alt="uploaded"
                             className="mt-1 max-w-xs rounded-[var(--radius-md)] border border-[var(--border-subtle)]"
                           />
+                        ) : message.message_type === 'video' && message.file_url ? (
+                          <VideoAttachment url={message.file_url} meta={message.content} />
                         ) : message.message_type === 'file' && message.file_url ? (
                           <FileAttachment url={message.file_url} meta={message.content} />
                         ) : (

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -13,6 +13,7 @@ import {
   getRealtimeClient,
   DMConversation,
   DMMessage,
+  type ChatMessageType,
   getOrCreateDMConversation,
   markDMMessagesRead,
   fetchDMConversations,
@@ -40,7 +41,7 @@ interface DirectMessagesContextValue {
   startConversation: (username: string) => Promise<string | null>;
   sendMessage: (
     content: string,
-    messageType?: 'text' | 'command' | 'audio' | 'image' | 'file',
+    messageType?: ChatMessageType,
     fileUrl?: string
   ) => Promise<DMMessage | null>;
   markAsRead: (conversationId: string) => Promise<void>;
@@ -308,7 +309,7 @@ function useProvideDirectMessages(): DirectMessagesContextValue {
   const sendMessage = useCallback(
     async (
       content: string,
-      messageType?: 'text' | 'command' | 'audio' | 'image' | 'file',
+      messageType?: ChatMessageType,
       fileUrl?: string
     ) => {
       const message = await sendConversationMessage(content, messageType, fileUrl);
@@ -401,7 +402,7 @@ export function useConversationMessages(conversationId: string | null) {
         conversation_id: string;
         sender_id: string;
         content: string;
-        message_type: 'text' | 'command' | 'audio' | 'image' | 'file';
+        message_type: ChatMessageType;
         file_url?: string;
         audio_url?: string;
       }
@@ -771,12 +772,12 @@ export function useConversationMessages(conversationId: string | null) {
   const sendMessage = useCallback(
     async (
       content: string,
-      messageType: 'text' | 'command' | 'audio' | 'image' | 'file' = 'text',
+      messageType: ChatMessageType = 'text',
       fileUrl?: string
     ): Promise<DMMessage | null> => {
     
       const trimmedContent = content.trim();
-      const requiresContent = messageType !== 'audio' && messageType !== 'image' && messageType !== 'file';
+      const requiresContent = messageType !== 'audio' && messageType !== 'image' && messageType !== 'video' && messageType !== 'file';
       if (!user || !conversationId || (requiresContent && !trimmedContent)) return null;
 
       setSending(true);

--- a/src/hooks/useFailedMessages.tsx
+++ b/src/hooks/useFailedMessages.tsx
@@ -1,8 +1,9 @@
+import type { ChatMessageType } from '../lib/supabase'
 import { useState } from 'react'
 
 export interface FailedMessage {
   id: string
-  type: 'text' | 'command' | 'image' | 'audio' | 'file'
+  type: ChatMessageType
   content: string
   dataUrl?: string
   fileName?: string

--- a/src/hooks/useMessages.tsx
+++ b/src/hooks/useMessages.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import {
   Message,
+  type ChatMessageType,
   ensureSession,
   refreshSessionLocked,
   getRealtimeClient,
@@ -38,7 +39,7 @@ const dedupeMessagesById = (items: Message[]) => {
 export const prepareMessageData = (
   userId: string,
   content: string,
-  messageType: 'text' | 'command' | 'audio' | 'image' | 'file',
+  messageType: ChatMessageType,
   fileUrl?: string,
   replyTo?: string
 ) => ({
@@ -53,7 +54,7 @@ export const prepareMessageData = (
 export const insertMessage = async (messageData: {
   user_id: string;
   content: string;
-  message_type: 'text' | 'command' | 'audio' | 'image' | 'file';
+  message_type: ChatMessageType;
   file_url?: string;
   audio_url?: string;
   reply_to?: string;
@@ -86,7 +87,7 @@ export const insertMessage = async (messageData: {
 export const refreshSessionAndRetry = async (messageData: {
   user_id: string;
   content: string;
-  message_type: 'text' | 'command' | 'audio' | 'image' | 'file';
+  message_type: ChatMessageType;
   file_url?: string;
   audio_url?: string;
   reply_to?: string;
@@ -122,7 +123,7 @@ interface MessagesContextValue {
   hasMore: boolean;
   sendMessage: (
     content: string,
-    type?: 'text' | 'command' | 'audio' | 'image' | 'file',
+    type?: ChatMessageType,
     fileUrl?: string,
     replyTo?: string
   ) => Promise<Message | null>;
@@ -617,7 +618,7 @@ function useProvideMessages(): MessagesContextValue {
 
   const sendMessage = useCallback(async (
     content: string,
-    messageType: 'text' | 'command' | 'audio' | 'image' | 'file' = 'text',
+    messageType: ChatMessageType = 'text',
     fileUrl?: string,
     replyTo?: string
   ): Promise<Message | null> => {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -674,11 +674,13 @@ export interface User {
   updated_at: string
 }
 
+export type ChatMessageType = 'text' | 'command' | 'audio' | 'image' | 'video' | 'file'
+
 export interface Message {
   id: string
   user_id: string
   content: string
-  message_type: 'text' | 'command' | 'audio' | 'image' | 'file'
+  message_type: ChatMessageType
   audio_url?: string
   audio_duration?: number
   file_url?: string
@@ -779,7 +781,7 @@ export interface DMMessage {
   conversation_id: string
   sender_id: string
   content: string
-  message_type: 'text' | 'command' | 'audio' | 'image' | 'file'
+  message_type: ChatMessageType
   audio_url?: string
   audio_duration?: number
   file_url?: string

--- a/tests/MessageInput.test.tsx
+++ b/tests/MessageInput.test.tsx
@@ -126,3 +126,50 @@ test('shows an error and keeps reply state when uploaded image send resolves to 
   expect(onCancelReply).not.toHaveBeenCalled()
   expect((toast as any).error).toHaveBeenCalledWith('Failed to send image')
 })
+
+test('sends selected videos as video attachments', async () => {
+  uploadChatFile.mockResolvedValueOnce('https://example.com/clip.mp4')
+  const onSendMessage = jest.fn().mockResolvedValue({ id: 'm1' })
+
+  const { container } = render(
+    <MessageInput
+      onSendMessage={onSendMessage}
+      replyingTo={{ id: 'parent', content: 'hello' }}
+    />
+  )
+
+  const videoInput = container.querySelector('input[type="file"][accept="video/*"]') as HTMLInputElement
+  const file = new File(['video'], 'clip.mp4', { type: 'video/mp4' })
+
+  fireEvent.change(videoInput, { target: { files: [file] } })
+
+  await waitFor(() => {
+    expect(onSendMessage).toHaveBeenCalledWith(
+      JSON.stringify({ name: 'clip.mp4', size: file.size, type: 'video/mp4' }),
+      'video',
+      'https://example.com/clip.mp4',
+      'parent'
+    )
+  })
+})
+
+test('auto-detects videos from the generic file picker', async () => {
+  uploadChatFile.mockResolvedValueOnce('https://example.com/movie.webm')
+  const onSendMessage = jest.fn().mockResolvedValue({ id: 'm1' })
+
+  const { container } = render(<MessageInput onSendMessage={onSendMessage} />)
+
+  const fileInput = container.querySelector('input[type="file"][data-upload-kind="file"]') as HTMLInputElement
+  const file = new File(['video'], 'movie.webm', { type: 'video/webm' })
+
+  fireEvent.change(fileInput, { target: { files: [file] } })
+
+  await waitFor(() => {
+    expect(onSendMessage).toHaveBeenCalledWith(
+      JSON.stringify({ name: 'movie.webm', size: file.size, type: 'video/webm' }),
+      'video',
+      'https://example.com/movie.webm',
+      undefined
+    )
+  })
+})

--- a/tests/MessageItem.test.tsx
+++ b/tests/MessageItem.test.tsx
@@ -91,6 +91,33 @@ test('renders audio message', () => {
   expect(audio).toHaveAttribute('src', audioMessage.audio_url)
 })
 
+test('renders video message', () => {
+  const videoMeta = JSON.stringify({ name: 'clip.mp4', size: 512, type: 'video/mp4' })
+  const videoMessage = {
+    ...baseMessage,
+    message_type: 'video',
+    content: videoMeta,
+    file_url: 'https://example.com/clip.mp4',
+  } as Message
+
+  const { container } = render(
+    <MessageItem
+      message={videoMessage}
+      onEdit={async () => {}}
+      onDelete={async () => {}}
+      onTogglePin={async () => {}}
+      onToggleReaction={async () => {}}
+      onJumpToMessage={() => {}}
+      containerRef={React.createRef()}
+    />
+  )
+
+  const video = container.querySelector('video')
+  expect(video).toHaveAttribute('src', videoMessage.file_url)
+  expect(video).toHaveAttribute('controls')
+  expect(screen.getByRole('link', { name: /clip.mp4/i })).toHaveAttribute('href', videoMessage.file_url)
+})
+
 test('renders file message', () => {
   const fileMeta = JSON.stringify({ name: 'doc.txt', size: 10, type: 'text/plain' })
   const fileMessage = {

--- a/tests/useMessages.test.tsx
+++ b/tests/useMessages.test.tsx
@@ -127,6 +127,21 @@ describe('helper functions', () => {
     });
   });
 
+  it('prepareMessageData stores video metadata and file url', () => {
+    const result = prepareMessageData(
+      'u1',
+      '{"name":"clip.mp4","size":5,"type":"video/mp4"}',
+      'video',
+      'https://example.com/clip.mp4'
+    );
+    expect(result).toEqual({
+      user_id: 'u1',
+      content: '{"name":"clip.mp4","size":5,"type":"video/mp4"}',
+      message_type: 'video',
+      file_url: 'https://example.com/clip.mp4',
+    });
+  });
+
   it('insertMessage inserts through supabase', async () => {
     const insertMock = jest.fn(() => ({ select: () => ({ single: () => Promise.resolve({ data: { id: '1' } as any, error: null }) }) }));
     workingClient.from.mockReturnValueOnce(createQuery({ insert: insertMock }) as any);


### PR DESCRIPTION
## Summary

- Adds a first-class `video` chat message type.
- Adds a Video attachment picker and detects `video/*` from the generic file picker.
- Renders uploaded videos inline with native controls in group chat, pinned messages, failed sends, and DMs.

## Validation

- `npm test -- --runInBand tests/MessageItem.test.tsx tests/MessageInput.test.tsx tests/useMessages.test.tsx`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npm run lint`
- `npm run build`
- Production preview smoke at `http://127.0.0.1:4174` returned HTTP 200 with no browser console errors.