### PR TITLE
Add feedback build automation workflow

### DIFF
--- a/docs/FEEDBACK_SUBMISSIONS.md
+++ b/docs/FEEDBACK_SUBMISSIONS.md
@@ -31,6 +31,88 @@ Deleting removes the `feedback_submissions` row first, then cleans up attached
 private images best-effort. Status editing, assignment, notifications, and
 moderation workflows are intentionally deferred.
 
+## Feedback Builds
+
+Full admins get an additional **Feedback Builds** lane inside Feedback Review.
+Sub-admin operators can continue reviewing submissions, but they cannot see or
+start Codex build runs.
+
+The build workflow uses two additional tables:
+
+- `public.feedback_build_runs`
+- `public.feedback_build_run_logs`
+
+Admins do not write directly to those tables from the browser. The UI calls
+these RPCs instead:
+
+- `create_feedback_build_run`
+- `retry_feedback_build_run`
+- `approve_feedback_build_merge`
+- `archive_feedback_build_run`
+
+Starting or retrying a build requires a companion prompt with at least 20
+characters. Attached screenshots are included by default, and a full admin can
+exclude any image before queueing the run. The generated prompt is stored on the
+run for review. Stage notes are append-only logs created as Codex finishes each
+step.
+
+Run statuses shown in the admin UI:
+
+1. Pending
+2. Running
+3. Ready for Testing
+4. Failed
+5. Archived
+
+The backend also stores merge-oriented states used by the processor:
+`approved_to_merge`, `merging`, and `merged`.
+
+The Codex processor should handle one repo operation globally at a time. It
+processes merge-approved runs first, then pending runs. The required stage log
+sequence is:
+
+1. `queued`
+2. `classifying`
+3. `reviewing_affected_code`
+4. `debugging_existing_behavior`
+5. `researching_solution`
+6. `planning`
+7. `reviewing_plan_against_code`
+8. `implementing`
+9. `testing`
+10. `branch_pushed`
+11. `ready_for_testing`
+12. `approved_to_merge`
+13. `merging`
+14. `documenting_cleanup`
+15. `merged`
+
+Failures can be retried from the admin run detail. Retries create a new pending
+run and restart from classification. Runs are archived, not deleted.
+
+When a run reaches Ready for Testing, the detail view shows the draft PR link,
+Netlify preview URL when available, branch name, generated prompt, screenshots
+marked Included or Excluded, and the stage-by-stage Codex notes. If the PR
+exists but the Netlify preview URL is missing, the run should still be Ready for
+Testing with a warning instead of Failed.
+
+After a full admin approves a run to merge, the processor reruns the gates,
+squash-merges to `main`, records the merge summary and commit SHA, closes the
+original feedback submission, deletes the remote feature branch, and logs the
+cleanup step.
+
+## Evening Report Recognition
+
+The daily Shado update should include public-safe credit for submitters whose
+feedback builds merged that day when `recognition_enabled = true`. Mention the
+display name or username only. Do not include screenshots, private companion
+prompt text, or sensitive bug details in the chat announcement.
+
+The evening report runs daily at 8:00 PM Eastern. It should include merged
+Feedback Builds and normal `main` commits from the day. If there were no app
+updates, it should still post a short, energetic good-evening message from
+Shado.
+
 ## Deployment
 
 Run the normal schema deployment before shipping the frontend:

--- a/src/components/settings/AdminFeedbackReview.tsx
+++ b/src/components/settings/AdminFeedbackReview.tsx
@@ -1,24 +1,39 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
+  AlertTriangle,
+  Archive,
   Bug,
-  Trash2,
+  CheckCircle2,
+  Clock,
   ExternalLink,
+  GitBranch,
   Image as ImageIcon,
   Lightbulb,
+  ListChecks,
   MessageSquarePlus,
+  Rocket,
   Search,
+  Send,
+  Trash2,
   X,
 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { Avatar } from '../ui/Avatar'
 import { useAdminFeedback } from '../../hooks/useAdminFeedback'
+import { useAdminAccess } from '../../hooks/useAdminAccess'
 import type {
   AdminFeedbackAttachmentRecord,
   AdminFeedbackSubmission,
+  FeedbackBuildRun,
+  FeedbackBuildRunLog,
+  FeedbackBuildRunStatus,
+  FeedbackBuildRunStage,
   FeedbackSubmissionType,
 } from '../../lib/feedback'
 
 type FeedbackFilter = 'all' | FeedbackSubmissionType
+type AdminFeedbackView = 'submissions' | 'builds'
+type BuildFilter = 'active' | FeedbackBuildRunStatus
 
 const typeLabels: Record<FeedbackSubmissionType, string> = {
   bug: 'Bug',
@@ -37,22 +52,94 @@ const statusStyles: Record<AdminFeedbackSubmission['status'], string> = {
   closed: 'border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] text-[var(--text-muted)]',
 }
 
-const formatDateTime = (value: string) =>
-  new Date(value).toLocaleString(undefined, {
+const buildStatusLabels: Record<FeedbackBuildRunStatus, string> = {
+  pending: 'Pending',
+  running: 'Running',
+  ready_for_testing: 'Ready for Testing',
+  failed: 'Failed',
+  approved_to_merge: 'Approved to Merge',
+  merging: 'Merging',
+  merged: 'Merged',
+  archived: 'Archived',
+}
+
+const buildStatusStyles: Record<FeedbackBuildRunStatus, string> = {
+  pending: 'border-[rgba(215,170,70,0.24)] bg-[rgba(215,170,70,0.08)] text-[var(--text-gold)]',
+  running: 'border-[rgba(224,164,62,0.30)] bg-[rgba(224,164,62,0.12)] text-amber-100',
+  ready_for_testing: 'border-[rgba(155,168,142,0.38)] bg-[rgba(118,130,102,0.14)] text-[rgb(218,230,204)]',
+  failed: 'border-[rgba(190,52,85,0.42)] bg-[rgba(87,14,28,0.2)] text-red-100',
+  approved_to_merge: 'border-[rgba(215,170,70,0.34)] bg-[rgba(215,170,70,0.12)] text-[var(--text-gold)]',
+  merging: 'border-[rgba(224,164,62,0.30)] bg-[rgba(224,164,62,0.12)] text-amber-100',
+  merged: 'border-[rgba(155,168,142,0.38)] bg-[rgba(118,130,102,0.14)] text-[rgb(218,230,204)]',
+  archived: 'border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] text-[var(--text-muted)]',
+}
+
+const stageLabels: Record<FeedbackBuildRunStage, string> = {
+  queued: 'Queued',
+  classifying: 'Classifying',
+  reviewing_affected_code: 'Reviewing affected code',
+  debugging_existing_behavior: 'Debugging existing behavior',
+  researching_solution: 'Researching solution',
+  planning: 'Planning',
+  reviewing_plan_against_code: 'Reviewing plan against code',
+  implementing: 'Implementing',
+  testing: 'Testing',
+  branch_pushed: 'Branch pushed',
+  ready_for_testing: 'Ready for testing',
+  approved_to_merge: 'Approved to merge',
+  merging: 'Merging',
+  documenting_cleanup: 'Documenting cleanup',
+  merged: 'Merged',
+  failed: 'Failed',
+  archived: 'Archived',
+}
+
+const activeBuildStatuses = new Set<FeedbackBuildRunStatus>([
+  'pending',
+  'running',
+  'approved_to_merge',
+  'merging',
+])
+
+const formatDateTime = (value: string | null | undefined) => {
+  if (!value) return 'Not set'
+
+  return new Date(value).toLocaleString(undefined, {
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
   })
+}
 
-const getSubmitterName = (submission: AdminFeedbackSubmission) =>
-  submission.user?.display_name || submission.user?.username || 'Unknown user'
+const getSubmitterName = (submission: AdminFeedbackSubmission | null | undefined) =>
+  submission?.user?.display_name || submission?.user?.username || 'Unknown user'
 
-const getSubmitterHandle = (submission: AdminFeedbackSubmission) =>
-  submission.user?.username ? `@${submission.user.username}` : submission.user_id
+const getSubmitterHandle = (submission: AdminFeedbackSubmission | null | undefined) =>
+  submission?.user?.username ? `@${submission.user.username}` : submission?.user_id || 'Unknown user'
 
 const getTypeIcon = (type: FeedbackSubmissionType) =>
   type === 'bug' ? Bug : Lightbulb
+
+const isBuildActive = (run: FeedbackBuildRun) => activeBuildStatuses.has(run.status)
+
+const getBuildPromptPreview = (
+  submission: AdminFeedbackSubmission,
+  companionPrompt: string,
+  includedAttachments: AdminFeedbackAttachmentRecord[],
+  recognitionEnabled: boolean
+) => [
+  'ShadowChat feedback build request',
+  `Submission id: ${submission.id}`,
+  `Submission type: ${submission.submission_type}`,
+  `Title: ${submission.title}`,
+  `Submitter: ${getSubmitterName(submission)}`,
+  `Submitter handle: ${getSubmitterHandle(submission)}`,
+  `Recognition allowed in evening report: ${recognitionEnabled ? 'yes' : 'no'}`,
+  `Included attachment metadata: ${JSON.stringify(includedAttachments.map(({ bucket, path, name, size, type }) => ({ bucket, path, name, size, type })), null, 2)}`,
+  `User submission:\n${submission.description}`,
+  `Admin companion prompt:\n${companionPrompt.trim()}`,
+].join('\n\n')
 
 function TypeBadge({ type }: { type: FeedbackSubmissionType }) {
   const Icon = getTypeIcon(type)
@@ -69,6 +156,14 @@ function StatusBadge({ status }: { status: AdminFeedbackSubmission['status'] }) 
   return (
     <span className={`inline-flex rounded-full border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] ${statusStyles[status]}`}>
       {status}
+    </span>
+  )
+}
+
+function BuildStatusBadge({ status }: { status: FeedbackBuildRunStatus }) {
+  return (
+    <span className={`inline-flex rounded-full border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] ${buildStatusStyles[status]}`}>
+      {buildStatusLabels[status]}
     </span>
   )
 }
@@ -105,14 +200,22 @@ function AttachmentThumbs({ attachments, title }: { attachments: AdminFeedbackAt
 
 function FeedbackDetailModal({
   submission,
+  latestRun,
+  canStartBuild,
+  onStartBuild,
   onClose,
   onDelete,
   deleting,
+  starting,
 }: {
   submission: AdminFeedbackSubmission | null
+  latestRun?: FeedbackBuildRun
+  canStartBuild: boolean
+  onStartBuild: (submission: AdminFeedbackSubmission) => void
   onClose: () => void
   onDelete: (submission: AdminFeedbackSubmission) => void
   deleting: boolean
+  starting: boolean
 }) {
   if (!submission) return null
 
@@ -124,12 +227,26 @@ function FeedbackDetailModal({
             <div className="flex flex-wrap items-center gap-2">
               <TypeBadge type={submission.submission_type} />
               <StatusBadge status={submission.status} />
+              {latestRun && <BuildStatusBadge status={latestRun.status} />}
             </div>
             <h2 className="mt-2 truncate text-base font-semibold text-[var(--text-primary)] sm:text-lg">
               {submission.title}
             </h2>
           </div>
           <div className="flex shrink-0 items-center gap-2">
+            {canStartBuild && (
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                loading={starting}
+                onClick={() => onStartBuild(submission)}
+                aria-label="Start feedback build"
+              >
+                <Rocket className="mr-1.5 h-4 w-4" />
+                Start Build
+              </Button>
+            )}
             <Button
               type="button"
               variant="danger"
@@ -193,52 +310,437 @@ function FeedbackDetailModal({
                 </dl>
               </div>
 
-              <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
-                <div className="mb-3 flex items-center justify-between gap-3">
-                  <h3 className="text-sm font-semibold text-[var(--text-primary)]">Images</h3>
-                  <span className="text-xs uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                    {submission.attachments.length}
+              <ImagesPanel submission={submission} />
+            </aside>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ImagesPanel({ submission }: { submission: AdminFeedbackSubmission }) {
+  return (
+    <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-[var(--text-primary)]">Images</h3>
+        <span className="text-xs uppercase tracking-[0.14em] text-[var(--text-muted)]">
+          {submission.attachments.length}
+        </span>
+      </div>
+
+      {submission.attachments.length === 0 ? (
+        <p className="text-sm text-[var(--text-muted)]">No images attached.</p>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+          {submission.attachments.map((attachment, index) => (
+            attachment.signedUrl ? (
+              <a
+                key={attachment.path}
+                href={attachment.signedUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.035)] transition-colors hover:border-[var(--border-glow)]"
+              >
+                <div className="relative flex max-h-72 min-h-36 items-center justify-center overflow-hidden bg-black/30">
+                  <img
+                    src={attachment.signedUrl}
+                    alt={`${submission.title} attachment ${index + 1}`}
+                    className="max-h-72 w-full object-contain"
+                  />
+                  <span className="absolute right-2 top-2 rounded-full border border-[rgba(255,240,184,0.28)] bg-black/55 p-1 text-[var(--text-gold)] opacity-0 transition-opacity group-hover:opacity-100">
+                    <ExternalLink className="h-3.5 w-3.5" />
                   </span>
                 </div>
+                <p className="truncate px-3 py-2 text-xs text-[var(--text-muted)]">{attachment.name}</p>
+              </a>
+            ) : (
+              <div
+                key={attachment.path}
+                className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-3 text-sm text-[var(--text-muted)]"
+              >
+                <ImageIcon className="mb-2 h-4 w-4" />
+                <p className="break-words">{attachment.name}</p>
+                {attachment.signedUrlError && (
+                  <p className="mt-2 text-xs text-red-200/85">{attachment.signedUrlError}</p>
+                )}
+              </div>
+            )
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
 
+function BuildRunFormModal({
+  submission,
+  previousRun,
+  saving,
+  onClose,
+  onSubmit,
+}: {
+  submission: AdminFeedbackSubmission | null
+  previousRun?: FeedbackBuildRun
+  saving: boolean
+  onClose: () => void
+  onSubmit: (input: {
+    companionPrompt: string
+    includedAttachments: AdminFeedbackAttachmentRecord[]
+    recognitionEnabled: boolean
+  }) => Promise<void>
+}) {
+  const [companionPrompt, setCompanionPrompt] = useState(previousRun?.companion_prompt ?? '')
+  const [recognitionEnabled, setRecognitionEnabled] = useState(previousRun?.recognition_enabled ?? true)
+  const [includedPaths, setIncludedPaths] = useState<Set<string>>(() => {
+    if (!submission) return new Set()
+    if (!previousRun) return new Set(submission.attachments.map(attachment => attachment.path))
+
+    return new Set(previousRun.included_attachments.map(attachment => attachment.path))
+  })
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setCompanionPrompt(previousRun?.companion_prompt ?? '')
+    setRecognitionEnabled(previousRun?.recognition_enabled ?? true)
+    setIncludedPaths(() => {
+      if (!submission) return new Set()
+      if (!previousRun) return new Set(submission.attachments.map(attachment => attachment.path))
+
+      return new Set(previousRun.included_attachments.map(attachment => attachment.path))
+    })
+  }, [previousRun, submission])
+
+  if (!submission) return null
+
+  const includedAttachments = submission.attachments.filter(attachment => includedPaths.has(attachment.path))
+  const promptPreview = getBuildPromptPreview(submission, companionPrompt, includedAttachments, recognitionEnabled)
+
+  const handleToggleAttachment = (path: string) => {
+    setIncludedPaths(current => {
+      const next = new Set(current)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (companionPrompt.trim().length < 20) {
+      setLocalError('Add at least 20 characters of companion prompt context.')
+      return
+    }
+
+    try {
+      setLocalError(null)
+      await onSubmit({
+        companionPrompt,
+        includedAttachments,
+        recognitionEnabled,
+      })
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Unable to send this feedback build to Codex.')
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/75 p-3 backdrop-blur-md sm:p-5" role="dialog" aria-modal="true">
+      <form
+        onSubmit={event => void handleSubmit(event)}
+        className="mx-auto flex h-full max-w-5xl flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-panel)] bg-[linear-gradient(180deg,rgba(20,22,23,0.98),rgba(9,10,11,0.99))] shadow-[0_28px_80px_rgba(0,0,0,0.55)]"
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-[var(--border-panel)] px-4 py-3 sm:px-5">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <TypeBadge type={submission.submission_type} />
+              {previousRun && <BuildStatusBadge status={previousRun.status} />}
+            </div>
+            <h2 className="mt-2 truncate text-base font-semibold text-[var(--text-primary)] sm:text-lg">
+              {previousRun ? 'Retry Feedback Build' : 'Start Feedback Build'}
+            </h2>
+          </div>
+          <Button type="button" variant="ghost" size="sm" onClick={onClose} aria-label="Close feedback build form">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-4 lg:p-6">
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(320px,0.8fr)]">
+            <section className="space-y-4">
+              <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+                <p className="text-xs uppercase tracking-[0.14em] text-[var(--text-muted)]">Submission</p>
+                <h3 className="mt-2 break-words text-lg font-semibold text-[var(--text-primary)]">{submission.title}</h3>
+                <p className="mt-2 line-clamp-4 whitespace-pre-wrap text-sm leading-6 text-[var(--text-secondary)]">
+                  {submission.description}
+                </p>
+              </div>
+
+              <label className="block">
+                <span className="mb-2 block text-sm font-medium text-[var(--text-secondary)]">Companion prompt</span>
+                <textarea
+                  value={companionPrompt}
+                  onChange={event => setCompanionPrompt(event.target.value)}
+                  rows={8}
+                  className="obsidian-input w-full resize-none rounded-[var(--radius-md)] px-3.5 py-3 text-sm leading-6"
+                  placeholder="Add the cleanup, priority, constraints, and exact outcome Codex should use before it begins coding."
+                />
+              </label>
+
+              <label className="flex items-start gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+                <input
+                  type="checkbox"
+                  checked={recognitionEnabled}
+                  onChange={event => setRecognitionEnabled(event.target.checked)}
+                  className="mt-1 h-4 w-4 accent-[var(--text-gold)]"
+                />
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium text-[var(--text-primary)]">Recognize submitter in evening report</span>
+                  <span className="mt-1 block text-xs leading-5 text-[var(--text-muted)]">
+                    Uses only the public display name or username.
+                  </span>
+                </span>
+              </label>
+
+              {localError && (
+                <div className="rounded-[var(--radius-md)] border border-[rgba(190,52,85,0.35)] bg-[rgba(87,14,28,0.18)] p-3 text-sm text-red-100">
+                  {localError}
+                </div>
+              )}
+            </section>
+
+            <aside className="space-y-4">
+              <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <h3 className="text-sm font-semibold text-[var(--text-primary)]">Screenshots</h3>
+                  <span className="text-xs uppercase tracking-[0.14em] text-[var(--text-muted)]">
+                    {includedAttachments.length}/{submission.attachments.length}
+                  </span>
+                </div>
                 {submission.attachments.length === 0 ? (
                   <p className="text-sm text-[var(--text-muted)]">No images attached.</p>
                 ) : (
-                  <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+                  <div className="space-y-2">
                     {submission.attachments.map((attachment, index) => (
-                      attachment.signedUrl ? (
-                        <a
-                          key={attachment.path}
-                          href={attachment.signedUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="group overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.035)] transition-colors hover:border-[var(--border-glow)]"
-                        >
-                          <div className="relative flex max-h-72 min-h-36 items-center justify-center overflow-hidden bg-black/30">
+                      <label
+                        key={attachment.path}
+                        className="flex items-center gap-3 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[rgba(0,0,0,0.18)] p-2.5"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={includedPaths.has(attachment.path)}
+                          onChange={() => handleToggleAttachment(attachment.path)}
+                          className="h-4 w-4 accent-[var(--text-gold)]"
+                        />
+                        <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-[var(--radius-sm)] bg-black/30 text-[var(--text-muted)]">
+                          {attachment.signedUrl ? (
                             <img
                               src={attachment.signedUrl}
-                              alt={`${submission.title} attachment ${index + 1}`}
-                              className="max-h-72 w-full object-contain"
+                              alt={`${submission.title} selectable attachment ${index + 1}`}
+                              className="h-full w-full object-cover"
                             />
-                            <span className="absolute right-2 top-2 rounded-full border border-[rgba(255,240,184,0.28)] bg-black/55 p-1 text-[var(--text-gold)] opacity-0 transition-opacity group-hover:opacity-100">
-                              <ExternalLink className="h-3.5 w-3.5" />
-                            </span>
-                          </div>
-                          <p className="truncate px-3 py-2 text-xs text-[var(--text-muted)]">{attachment.name}</p>
-                        </a>
-                      ) : (
-                        <div
-                          key={attachment.path}
-                          className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-3 text-sm text-[var(--text-muted)]"
-                        >
-                          <ImageIcon className="mb-2 h-4 w-4" />
-                          <p className="break-words">{attachment.name}</p>
-                          {attachment.signedUrlError && (
-                            <p className="mt-2 text-xs text-red-200/85">{attachment.signedUrlError}</p>
+                          ) : (
+                            <ImageIcon className="h-4 w-4" />
                           )}
                         </div>
-                      )
+                        <span className="min-w-0 flex-1 truncate text-sm text-[var(--text-secondary)]">{attachment.name}</span>
+                      </label>
                     ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">Generated prompt</h3>
+                <pre className="mt-3 max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-black/25 p-3 text-xs leading-5 text-[var(--text-muted)]">
+                  {promptPreview}
+                </pre>
+              </div>
+            </aside>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 border-t border-[var(--border-panel)] px-4 py-3 sm:flex-row sm:items-center sm:justify-end sm:px-5">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" loading={saving}>
+            <Send className="mr-1.5 h-4 w-4" />
+            {previousRun ? 'Queue Retry' : 'Send to Codex'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function BuildRunDetailModal({
+  run,
+  submission,
+  logs,
+  saving,
+  onClose,
+  onRetry,
+  onApprove,
+  onArchive,
+}: {
+  run: FeedbackBuildRun | null
+  submission?: AdminFeedbackSubmission
+  logs: FeedbackBuildRunLog[]
+  saving: boolean
+  onClose: () => void
+  onRetry: (run: FeedbackBuildRun) => void
+  onApprove: (run: FeedbackBuildRun) => void
+  onArchive: (run: FeedbackBuildRun) => void
+}) {
+  if (!run) return null
+
+  const includedPaths = new Set(run.included_attachments.map(attachment => attachment.path))
+  const canArchive = !isBuildActive(run) && run.status !== 'archived'
+
+  return (
+    <div className="fixed inset-0 z-[90] bg-black/72 p-3 backdrop-blur-md sm:p-5" role="dialog" aria-modal="true">
+      <div className="mx-auto flex h-full max-w-6xl flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-panel)] bg-[linear-gradient(180deg,rgba(20,22,23,0.98),rgba(9,10,11,0.99))] shadow-[0_28px_80px_rgba(0,0,0,0.55)]">
+        <div className="flex items-center justify-between gap-3 border-b border-[var(--border-panel)] px-4 py-3 sm:px-5">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <BuildStatusBadge status={run.status} />
+              <span className="rounded-full border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
+                {stageLabels[run.current_stage]}
+              </span>
+            </div>
+            <h2 className="mt-2 truncate text-base font-semibold text-[var(--text-primary)] sm:text-lg">
+              {submission?.title || `Feedback build ${run.id.slice(0, 8)}`}
+            </h2>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {run.status === 'failed' && (
+              <Button type="button" variant="secondary" size="sm" loading={saving} onClick={() => onRetry(run)}>
+                <Rocket className="mr-1.5 h-4 w-4" />
+                Retry
+              </Button>
+            )}
+            {run.status === 'ready_for_testing' && run.pr_url && (
+              <Button type="button" variant="primary" size="sm" loading={saving} onClick={() => onApprove(run)}>
+                <CheckCircle2 className="mr-1.5 h-4 w-4" />
+                Approve & Merge
+              </Button>
+            )}
+            {canArchive && (
+              <Button type="button" variant="ghost" size="sm" loading={saving} onClick={() => onArchive(run)}>
+                <Archive className="mr-1.5 h-4 w-4" />
+                Archive
+              </Button>
+            )}
+            <Button type="button" variant="ghost" size="sm" onClick={onClose} aria-label="Close feedback build run">
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-4 lg:p-6">
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(320px,0.75fr)]">
+            <section className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <BuildLinkCard icon={GitBranch} label="Branch" value={run.branch_name || 'Not pushed yet'} />
+                <BuildLinkCard icon={ExternalLink} label="Pull request" value={run.pr_url || 'Not created yet'} href={run.pr_url || undefined} />
+                <BuildLinkCard icon={ExternalLink} label="Netlify preview" value={run.preview_url || 'Waiting for preview'} href={run.preview_url || undefined} />
+                <BuildLinkCard icon={Clock} label="Created" value={formatDateTime(run.created_at)} />
+              </div>
+
+              {run.preview_warning && (
+                <div className="flex gap-3 rounded-[var(--radius-md)] border border-[rgba(224,164,62,0.3)] bg-[rgba(224,164,62,0.1)] p-4 text-sm text-amber-100">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>{run.preview_warning}</p>
+                </div>
+              )}
+
+              {run.failure_message && (
+                <div className="flex gap-3 rounded-[var(--radius-md)] border border-[rgba(190,52,85,0.35)] bg-[rgba(87,14,28,0.18)] p-4 text-sm text-red-100">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>{run.failure_message}</p>
+                </div>
+              )}
+
+              {run.summary && (
+                <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+                  <h3 className="text-sm font-semibold text-[var(--text-primary)]">Summary</h3>
+                  <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-[var(--text-secondary)]">{run.summary}</p>
+                </div>
+              )}
+
+              <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+                <h3 className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)]">
+                  <ListChecks className="h-4 w-4 text-[var(--text-gold)]" />
+                  Stage notes
+                </h3>
+                {logs.length === 0 ? (
+                  <p className="mt-3 text-sm text-[var(--text-muted)]">No stage notes recorded yet.</p>
+                ) : (
+                  <ol className="mt-4 space-y-3">
+                    {logs.map(log => (
+                      <li key={log.id} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[rgba(0,0,0,0.18)] p-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="rounded-full border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--text-gold)]">
+                            {stageLabels[log.stage]}
+                          </span>
+                          <span className="text-xs text-[var(--text-muted)]">{formatDateTime(log.created_at)}</span>
+                        </div>
+                        <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-[var(--text-secondary)]">{log.message}</p>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+            </section>
+
+            <aside className="space-y-4">
+              <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">Generated prompt</h3>
+                <pre className="mt-3 max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-black/25 p-3 text-xs leading-5 text-[var(--text-muted)]">
+                  {run.generated_prompt}
+                </pre>
+              </div>
+
+              <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">Screenshots</h3>
+                {!submission || submission.attachments.length === 0 ? (
+                  <p className="mt-3 text-sm text-[var(--text-muted)]">No images attached.</p>
+                ) : (
+                  <div className="mt-3 space-y-2">
+                    {submission.attachments.map((attachment, index) => {
+                      const included = includedPaths.has(attachment.path)
+
+                      return (
+                        <div
+                          key={attachment.path}
+                          className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[rgba(0,0,0,0.18)] p-2.5"
+                        >
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-[var(--radius-sm)] bg-black/30 text-[var(--text-muted)]">
+                              {attachment.signedUrl ? (
+                                <img
+                                  src={attachment.signedUrl}
+                                  alt={`${submission.title} build attachment ${index + 1}`}
+                                  className="h-full w-full object-cover"
+                                />
+                              ) : (
+                                <ImageIcon className="h-4 w-4" />
+                              )}
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <p className="truncate text-sm text-[var(--text-secondary)]">{attachment.name}</p>
+                              <p className={included ? 'text-xs text-[var(--text-gold)]' : 'text-xs text-[var(--text-muted)]'}>
+                                {included ? 'Included' : 'Excluded'}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      )
+                    })}
                   </div>
                 )}
               </div>
@@ -250,11 +752,147 @@ function FeedbackDetailModal({
   )
 }
 
+function BuildLinkCard({
+  icon: Icon,
+  label,
+  value,
+  href,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: string
+  href?: string
+}) {
+  const content = (
+    <>
+      <Icon className="h-4 w-4 shrink-0 text-[var(--text-gold)]" />
+      <span className="min-w-0">
+        <span className="block text-xs uppercase tracking-[0.14em] text-[var(--text-muted)]">{label}</span>
+        <span className="mt-1 block truncate text-sm text-[var(--text-secondary)]">{value}</span>
+      </span>
+    </>
+  )
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex min-w-0 items-center gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-3 transition-colors hover:border-[var(--border-glow)]"
+      >
+        {content}
+      </a>
+    )
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-3">
+      {content}
+    </div>
+  )
+}
+
+function ApproveMergeModal({
+  run,
+  saving,
+  onCancel,
+  onConfirm,
+}: {
+  run: FeedbackBuildRun | null
+  saving: boolean
+  onCancel: () => void
+  onConfirm: (run: FeedbackBuildRun) => Promise<void>
+}) {
+  if (!run) return null
+
+  return (
+    <div className="fixed inset-0 z-[110] bg-black/75 p-4 backdrop-blur-md" role="dialog" aria-modal="true">
+      <div className="mx-auto mt-24 max-w-lg rounded-[var(--radius-lg)] border border-[var(--border-panel)] bg-[linear-gradient(180deg,rgba(20,22,23,0.98),rgba(9,10,11,0.99))] p-5 shadow-[0_28px_80px_rgba(0,0,0,0.55)]">
+        <h2 className="text-lg font-semibold text-[var(--text-primary)]">Approve merge?</h2>
+        <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">
+          Codex will rerun the gates, squash merge to main, document the result, close the feedback submission, and clean up the branch.
+        </p>
+        <div className="mt-4 space-y-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-3 text-sm">
+          <p className="break-words text-[var(--text-secondary)]">PR: {run.pr_url}</p>
+          <p className="break-words text-[var(--text-secondary)]">Preview: {run.preview_url || 'No preview URL recorded'}</p>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="button" variant="primary" loading={saving} onClick={() => void onConfirm(run)}>
+            <CheckCircle2 className="mr-1.5 h-4 w-4" />
+            Approve
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function AdminFeedbackReview() {
-  const { submissions, loading, error, deletingId, deleteSubmission } = useAdminFeedback()
+  const { isAdmin } = useAdminAccess()
+  const {
+    submissions,
+    loading,
+    error,
+    deletingId,
+    buildRuns,
+    buildLogsByRunId,
+    buildLoading,
+    buildError,
+    activeBuildActionId,
+    refreshBuildRuns,
+    deleteSubmission,
+    startBuildRun,
+    retryBuildRun,
+    approveMerge,
+    archiveBuildRun,
+  } = useAdminFeedback({ buildsEnabled: isAdmin })
   const [selectedSubmission, setSelectedSubmission] = useState<AdminFeedbackSubmission | null>(null)
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+  const [buildDraftSubmission, setBuildDraftSubmission] = useState<AdminFeedbackSubmission | null>(null)
+  const [retryRun, setRetryRun] = useState<FeedbackBuildRun | undefined>()
+  const [approveRun, setApproveRun] = useState<FeedbackBuildRun | null>(null)
+  const [view, setView] = useState<AdminFeedbackView>('submissions')
   const [filter, setFilter] = useState<FeedbackFilter>('all')
+  const [buildFilter, setBuildFilter] = useState<BuildFilter>('active')
   const [searchTerm, setSearchTerm] = useState('')
+  const [buildSearchTerm, setBuildSearchTerm] = useState('')
+
+  const submissionsById = useMemo(() => {
+    return submissions.reduce<Record<string, AdminFeedbackSubmission>>((acc, submission) => {
+      acc[submission.id] = submission
+      return acc
+    }, {})
+  }, [submissions])
+
+  const latestRunBySubmissionId = useMemo(() => {
+    return buildRuns.reduce<Record<string, FeedbackBuildRun>>((acc, run) => {
+      const current = acc[run.feedback_submission_id]
+      if (!current || new Date(run.created_at).getTime() > new Date(current.created_at).getTime()) {
+        acc[run.feedback_submission_id] = run
+      }
+      return acc
+    }, {})
+  }, [buildRuns])
+
+  useEffect(() => {
+    if (!isAdmin || !buildRuns.some(isBuildActive)) return undefined
+
+    const interval = window.setInterval(() => {
+      void refreshBuildRuns()
+    }, 30_000)
+
+    return () => window.clearInterval(interval)
+  }, [buildRuns, isAdmin, refreshBuildRuns])
+
+  useEffect(() => {
+    if (!isAdmin && view === 'builds') {
+      setView('submissions')
+    }
+  }, [isAdmin, view])
 
   const handleDeleteSubmission = async (submission: AdminFeedbackSubmission) => {
     const confirmed = window.confirm(`Delete "${submission.title}"? This removes the submission and any attached images.`)
@@ -270,8 +908,16 @@ export function AdminFeedbackReview() {
 
   const filteredSubmissions = useMemo(() => {
     const normalizedSearch = searchTerm.trim().toLowerCase()
+    const sentSubmissionIds = new Set(
+      isAdmin
+        ? buildRuns
+          .filter(run => run.status !== 'archived')
+          .map(run => run.feedback_submission_id)
+        : []
+    )
 
     return submissions.filter(submission => {
+      if (isAdmin && sentSubmissionIds.has(submission.id)) return false
       if (filter !== 'all' && submission.submission_type !== filter) return false
       if (!normalizedSearch) return true
 
@@ -282,7 +928,85 @@ export function AdminFeedbackReview() {
         getSubmitterHandle(submission).toLowerCase().includes(normalizedSearch)
       )
     })
-  }, [filter, searchTerm, submissions])
+  }, [buildRuns, filter, isAdmin, searchTerm, submissions])
+
+  const filteredBuildRuns = useMemo(() => {
+    const normalizedSearch = buildSearchTerm.trim().toLowerCase()
+
+    return buildRuns.filter(run => {
+      if (buildFilter === 'active') {
+        if (run.status === 'archived' || run.status === 'merged') return false
+      } else if (run.status !== buildFilter) {
+        return false
+      }
+
+      if (!normalizedSearch) return true
+      const submission = submissionsById[run.feedback_submission_id]
+
+      return (
+        run.id.toLowerCase().includes(normalizedSearch) ||
+        run.branch_name?.toLowerCase().includes(normalizedSearch) ||
+        submission?.title.toLowerCase().includes(normalizedSearch) ||
+        getSubmitterName(submission).toLowerCase().includes(normalizedSearch) ||
+        getSubmitterHandle(submission).toLowerCase().includes(normalizedSearch)
+      )
+    })
+  }, [buildFilter, buildRuns, buildSearchTerm, submissionsById])
+
+  const selectedRun = selectedRunId ? buildRuns.find(run => run.id === selectedRunId) ?? null : null
+  const selectedRunSubmission = selectedRun ? submissionsById[selectedRun.feedback_submission_id] : undefined
+
+  const openStartBuild = (submission: AdminFeedbackSubmission) => {
+    setRetryRun(undefined)
+    setBuildDraftSubmission(submission)
+  }
+
+  const openRetryBuild = (run: FeedbackBuildRun) => {
+    setRetryRun(run)
+    setBuildDraftSubmission(submissionsById[run.feedback_submission_id] ?? null)
+  }
+
+  const handleBuildSubmit = async (input: {
+    companionPrompt: string
+    includedAttachments: AdminFeedbackAttachmentRecord[]
+    recognitionEnabled: boolean
+  }) => {
+    if (!buildDraftSubmission) return
+
+    if (retryRun) {
+      await retryBuildRun({
+        previousRunId: retryRun.id,
+        companionPrompt: input.companionPrompt,
+        includedAttachments: input.includedAttachments,
+        recognitionEnabled: input.recognitionEnabled,
+      })
+    } else {
+      await startBuildRun({
+        feedbackSubmissionId: buildDraftSubmission.id,
+        companionPrompt: input.companionPrompt,
+        includedAttachments: input.includedAttachments,
+        recognitionEnabled: input.recognitionEnabled,
+      })
+    }
+
+    setBuildDraftSubmission(null)
+    setRetryRun(undefined)
+    setSelectedSubmission(null)
+    setView('builds')
+  }
+
+  const handleApproveMerge = async (run: FeedbackBuildRun) => {
+    await approveMerge(run.id)
+    setApproveRun(null)
+    setSelectedRunId(run.id)
+  }
+
+  const handleArchiveRun = async (run: FeedbackBuildRun) => {
+    const confirmed = window.confirm(`Archive feedback build ${run.id.slice(0, 8)}?`)
+    if (!confirmed) return
+
+    await archiveBuildRun(run.id)
+  }
 
   return (
     <div className="glass-panel rounded-[var(--radius-lg)] p-5">
@@ -292,12 +1016,134 @@ export function AdminFeedbackReview() {
           <div>
             <h2 className="text-lg font-semibold text-[var(--text-primary)]">Feedback Review</h2>
             <p className="mt-1 text-sm text-[var(--text-muted)]">
-              Submitted bugs, suggestions, and screenshots.
+              Submitted bugs, suggestions, screenshots, and admin-only build runs.
             </p>
           </div>
         </div>
+
+        {isAdmin && (
+          <div className="flex rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(0,0,0,0.2)] p-1">
+            <button
+              type="button"
+              onClick={() => setView('submissions')}
+              className={`rounded-[var(--radius-sm)] px-3 py-2 text-xs font-medium transition-colors ${
+                view === 'submissions'
+                  ? 'bg-[rgba(215,170,70,0.14)] text-[var(--text-gold)]'
+                  : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+              }`}
+            >
+              Submissions
+            </button>
+            <button
+              type="button"
+              onClick={() => setView('builds')}
+              className={`rounded-[var(--radius-sm)] px-3 py-2 text-xs font-medium transition-colors ${
+                view === 'builds'
+                  ? 'bg-[rgba(215,170,70,0.14)] text-[var(--text-gold)]'
+                  : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+              }`}
+            >
+              Feedback Builds
+            </button>
+          </div>
+        )}
       </div>
 
+      {view === 'submissions' ? (
+        <SubmissionList
+          submissions={filteredSubmissions}
+          loading={loading}
+          error={error}
+          filter={filter}
+          searchTerm={searchTerm}
+          isAdmin={isAdmin}
+          latestRunBySubmissionId={latestRunBySubmissionId}
+          onFilterChange={setFilter}
+          onSearchChange={setSearchTerm}
+          onSelectSubmission={setSelectedSubmission}
+        />
+      ) : (
+        <BuildRunList
+          runs={filteredBuildRuns}
+          loading={buildLoading}
+          error={buildError}
+          filter={buildFilter}
+          searchTerm={buildSearchTerm}
+          submissionsById={submissionsById}
+          onFilterChange={setBuildFilter}
+          onSearchChange={setBuildSearchTerm}
+          onSelectRun={run => setSelectedRunId(run.id)}
+        />
+      )}
+
+      <FeedbackDetailModal
+        submission={selectedSubmission}
+        latestRun={selectedSubmission ? latestRunBySubmissionId[selectedSubmission.id] : undefined}
+        canStartBuild={isAdmin && Boolean(selectedSubmission)}
+        onStartBuild={openStartBuild}
+        onClose={() => setSelectedSubmission(null)}
+        onDelete={(submission) => void handleDeleteSubmission(submission)}
+        deleting={Boolean(selectedSubmission && deletingId === selectedSubmission.id)}
+        starting={Boolean(selectedSubmission && activeBuildActionId === selectedSubmission.id)}
+      />
+
+      <BuildRunFormModal
+        submission={buildDraftSubmission}
+        previousRun={retryRun}
+        saving={Boolean(activeBuildActionId)}
+        onClose={() => {
+          setBuildDraftSubmission(null)
+          setRetryRun(undefined)
+        }}
+        onSubmit={handleBuildSubmit}
+      />
+
+      <BuildRunDetailModal
+        run={selectedRun}
+        submission={selectedRunSubmission}
+        logs={selectedRun ? buildLogsByRunId[selectedRun.id] ?? [] : []}
+        saving={Boolean(selectedRun && activeBuildActionId === selectedRun.id)}
+        onClose={() => setSelectedRunId(null)}
+        onRetry={openRetryBuild}
+        onApprove={setApproveRun}
+        onArchive={(run) => void handleArchiveRun(run)}
+      />
+
+      <ApproveMergeModal
+        run={approveRun}
+        saving={Boolean(approveRun && activeBuildActionId === approveRun.id)}
+        onCancel={() => setApproveRun(null)}
+        onConfirm={handleApproveMerge}
+      />
+    </div>
+  )
+}
+
+function SubmissionList({
+  submissions,
+  loading,
+  error,
+  filter,
+  searchTerm,
+  isAdmin,
+  latestRunBySubmissionId,
+  onFilterChange,
+  onSearchChange,
+  onSelectSubmission,
+}: {
+  submissions: AdminFeedbackSubmission[]
+  loading: boolean
+  error: string | null
+  filter: FeedbackFilter
+  searchTerm: string
+  isAdmin: boolean
+  latestRunBySubmissionId: Record<string, FeedbackBuildRun>
+  onFilterChange: (filter: FeedbackFilter) => void
+  onSearchChange: (value: string) => void
+  onSelectSubmission: (submission: AdminFeedbackSubmission) => void
+}) {
+  return (
+    <>
       <div className="mb-4 grid gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4 lg:grid-cols-[1fr_auto] lg:items-center">
         <label className="min-w-0">
           <span className="sr-only">Search feedback</span>
@@ -305,7 +1151,7 @@ export function AdminFeedbackReview() {
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-muted)]" />
             <input
               value={searchTerm}
-              onChange={event => setSearchTerm(event.target.value)}
+              onChange={event => onSearchChange(event.target.value)}
               placeholder="Search title, description, or submitter"
               className="obsidian-input w-full rounded-[var(--radius-md)] py-3 pl-9 pr-3.5 text-sm"
             />
@@ -321,7 +1167,7 @@ export function AdminFeedbackReview() {
             <button
               key={id}
               type="button"
-              onClick={() => setFilter(id as FeedbackFilter)}
+              onClick={() => onFilterChange(id as FeedbackFilter)}
               className={`rounded-[var(--radius-sm)] px-3 py-2 text-xs font-medium transition-colors ${
                 filter === id
                   ? 'bg-[rgba(215,170,70,0.14)] text-[var(--text-gold)]'
@@ -342,64 +1188,193 @@ export function AdminFeedbackReview() {
         <div className="rounded-[var(--radius-md)] border border-[rgba(190,52,85,0.35)] bg-[rgba(87,14,28,0.18)] p-4 text-sm text-red-100">
           {error}
         </div>
-      ) : filteredSubmissions.length === 0 ? (
+      ) : submissions.length === 0 ? (
         <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-5 text-center text-sm text-[var(--text-muted)]">
           No feedback submissions found.
         </div>
       ) : (
         <div className="space-y-3">
-          {filteredSubmissions.map(submission => (
-            <button
-              key={submission.id}
-              type="button"
-              onClick={() => setSelectedSubmission(submission)}
-              className="group w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4 text-left transition-all hover:-translate-y-0.5 hover:border-[var(--border-glow)] hover:bg-[rgba(255,255,255,0.05)]"
-            >
-              <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <TypeBadge type={submission.submission_type} />
-                    <StatusBadge status={submission.status} />
-                    <span className="text-xs text-[var(--text-muted)]">{formatDateTime(submission.created_at)}</span>
-                  </div>
-                  <h3 className="mt-3 break-words text-base font-semibold text-[var(--text-primary)]">
-                    {submission.title}
-                  </h3>
-                  <p className="mt-2 line-clamp-3 break-words text-sm leading-6 text-[var(--text-muted)]">
-                    {submission.description}
-                  </p>
-                  <AttachmentThumbs attachments={submission.attachments} title={submission.title} />
-                </div>
+          {submissions.map(submission => {
+            const latestRun = latestRunBySubmissionId[submission.id]
 
-                <div className="flex min-w-0 items-center gap-3 lg:min-w-52 lg:justify-end">
-                  <Avatar
-                    src={submission.user?.avatar_url}
-                    alt={getSubmitterName(submission)}
-                    fallback={getSubmitterName(submission).slice(0, 2)}
-                    size="sm"
-                    status={submission.user?.status}
-                    userId={submission.user?.id}
-                    presenceVisibility={submission.user?.presence_visibility}
-                    color={submission.user?.color}
-                    showStatus
-                  />
+            return (
+              <button
+                key={submission.id}
+                type="button"
+                onClick={() => onSelectSubmission(submission)}
+                className="group w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4 text-left transition-all hover:-translate-y-0.5 hover:border-[var(--border-glow)] hover:bg-[rgba(255,255,255,0.05)]"
+              >
+                <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-medium text-[var(--text-primary)]">{getSubmitterName(submission)}</p>
-                    <p className="truncate text-xs text-[var(--text-muted)]">{getSubmitterHandle(submission)}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <TypeBadge type={submission.submission_type} />
+                      <StatusBadge status={submission.status} />
+                      {isAdmin && latestRun && <BuildStatusBadge status={latestRun.status} />}
+                      <span className="text-xs text-[var(--text-muted)]">{formatDateTime(submission.created_at)}</span>
+                    </div>
+                    <h3 className="mt-3 break-words text-base font-semibold text-[var(--text-primary)]">
+                      {submission.title}
+                    </h3>
+                    <p className="mt-2 line-clamp-3 break-words text-sm leading-6 text-[var(--text-muted)]">
+                      {submission.description}
+                    </p>
+                    <AttachmentThumbs attachments={submission.attachments} title={submission.title} />
                   </div>
+
+                  <SubmitterBlock submission={submission} />
                 </div>
-              </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </>
+  )
+}
+
+function BuildRunList({
+  runs,
+  loading,
+  error,
+  filter,
+  searchTerm,
+  submissionsById,
+  onFilterChange,
+  onSearchChange,
+  onSelectRun,
+}: {
+  runs: FeedbackBuildRun[]
+  loading: boolean
+  error: string | null
+  filter: BuildFilter
+  searchTerm: string
+  submissionsById: Record<string, AdminFeedbackSubmission>
+  onFilterChange: (filter: BuildFilter) => void
+  onSearchChange: (value: string) => void
+  onSelectRun: (run: FeedbackBuildRun) => void
+}) {
+  return (
+    <>
+      <div className="mb-4 grid gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4 lg:grid-cols-[1fr_auto] lg:items-center">
+        <label className="min-w-0">
+          <span className="sr-only">Search feedback builds</span>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-muted)]" />
+            <input
+              value={searchTerm}
+              onChange={event => onSearchChange(event.target.value)}
+              placeholder="Search build runs, branch, title, or submitter"
+              className="obsidian-input w-full rounded-[var(--radius-md)] py-3 pl-9 pr-3.5 text-sm"
+            />
+          </div>
+        </label>
+
+        <div className="flex flex-wrap rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(0,0,0,0.2)] p-1">
+          {[
+            ['active', 'Active'],
+            ['pending', 'Pending'],
+            ['running', 'Running'],
+            ['ready_for_testing', 'Ready'],
+            ['failed', 'Failed'],
+            ['merged', 'Merged'],
+            ['archived', 'Archived'],
+          ].map(([id, label]) => (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onFilterChange(id as BuildFilter)}
+              className={`rounded-[var(--radius-sm)] px-3 py-2 text-xs font-medium transition-colors ${
+                filter === id
+                  ? 'bg-[rgba(215,170,70,0.14)] text-[var(--text-gold)]'
+                  : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+              }`}
+            >
+              {label}
             </button>
           ))}
         </div>
-      )}
+      </div>
 
-      <FeedbackDetailModal
-        submission={selectedSubmission}
-        onClose={() => setSelectedSubmission(null)}
-        onDelete={(submission) => void handleDeleteSubmission(submission)}
-        deleting={Boolean(selectedSubmission && deletingId === selectedSubmission.id)}
+      {loading ? (
+        <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4 text-sm text-[var(--text-muted)]">
+          Loading feedback build runs.
+        </div>
+      ) : error ? (
+        <div className="rounded-[var(--radius-md)] border border-[rgba(190,52,85,0.35)] bg-[rgba(87,14,28,0.18)] p-4 text-sm text-red-100">
+          {error}
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-5 text-center text-sm text-[var(--text-muted)]">
+          No feedback build runs found.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {runs.map(run => {
+            const submission = submissionsById[run.feedback_submission_id]
+
+            return (
+              <button
+                key={run.id}
+                type="button"
+                onClick={() => onSelectRun(run)}
+                className="group w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] p-4 text-left transition-all hover:-translate-y-0.5 hover:border-[var(--border-glow)] hover:bg-[rgba(255,255,255,0.05)]"
+              >
+                <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <BuildStatusBadge status={run.status} />
+                      <span className="rounded-full border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.03)] px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
+                        {stageLabels[run.current_stage]}
+                      </span>
+                      <span className="text-xs text-[var(--text-muted)]">{formatDateTime(run.created_at)}</span>
+                    </div>
+                    <h3 className="mt-3 break-words text-base font-semibold text-[var(--text-primary)]">
+                      {submission?.title || `Feedback build ${run.id.slice(0, 8)}`}
+                    </h3>
+                    <p className="mt-2 line-clamp-2 break-words text-sm leading-6 text-[var(--text-muted)]">
+                      {run.summary || run.failure_message || run.branch_name || 'Waiting for the Codex processor.'}
+                    </p>
+                    {run.preview_warning && (
+                      <p className="mt-2 flex items-center gap-1.5 text-xs text-amber-100">
+                        <AlertTriangle className="h-3.5 w-3.5" />
+                        {run.preview_warning}
+                      </p>
+                    )}
+                  </div>
+
+                  {submission ? (
+                    <SubmitterBlock submission={submission} />
+                  ) : (
+                    <div className="text-sm text-[var(--text-muted)] lg:min-w-52 lg:text-right">Submission unavailable</div>
+                  )}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </>
+  )
+}
+
+function SubmitterBlock({ submission }: { submission: AdminFeedbackSubmission }) {
+  return (
+    <div className="flex min-w-0 items-center gap-3 lg:min-w-52 lg:justify-end">
+      <Avatar
+        src={submission.user?.avatar_url}
+        alt={getSubmitterName(submission)}
+        fallback={getSubmitterName(submission).slice(0, 2)}
+        size="sm"
+        status={submission.user?.status}
+        userId={submission.user?.id}
+        presenceVisibility={submission.user?.presence_visibility}
+        color={submission.user?.color}
+        showStatus
       />
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-[var(--text-primary)]">{getSubmitterName(submission)}</p>
+        <p className="truncate text-xs text-[var(--text-muted)]">{getSubmitterHandle(submission)}</p>
+      </div>
     </div>
   )
 }

--- a/src/hooks/useAdminFeedback.ts
+++ b/src/hooks/useAdminFeedback.ts
@@ -1,20 +1,36 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
+  approveFeedbackBuildMerge,
+  archiveFeedbackBuildRun,
+  createFeedbackBuildRun,
   deleteAdminFeedbackSubmission,
   fetchAdminFeedbackSubmissions,
+  fetchFeedbackBuildRunLogs,
+  fetchFeedbackBuildRuns,
+  retryFeedbackBuildRun,
   type AdminFeedbackSubmission,
+  type FeedbackBuildRetryInput,
+  type FeedbackBuildRun,
+  type FeedbackBuildRunInput,
+  type FeedbackBuildRunLog,
 } from '../lib/feedback'
 
 type UseAdminFeedbackOptions = {
   enabled?: boolean
+  buildsEnabled?: boolean
 }
 
 export function useAdminFeedback(options: UseAdminFeedbackOptions = {}) {
-  const { enabled = true } = options
+  const { enabled = true, buildsEnabled = enabled } = options
   const [submissions, setSubmissions] = useState<AdminFeedbackSubmission[]>([])
   const [loading, setLoading] = useState(enabled)
   const [error, setError] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [buildRuns, setBuildRuns] = useState<FeedbackBuildRun[]>([])
+  const [buildLogsByRunId, setBuildLogsByRunId] = useState<Record<string, FeedbackBuildRunLog[]>>({})
+  const [buildLoading, setBuildLoading] = useState(buildsEnabled)
+  const [buildError, setBuildError] = useState<string | null>(null)
+  const [activeBuildActionId, setActiveBuildActionId] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
     if (!enabled) {
@@ -40,6 +56,38 @@ export function useAdminFeedback(options: UseAdminFeedbackOptions = {}) {
     void refresh()
   }, [refresh])
 
+  const refreshBuildRuns = useCallback(async () => {
+    if (!buildsEnabled) {
+      setBuildRuns([])
+      setBuildLogsByRunId({})
+      setBuildLoading(false)
+      setBuildError(null)
+      return
+    }
+
+    setBuildLoading(true)
+    try {
+      const nextRuns = await fetchFeedbackBuildRuns()
+      const nextLogs = await fetchFeedbackBuildRunLogs(nextRuns.map(run => run.id))
+      const nextLogsByRunId = nextLogs.reduce<Record<string, FeedbackBuildRunLog[]>>((acc, log) => {
+        acc[log.run_id] = [...(acc[log.run_id] ?? []), log]
+        return acc
+      }, {})
+
+      setBuildRuns(nextRuns)
+      setBuildLogsByRunId(nextLogsByRunId)
+      setBuildError(null)
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : 'Unable to load feedback build runs')
+    } finally {
+      setBuildLoading(false)
+    }
+  }, [buildsEnabled])
+
+  useEffect(() => {
+    void refreshBuildRuns()
+  }, [refreshBuildRuns])
+
   const deleteSubmission = useCallback(async (submission: AdminFeedbackSubmission) => {
     setDeletingId(submission.id)
     try {
@@ -54,12 +102,82 @@ export function useAdminFeedback(options: UseAdminFeedbackOptions = {}) {
     }
   }, [])
 
+  const startBuildRun = useCallback(async (input: FeedbackBuildRunInput) => {
+    setActiveBuildActionId(input.feedbackSubmissionId)
+    try {
+      const nextRun = await createFeedbackBuildRun(input)
+      setBuildRuns(current => [nextRun, ...current.filter(run => run.id !== nextRun.id)])
+      await Promise.all([refresh(), refreshBuildRuns()])
+      return nextRun
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : 'Unable to start feedback build run')
+      throw err
+    } finally {
+      setActiveBuildActionId(null)
+    }
+  }, [refresh, refreshBuildRuns])
+
+  const retryBuildRun = useCallback(async (input: FeedbackBuildRetryInput) => {
+    setActiveBuildActionId(input.previousRunId)
+    try {
+      const nextRun = await retryFeedbackBuildRun(input)
+      setBuildRuns(current => [nextRun, ...current.filter(run => run.id !== nextRun.id)])
+      await refreshBuildRuns()
+      return nextRun
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : 'Unable to retry feedback build run')
+      throw err
+    } finally {
+      setActiveBuildActionId(null)
+    }
+  }, [refreshBuildRuns])
+
+  const approveMerge = useCallback(async (runId: string) => {
+    setActiveBuildActionId(runId)
+    try {
+      const nextRun = await approveFeedbackBuildMerge(runId)
+      setBuildRuns(current => current.map(run => run.id === nextRun.id ? nextRun : run))
+      await refreshBuildRuns()
+      return nextRun
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : 'Unable to approve feedback build merge')
+      throw err
+    } finally {
+      setActiveBuildActionId(null)
+    }
+  }, [refreshBuildRuns])
+
+  const archiveBuildRun = useCallback(async (runId: string) => {
+    setActiveBuildActionId(runId)
+    try {
+      const nextRun = await archiveFeedbackBuildRun(runId)
+      setBuildRuns(current => current.map(run => run.id === nextRun.id ? nextRun : run))
+      await refreshBuildRuns()
+      return nextRun
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : 'Unable to archive feedback build run')
+      throw err
+    } finally {
+      setActiveBuildActionId(null)
+    }
+  }, [refreshBuildRuns])
+
   return {
     submissions,
     loading,
     error,
     deletingId,
+    buildRuns,
+    buildLogsByRunId,
+    buildLoading,
+    buildError,
+    activeBuildActionId,
     refresh,
+    refreshBuildRuns,
     deleteSubmission,
+    startBuildRun,
+    retryBuildRun,
+    approveMerge,
+    archiveBuildRun,
   }
 }

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -7,6 +7,34 @@ export const FEEDBACK_ATTACHMENT_SIGNED_URL_SECONDS = 30 * 60
 
 export type FeedbackSubmissionType = 'bug' | 'feature'
 export type FeedbackSubmissionStatus = 'new' | 'reviewing' | 'planned' | 'closed'
+export type FeedbackBuildRunStatus =
+  | 'pending'
+  | 'running'
+  | 'ready_for_testing'
+  | 'failed'
+  | 'approved_to_merge'
+  | 'merging'
+  | 'merged'
+  | 'archived'
+
+export type FeedbackBuildRunStage =
+  | 'queued'
+  | 'classifying'
+  | 'reviewing_affected_code'
+  | 'debugging_existing_behavior'
+  | 'researching_solution'
+  | 'planning'
+  | 'reviewing_plan_against_code'
+  | 'implementing'
+  | 'testing'
+  | 'branch_pushed'
+  | 'ready_for_testing'
+  | 'approved_to_merge'
+  | 'merging'
+  | 'documenting_cleanup'
+  | 'merged'
+  | 'failed'
+  | 'archived'
 
 export interface FeedbackAttachmentRecord {
   bucket: typeof FEEDBACK_ATTACHMENTS_BUCKET
@@ -59,8 +87,66 @@ export interface AdminFeedbackSubmission {
   user?: FeedbackSubmitter | null
 }
 
+export interface FeedbackBuildRun {
+  id: string
+  feedback_submission_id: string
+  created_by: string
+  companion_prompt: string
+  generated_prompt: string
+  included_attachments: AdminFeedbackAttachmentRecord[]
+  recognition_enabled: boolean
+  status: FeedbackBuildRunStatus
+  current_stage: FeedbackBuildRunStage
+  branch_name?: string | null
+  pr_url?: string | null
+  preview_url?: string | null
+  preview_warning?: string | null
+  summary?: string | null
+  merge_commit_sha?: string | null
+  failure_message?: string | null
+  approved_merge_at?: string | null
+  approved_merge_by?: string | null
+  archived_at?: string | null
+  archived_by?: string | null
+  started_at?: string | null
+  completed_at?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface FeedbackBuildRunLog {
+  id: string
+  run_id: string
+  stage: FeedbackBuildRunStage
+  message: string
+  metadata: Record<string, unknown>
+  created_at: string
+}
+
+export interface FeedbackBuildRunInput {
+  feedbackSubmissionId: string
+  companionPrompt: string
+  includedAttachments: AdminFeedbackAttachmentRecord[]
+  recognitionEnabled: boolean
+}
+
+export interface FeedbackBuildRetryInput {
+  previousRunId: string
+  companionPrompt: string
+  includedAttachments: AdminFeedbackAttachmentRecord[]
+  recognitionEnabled: boolean
+}
+
 type FeedbackSubmissionRow = Omit<AdminFeedbackSubmission, 'attachments' | 'user'> & {
   attachments: unknown
+}
+
+type FeedbackBuildRunRow = Omit<FeedbackBuildRun, 'included_attachments'> & {
+  included_attachments: unknown
+}
+
+type FeedbackBuildRunLogRow = Omit<FeedbackBuildRunLog, 'metadata'> & {
+  metadata: unknown
 }
 
 const titleMinLength = 3
@@ -112,6 +198,33 @@ const normalizeFeedbackAttachments = (attachments: unknown): FeedbackAttachmentR
 
   return attachments.filter(isFeedbackAttachmentRecord)
 }
+
+const normalizeAdminFeedbackAttachments = (attachments: unknown): AdminFeedbackAttachmentRecord[] => {
+  if (!Array.isArray(attachments)) return []
+
+  return attachments.filter(isFeedbackAttachmentRecord).map(attachment => attachment as AdminFeedbackAttachmentRecord)
+}
+
+const normalizeBuildRun = (row: FeedbackBuildRunRow): FeedbackBuildRun => ({
+  ...row,
+  included_attachments: normalizeAdminFeedbackAttachments(row.included_attachments),
+})
+
+const normalizeBuildRunLog = (row: FeedbackBuildRunLogRow): FeedbackBuildRunLog => ({
+  ...row,
+  metadata: row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata)
+    ? row.metadata as Record<string, unknown>
+    : {},
+})
+
+const serializeBuildAttachments = (attachments: AdminFeedbackAttachmentRecord[]) =>
+  attachments.map(({ bucket, path, name, size, type }) => ({
+    bucket,
+    path,
+    name,
+    size,
+    type,
+  }))
 
 const signFeedbackAttachments = async (
   workingClient: Awaited<ReturnType<typeof getWorkingClient>>,
@@ -213,6 +326,96 @@ export const deleteAdminFeedbackSubmission = async (
       // The submission is already removed; orphan cleanup can be retried later.
     }
   }
+}
+
+export const fetchFeedbackBuildRuns = async (): Promise<FeedbackBuildRun[]> => {
+  const workingClient = await getWorkingClient()
+  const { data, error } = await workingClient
+    .from('feedback_build_runs')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(100)
+
+  if (error) {
+    throw error
+  }
+
+  return ((data ?? []) as FeedbackBuildRunRow[]).map(normalizeBuildRun)
+}
+
+export const fetchFeedbackBuildRunLogs = async (runIds: string[]): Promise<FeedbackBuildRunLog[]> => {
+  if (runIds.length === 0) return []
+
+  const workingClient = await getWorkingClient()
+  const { data, error } = await workingClient
+    .from('feedback_build_run_logs')
+    .select('*')
+    .in('run_id', runIds)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    throw error
+  }
+
+  return ((data ?? []) as FeedbackBuildRunLogRow[]).map(normalizeBuildRunLog)
+}
+
+export const createFeedbackBuildRun = async (input: FeedbackBuildRunInput): Promise<FeedbackBuildRun> => {
+  const workingClient = await getWorkingClient()
+  const { data, error } = await workingClient.rpc('create_feedback_build_run', {
+    p_feedback_submission_id: input.feedbackSubmissionId,
+    p_companion_prompt: input.companionPrompt,
+    p_included_attachments: serializeBuildAttachments(input.includedAttachments),
+    p_recognition_enabled: input.recognitionEnabled,
+  })
+
+  if (error) {
+    throw error
+  }
+
+  return normalizeBuildRun(data as FeedbackBuildRunRow)
+}
+
+export const retryFeedbackBuildRun = async (input: FeedbackBuildRetryInput): Promise<FeedbackBuildRun> => {
+  const workingClient = await getWorkingClient()
+  const { data, error } = await workingClient.rpc('retry_feedback_build_run', {
+    p_previous_run_id: input.previousRunId,
+    p_companion_prompt: input.companionPrompt,
+    p_included_attachments: serializeBuildAttachments(input.includedAttachments),
+    p_recognition_enabled: input.recognitionEnabled,
+  })
+
+  if (error) {
+    throw error
+  }
+
+  return normalizeBuildRun(data as FeedbackBuildRunRow)
+}
+
+export const approveFeedbackBuildMerge = async (runId: string): Promise<FeedbackBuildRun> => {
+  const workingClient = await getWorkingClient()
+  const { data, error } = await workingClient.rpc('approve_feedback_build_merge', {
+    p_run_id: runId,
+  })
+
+  if (error) {
+    throw error
+  }
+
+  return normalizeBuildRun(data as FeedbackBuildRunRow)
+}
+
+export const archiveFeedbackBuildRun = async (runId: string): Promise<FeedbackBuildRun> => {
+  const workingClient = await getWorkingClient()
+  const { data, error } = await workingClient.rpc('archive_feedback_build_run', {
+    p_run_id: runId,
+  })
+
+  if (error) {
+    throw error
+  }
+
+  return normalizeBuildRun(data as FeedbackBuildRunRow)
 }
 
 export const buildFeedbackAttachmentPath = (

--- a/supabase/migrations/20260507010000_feedback_build_runs.sql
+++ b/supabase/migrations/20260507010000_feedback_build_runs.sql
@@ -1,0 +1,412 @@
+/*
+  # Feedback build runs
+
+  Adds the full-admin-only queue that turns reviewed feedback submissions into
+  structured Codex build runs. The browser can read run state and call narrow
+  RPCs, while the Codex cron runner records stage logs and repo outcomes with
+  service-role credentials.
+*/
+
+CREATE TABLE IF NOT EXISTS public.feedback_build_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  feedback_submission_id uuid NOT NULL REFERENCES public.feedback_submissions(id) ON DELETE CASCADE,
+  created_by uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  companion_prompt text NOT NULL CHECK (char_length(trim(companion_prompt)) >= 20),
+  generated_prompt text NOT NULL,
+  included_attachments jsonb NOT NULL DEFAULT '[]'::jsonb CHECK (jsonb_typeof(included_attachments) = 'array'),
+  recognition_enabled boolean NOT NULL DEFAULT true,
+  status text NOT NULL DEFAULT 'pending' CHECK (
+    status IN (
+      'pending',
+      'running',
+      'ready_for_testing',
+      'failed',
+      'approved_to_merge',
+      'merging',
+      'merged',
+      'archived'
+    )
+  ),
+  current_stage text NOT NULL DEFAULT 'queued' CHECK (
+    current_stage IN (
+      'queued',
+      'classifying',
+      'reviewing_affected_code',
+      'debugging_existing_behavior',
+      'researching_solution',
+      'planning',
+      'reviewing_plan_against_code',
+      'implementing',
+      'testing',
+      'branch_pushed',
+      'ready_for_testing',
+      'approved_to_merge',
+      'merging',
+      'documenting_cleanup',
+      'merged',
+      'failed',
+      'archived'
+    )
+  ),
+  branch_name text,
+  pr_url text,
+  preview_url text,
+  preview_warning text,
+  summary text,
+  merge_commit_sha text,
+  failure_message text,
+  approved_merge_at timestamptz,
+  approved_merge_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  archived_at timestamptz,
+  archived_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.feedback_build_run_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid NOT NULL REFERENCES public.feedback_build_runs(id) ON DELETE CASCADE,
+  stage text NOT NULL CHECK (
+    stage IN (
+      'queued',
+      'classifying',
+      'reviewing_affected_code',
+      'debugging_existing_behavior',
+      'researching_solution',
+      'planning',
+      'reviewing_plan_against_code',
+      'implementing',
+      'testing',
+      'branch_pushed',
+      'ready_for_testing',
+      'approved_to_merge',
+      'merging',
+      'documenting_cleanup',
+      'merged',
+      'failed',
+      'archived'
+    )
+  ),
+  message text NOT NULL CHECK (char_length(trim(message)) > 0),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object'),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS feedback_build_runs_submission_created_idx
+  ON public.feedback_build_runs (feedback_submission_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS feedback_build_runs_status_created_idx
+  ON public.feedback_build_runs (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS feedback_build_runs_active_global_idx
+  ON public.feedback_build_runs (created_at ASC)
+  WHERE status IN ('running', 'approved_to_merge', 'merging');
+
+CREATE INDEX IF NOT EXISTS feedback_build_run_logs_run_created_idx
+  ON public.feedback_build_run_logs (run_id, created_at ASC);
+
+DROP TRIGGER IF EXISTS update_feedback_build_runs_updated_at ON public.feedback_build_runs;
+CREATE TRIGGER update_feedback_build_runs_updated_at
+  BEFORE UPDATE ON public.feedback_build_runs
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+ALTER TABLE public.feedback_build_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.feedback_build_run_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Full admins can read feedback build runs" ON public.feedback_build_runs;
+CREATE POLICY "Full admins can read feedback build runs"
+ON public.feedback_build_runs
+FOR SELECT
+TO authenticated
+USING (public.is_app_admin((select auth.uid())));
+
+DROP POLICY IF EXISTS "Full admins can read feedback build run logs" ON public.feedback_build_run_logs;
+CREATE POLICY "Full admins can read feedback build run logs"
+ON public.feedback_build_run_logs
+FOR SELECT
+TO authenticated
+USING (
+  public.is_app_admin((select auth.uid()))
+  AND EXISTS (
+    SELECT 1
+    FROM public.feedback_build_runs runs
+    WHERE runs.id = feedback_build_run_logs.run_id
+  )
+);
+
+CREATE OR REPLACE FUNCTION public.build_feedback_run_prompt(
+  target_submission public.feedback_submissions,
+  submitter_name text,
+  submitter_username text,
+  companion_prompt text,
+  included_attachments jsonb,
+  recognition_enabled boolean
+)
+RETURNS text
+LANGUAGE plpgsql
+STABLE
+SET search_path = public
+AS $$
+BEGIN
+  RETURN concat_ws(
+    E'\n\n',
+    'ShadowChat feedback build request',
+    concat('Submission id: ', target_submission.id),
+    concat('Submission type: ', target_submission.submission_type),
+    concat('Title: ', target_submission.title),
+    concat('Submitter: ', COALESCE(NULLIF(submitter_name, ''), submitter_username, 'Unknown user')),
+    concat('Submitter handle: ', COALESCE('@' || NULLIF(submitter_username, ''), 'unknown')),
+    concat('Recognition allowed in evening report: ', CASE WHEN recognition_enabled THEN 'yes' ELSE 'no' END),
+    concat('Included attachment metadata: ', included_attachments::text),
+    concat(E'User submission:\n', target_submission.description),
+    concat(E'Admin companion prompt:\n', trim(companion_prompt)),
+    E'Required Codex workflow:\n1. Classify the issue or feature area.\n2. Review the affected code and docs before editing.\n3. Debug the existing behavior and confirm it is not a simple local bug.\n4. Research the best fit for the codebase and provider docs where needed.\n5. Build a comprehensive step-by-step implementation plan.\n6. Compare the plan with existing code to remove overlap and avoid conflicts.\n7. Implement the change on a codex/feedback-* branch.\n8. Run lint, typecheck, build, and targeted tests.\n9. Push the branch, open a draft PR, and attach a Netlify preview when available.\n10. Record stage logs as each step completes.'
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_feedback_build_run(
+  p_feedback_submission_id uuid,
+  p_companion_prompt text,
+  p_included_attachments jsonb DEFAULT '[]'::jsonb,
+  p_recognition_enabled boolean DEFAULT true
+)
+RETURNS public.feedback_build_runs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_user_id uuid := auth.uid();
+  target_submission public.feedback_submissions%ROWTYPE;
+  submitter_record public.users%ROWTYPE;
+  created_run public.feedback_build_runs%ROWTYPE;
+  generated text;
+BEGIN
+  IF actor_user_id IS NULL OR NOT public.is_app_admin(actor_user_id) THEN
+    RAISE EXCEPTION 'Only full admins can start feedback build runs';
+  END IF;
+
+  IF char_length(trim(COALESCE(p_companion_prompt, ''))) < 20 THEN
+    RAISE EXCEPTION 'Add at least 20 characters of companion prompt context';
+  END IF;
+
+  IF p_included_attachments IS NULL OR jsonb_typeof(p_included_attachments) <> 'array' THEN
+    RAISE EXCEPTION 'Included attachments must be a JSON array';
+  END IF;
+
+  SELECT *
+  INTO target_submission
+  FROM public.feedback_submissions
+  WHERE id = p_feedback_submission_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Feedback submission not found';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.feedback_build_runs runs
+    WHERE runs.feedback_submission_id = p_feedback_submission_id
+      AND runs.status IN ('pending', 'running', 'approved_to_merge', 'merging')
+  ) THEN
+    RAISE EXCEPTION 'This feedback submission already has an active build run';
+  END IF;
+
+  SELECT *
+  INTO submitter_record
+  FROM public.users
+  WHERE id = target_submission.user_id;
+
+  generated := public.build_feedback_run_prompt(
+    target_submission,
+    submitter_record.display_name,
+    submitter_record.username,
+    p_companion_prompt,
+    p_included_attachments,
+    COALESCE(p_recognition_enabled, true)
+  );
+
+  INSERT INTO public.feedback_build_runs (
+    feedback_submission_id,
+    created_by,
+    companion_prompt,
+    generated_prompt,
+    included_attachments,
+    recognition_enabled
+  )
+  VALUES (
+    p_feedback_submission_id,
+    actor_user_id,
+    trim(p_companion_prompt),
+    generated,
+    p_included_attachments,
+    COALESCE(p_recognition_enabled, true)
+  )
+  RETURNING * INTO created_run;
+
+  INSERT INTO public.feedback_build_run_logs (run_id, stage, message)
+  VALUES (created_run.id, 'queued', 'Build request queued for the Codex processor.');
+
+  UPDATE public.feedback_submissions
+  SET status = 'reviewing'
+  WHERE id = p_feedback_submission_id
+    AND status <> 'closed';
+
+  RETURN created_run;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.retry_feedback_build_run(
+  p_previous_run_id uuid,
+  p_companion_prompt text,
+  p_included_attachments jsonb DEFAULT NULL,
+  p_recognition_enabled boolean DEFAULT NULL
+)
+RETURNS public.feedback_build_runs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_user_id uuid := auth.uid();
+  previous_run public.feedback_build_runs%ROWTYPE;
+  next_run public.feedback_build_runs%ROWTYPE;
+BEGIN
+  IF actor_user_id IS NULL OR NOT public.is_app_admin(actor_user_id) THEN
+    RAISE EXCEPTION 'Only full admins can retry feedback build runs';
+  END IF;
+
+  SELECT *
+  INTO previous_run
+  FROM public.feedback_build_runs
+  WHERE id = p_previous_run_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Feedback build run not found';
+  END IF;
+
+  IF previous_run.status <> 'failed' THEN
+    RAISE EXCEPTION 'Only failed feedback build runs can be retried';
+  END IF;
+
+  SELECT *
+  INTO next_run
+  FROM public.create_feedback_build_run(
+    previous_run.feedback_submission_id,
+    p_companion_prompt,
+    COALESCE(p_included_attachments, previous_run.included_attachments),
+    COALESCE(p_recognition_enabled, previous_run.recognition_enabled)
+  );
+
+  INSERT INTO public.feedback_build_run_logs (run_id, stage, message, metadata)
+  VALUES (
+    next_run.id,
+    'queued',
+    'Retry created from failed feedback build run.',
+    jsonb_build_object('previous_run_id', previous_run.id)
+  );
+
+  RETURN next_run;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.approve_feedback_build_merge(p_run_id uuid)
+RETURNS public.feedback_build_runs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_user_id uuid := auth.uid();
+  target_run public.feedback_build_runs%ROWTYPE;
+BEGIN
+  IF actor_user_id IS NULL OR NOT public.is_app_admin(actor_user_id) THEN
+    RAISE EXCEPTION 'Only full admins can approve feedback build merges';
+  END IF;
+
+  SELECT *
+  INTO target_run
+  FROM public.feedback_build_runs
+  WHERE id = p_run_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Feedback build run not found';
+  END IF;
+
+  IF target_run.status <> 'ready_for_testing' THEN
+    RAISE EXCEPTION 'Only ready-for-testing feedback build runs can be approved';
+  END IF;
+
+  IF target_run.pr_url IS NULL OR trim(target_run.pr_url) = '' THEN
+    RAISE EXCEPTION 'A pull request URL is required before merge approval';
+  END IF;
+
+  UPDATE public.feedback_build_runs
+  SET
+    status = 'approved_to_merge',
+    current_stage = 'approved_to_merge',
+    approved_merge_at = now(),
+    approved_merge_by = actor_user_id
+  WHERE id = p_run_id
+  RETURNING * INTO target_run;
+
+  INSERT INTO public.feedback_build_run_logs (run_id, stage, message)
+  VALUES (target_run.id, 'approved_to_merge', 'Admin approved this feedback build for merge.');
+
+  RETURN target_run;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.archive_feedback_build_run(p_run_id uuid)
+RETURNS public.feedback_build_runs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_user_id uuid := auth.uid();
+  target_run public.feedback_build_runs%ROWTYPE;
+BEGIN
+  IF actor_user_id IS NULL OR NOT public.is_app_admin(actor_user_id) THEN
+    RAISE EXCEPTION 'Only full admins can archive feedback build runs';
+  END IF;
+
+  SELECT *
+  INTO target_run
+  FROM public.feedback_build_runs
+  WHERE id = p_run_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Feedback build run not found';
+  END IF;
+
+  IF target_run.status IN ('running', 'approved_to_merge', 'merging') THEN
+    RAISE EXCEPTION 'Active feedback build runs cannot be archived';
+  END IF;
+
+  UPDATE public.feedback_build_runs
+  SET
+    status = 'archived',
+    current_stage = 'archived',
+    archived_at = COALESCE(archived_at, now()),
+    archived_by = COALESCE(archived_by, actor_user_id)
+  WHERE id = p_run_id
+  RETURNING * INTO target_run;
+
+  INSERT INTO public.feedback_build_run_logs (run_id, stage, message)
+  VALUES (target_run.id, 'archived', 'Admin archived this feedback build run.');
+
+  RETURN target_run;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.build_feedback_run_prompt(public.feedback_submissions, text, text, text, jsonb, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_feedback_build_run(uuid, text, jsonb, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.retry_feedback_build_run(uuid, text, jsonb, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.approve_feedback_build_merge(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.archive_feedback_build_run(uuid) TO authenticated;

--- a/tests/AdminFeedbackReview.test.tsx
+++ b/tests/AdminFeedbackReview.test.tsx
@@ -3,15 +3,31 @@ import React from 'react'
 import { AdminFeedbackReview } from '../src/components/settings/AdminFeedbackReview'
 
 const mockRefresh = jest.fn()
+const mockRefreshBuildRuns = jest.fn()
 const mockDeleteSubmission = jest.fn()
+const mockStartBuildRun = jest.fn()
+const mockRetryBuildRun = jest.fn()
+const mockApproveMerge = jest.fn()
+const mockArchiveBuildRun = jest.fn()
 const mockUseAdminFeedback = jest.fn()
+const mockUseAdminAccess = jest.fn()
 
 jest.mock('../src/hooks/useAdminFeedback', () => ({
   useAdminFeedback: () => mockUseAdminFeedback(),
 }))
 
+jest.mock('../src/hooks/useAdminAccess', () => ({
+  useAdminAccess: () => mockUseAdminAccess(),
+}))
+
 beforeEach(() => {
   jest.clearAllMocks()
+  mockUseAdminAccess.mockReturnValue({
+    isAdmin: true,
+    isOperator: true,
+    role: 'admin',
+    loading: false,
+  })
   mockUseAdminFeedback.mockReturnValue({
     submissions: [
       {
@@ -71,8 +87,18 @@ beforeEach(() => {
     loading: false,
     error: null,
     deletingId: null,
+    buildRuns: [],
+    buildLogsByRunId: {},
+    buildLoading: false,
+    buildError: null,
+    activeBuildActionId: null,
     refresh: mockRefresh,
+    refreshBuildRuns: mockRefreshBuildRuns,
     deleteSubmission: mockDeleteSubmission,
+    startBuildRun: mockStartBuildRun,
+    retryBuildRun: mockRetryBuildRun,
+    approveMerge: mockApproveMerge,
+    archiveBuildRun: mockArchiveBuildRun,
   })
 })
 
@@ -123,4 +149,108 @@ test('deletes a feedback submission after confirmation', async () => {
   await waitFor(() => {
     expect(mockDeleteSubmission).toHaveBeenCalledWith(expect.objectContaining({ id: 'feedback-1' }))
   })
+})
+
+test('lets full admins start a feedback build with companion prompt and selected screenshots', async () => {
+  mockStartBuildRun.mockResolvedValueOnce({
+    id: 'run-1',
+    feedback_submission_id: 'feedback-1',
+    status: 'pending',
+    current_stage: 'queued',
+  })
+  render(<AdminFeedbackReview />)
+
+  fireEvent.click(screen.getByRole('button', { name: /app crashes after upload/i }))
+  fireEvent.click(screen.getByRole('button', { name: /start feedback build/i }))
+
+  const dialogs = screen.getAllByRole('dialog')
+  const dialog = dialogs[dialogs.length - 1]
+  fireEvent.change(within(dialog).getByLabelText(/companion prompt/i), {
+    target: { value: 'Please reproduce the upload crash and keep the fix tightly scoped.' },
+  })
+  fireEvent.click(within(dialog).getByRole('button', { name: /send to codex/i }))
+
+  await waitFor(() => {
+    expect(mockStartBuildRun).toHaveBeenCalledWith(expect.objectContaining({
+      feedbackSubmissionId: 'feedback-1',
+      companionPrompt: 'Please reproduce the upload crash and keep the fix tightly scoped.',
+      recognitionEnabled: true,
+      includedAttachments: [
+        expect.objectContaining({
+          path: 'user-1/feedback-1/1-crash.png',
+        }),
+      ],
+    }))
+  })
+})
+
+test('hides feedback build controls from sub-admins', () => {
+  mockUseAdminAccess.mockReturnValue({
+    isAdmin: false,
+    isOperator: true,
+    role: 'sub_admin',
+    loading: false,
+  })
+
+  render(<AdminFeedbackReview />)
+
+  expect(screen.queryByRole('button', { name: /feedback builds/i })).not.toBeInTheDocument()
+  fireEvent.click(screen.getByRole('button', { name: /app crashes after upload/i }))
+  expect(screen.queryByRole('button', { name: /start feedback build/i })).not.toBeInTheDocument()
+})
+
+test('shows build runs with logs and approve action', () => {
+  mockUseAdminFeedback.mockReturnValue({
+    ...mockUseAdminFeedback(),
+    buildRuns: [
+      {
+        id: 'run-1',
+        feedback_submission_id: 'feedback-1',
+        created_by: 'admin-1',
+        companion_prompt: 'Please fix this crash carefully.',
+        generated_prompt: 'Generated Codex prompt',
+        included_attachments: [],
+        recognition_enabled: true,
+        status: 'ready_for_testing',
+        current_stage: 'ready_for_testing',
+        branch_name: 'codex/feedback-feedback-1-upload-crash',
+        pr_url: 'https://github.com/example/repo/pull/1',
+        preview_url: 'https://deploy-preview-1.netlify.app',
+        preview_warning: null,
+        summary: 'Fixed the upload crash.',
+        merge_commit_sha: null,
+        failure_message: null,
+        approved_merge_at: null,
+        approved_merge_by: null,
+        archived_at: null,
+        archived_by: null,
+        started_at: null,
+        completed_at: null,
+        created_at: '2026-05-07T01:00:00.000Z',
+        updated_at: '2026-05-07T01:00:00.000Z',
+      },
+    ],
+    buildLogsByRunId: {
+      'run-1': [
+        {
+          id: 'log-1',
+          run_id: 'run-1',
+          stage: 'testing',
+          message: 'Lint, typecheck, and build passed.',
+          metadata: {},
+          created_at: '2026-05-07T01:20:00.000Z',
+        },
+      ],
+    },
+  })
+
+  render(<AdminFeedbackReview />)
+
+  fireEvent.click(screen.getByRole('button', { name: /feedback builds/i }))
+  fireEvent.click(screen.getByRole('button', { name: /app crashes after upload/i }))
+
+  const dialog = screen.getByRole('dialog')
+  expect(within(dialog).getByText('Generated Codex prompt')).toBeInTheDocument()
+  expect(within(dialog).getByText('Lint, typecheck, and build passed.')).toBeInTheDocument()
+  expect(within(dialog).getByRole('button', { name: /approve & merge/i })).toBeInTheDocument()
 })

--- a/tests/feedback.test.ts
+++ b/tests/feedback.test.ts
@@ -1,8 +1,14 @@
 import {
   FEEDBACK_ATTACHMENT_SIGNED_URL_SECONDS,
   FEEDBACK_ATTACHMENTS_BUCKET,
+  approveFeedbackBuildMerge,
+  archiveFeedbackBuildRun,
+  createFeedbackBuildRun,
   deleteAdminFeedbackSubmission,
   fetchAdminFeedbackSubmissions,
+  fetchFeedbackBuildRunLogs,
+  fetchFeedbackBuildRuns,
+  retryFeedbackBuildRun,
   submitFeedback,
   validateFeedbackSubmission,
 } from '../src/lib/feedback'
@@ -20,6 +26,13 @@ const orderFeedback = jest.fn()
 const limitFeedback = jest.fn()
 const selectUsers = jest.fn()
 const inUsers = jest.fn()
+const selectBuildRuns = jest.fn()
+const orderBuildRuns = jest.fn()
+const limitBuildRuns = jest.fn()
+const selectBuildLogs = jest.fn()
+const inBuildLogs = jest.fn()
+const orderBuildLogs = jest.fn()
+const rpc = jest.fn()
 const getUser = jest.fn()
 
 jest.mock('../src/lib/supabase', () => ({
@@ -41,12 +54,25 @@ jest.mock('../src/lib/supabase', () => ({
         }
       }
 
+      if (table === 'feedback_build_runs') {
+        return {
+          select: selectBuildRuns,
+        }
+      }
+
+      if (table === 'feedback_build_run_logs') {
+        return {
+          select: selectBuildLogs,
+        }
+      }
+
       return {
         insert,
         delete: deleteFeedback,
         select: selectFeedback,
       }
     }),
+    rpc,
   })),
 }))
 
@@ -64,6 +90,13 @@ beforeEach(() => {
   selectFeedback.mockReturnValue({ order: orderFeedback })
   inUsers.mockResolvedValue({ data: [], error: null })
   selectUsers.mockReturnValue({ in: inUsers })
+  limitBuildRuns.mockResolvedValue({ data: [], error: null })
+  orderBuildRuns.mockReturnValue({ limit: limitBuildRuns })
+  selectBuildRuns.mockReturnValue({ order: orderBuildRuns })
+  orderBuildLogs.mockResolvedValue({ data: [], error: null })
+  inBuildLogs.mockReturnValue({ order: orderBuildLogs })
+  selectBuildLogs.mockReturnValue({ in: inBuildLogs })
+  rpc.mockResolvedValue({ data: null, error: null })
   createSignedUrls.mockResolvedValue({ data: [], error: null })
   getUser.mockResolvedValue({ data: { user: { id: 'user-id' } }, error: null })
 })
@@ -227,4 +260,137 @@ test('deletes admin feedback submissions and attached images', async () => {
   expect(remove).toHaveBeenCalledWith(['user-id/feedback-1/1-upload.png'])
   expect(deleteFeedback).toHaveBeenCalled()
   expect(eqFeedback).toHaveBeenCalledWith('id', 'feedback-1')
+})
+
+test('loads feedback build runs and stage logs', async () => {
+  limitBuildRuns.mockResolvedValueOnce({
+    data: [
+      {
+        id: 'run-1',
+        feedback_submission_id: 'feedback-1',
+        created_by: 'admin-1',
+        companion_prompt: 'Please fix the upload flow with care.',
+        generated_prompt: 'Generated prompt',
+        included_attachments: [
+          {
+            bucket: FEEDBACK_ATTACHMENTS_BUCKET,
+            path: 'user-id/feedback-1/1-upload.png',
+            name: 'upload.png',
+            size: 1200,
+            type: 'image/png',
+          },
+        ],
+        recognition_enabled: true,
+        status: 'pending',
+        current_stage: 'queued',
+        branch_name: null,
+        pr_url: null,
+        preview_url: null,
+        preview_warning: null,
+        summary: null,
+        merge_commit_sha: null,
+        failure_message: null,
+        approved_merge_at: null,
+        approved_merge_by: null,
+        archived_at: null,
+        archived_by: null,
+        started_at: null,
+        completed_at: null,
+        created_at: '2026-05-07T01:00:00.000Z',
+        updated_at: '2026-05-07T01:00:00.000Z',
+      },
+    ],
+    error: null,
+  })
+  orderBuildLogs.mockResolvedValueOnce({
+    data: [
+      {
+        id: 'log-1',
+        run_id: 'run-1',
+        stage: 'queued',
+        message: 'Queued for Codex.',
+        metadata: { source: 'test' },
+        created_at: '2026-05-07T01:00:00.000Z',
+      },
+    ],
+    error: null,
+  })
+
+  const runs = await fetchFeedbackBuildRuns()
+  const logs = await fetchFeedbackBuildRunLogs(['run-1'])
+
+  expect(limitBuildRuns).toHaveBeenCalledWith(100)
+  expect(inBuildLogs).toHaveBeenCalledWith('run_id', ['run-1'])
+  expect(runs[0]).toEqual(expect.objectContaining({
+    id: 'run-1',
+    included_attachments: [
+      expect.objectContaining({
+        name: 'upload.png',
+      }),
+    ],
+  }))
+  expect(logs[0]).toEqual(expect.objectContaining({
+    stage: 'queued',
+    metadata: { source: 'test' },
+  }))
+})
+
+test('calls feedback build run RPCs with sanitized attachment metadata', async () => {
+  const runRow = {
+    id: 'run-1',
+    feedback_submission_id: 'feedback-1',
+    created_by: 'admin-1',
+    companion_prompt: 'Please fix the upload flow with care.',
+    generated_prompt: 'Generated prompt',
+    included_attachments: [],
+    recognition_enabled: true,
+    status: 'pending',
+    current_stage: 'queued',
+    created_at: '2026-05-07T01:00:00.000Z',
+    updated_at: '2026-05-07T01:00:00.000Z',
+  }
+  rpc.mockResolvedValue({ data: runRow, error: null })
+
+  await createFeedbackBuildRun({
+    feedbackSubmissionId: 'feedback-1',
+    companionPrompt: 'Please fix the upload flow with care.',
+    includedAttachments: [
+      {
+        bucket: FEEDBACK_ATTACHMENTS_BUCKET,
+        path: 'user-id/feedback-1/1-upload.png',
+        name: 'upload.png',
+        size: 1200,
+        type: 'image/png',
+        signedUrl: 'https://example.test/private-url.png',
+      },
+    ],
+    recognitionEnabled: false,
+  })
+  await retryFeedbackBuildRun({
+    previousRunId: 'run-1',
+    companionPrompt: 'Try again with the smaller implementation plan.',
+    includedAttachments: [],
+    recognitionEnabled: true,
+  })
+  await approveFeedbackBuildMerge('run-1')
+  await archiveFeedbackBuildRun('run-1')
+
+  expect(rpc).toHaveBeenNthCalledWith(1, 'create_feedback_build_run', expect.objectContaining({
+    p_feedback_submission_id: 'feedback-1',
+    p_recognition_enabled: false,
+    p_included_attachments: [
+      {
+        bucket: FEEDBACK_ATTACHMENTS_BUCKET,
+        path: 'user-id/feedback-1/1-upload.png',
+        name: 'upload.png',
+        size: 1200,
+        type: 'image/png',
+      },
+    ],
+  }))
+  expect(rpc).toHaveBeenNthCalledWith(2, 'retry_feedback_build_run', expect.objectContaining({
+    p_previous_run_id: 'run-1',
+  }))
+  expect(rpc).toHaveBeenNthCalledWith(3, 'approve_feedback_build_merge', { p_run_id: 'run-1' })
+  expect(rpc).toHaveBeenNthCalledWith(4, 'archive_feedback_build_run', { p_run_id: 'run-1' })
 })


### PR DESCRIPTION
## Summary
- add full-admin Feedback Builds workflow for turning feedback submissions into Codex build runs
- add Supabase run/log tables plus RPCs for start, retry, approve merge, and archive actions
- add admin UI for generated prompts, screenshot inclusion, stage logs, PR/Netlify preview links, retry, archive, and approve-to-merge
- document the processor workflow and daily Shado recognition rules

## Tests
- npm run lint
- npx tsc --noEmit -p tsconfig.app.json
- npm run build
- npx jest --runInBand tests/AdminFeedbackReview.test.tsx tests/feedback.test.ts

## Risks / Notes
- Supabase migration 20260507010000_feedback_build_runs.sql has already been pushed to the remote database.
- Feedback Builds are hidden from sub-admins and visible to full admins only.
- The Jest run passes but still prints the existing Avatar/channel-ban async act(...) warning.
- Netlify preview should be verified before merging.