### PR TITLE
Add mobile-friendly light theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { useSessionResumeRecovery } from './hooks/useSessionResumeRecovery'
 import { useAdminRoleNotifications } from './hooks/useAdminRoleNotifications'
 import { useChannelBanExpirySweep } from './hooks/useChannelBanExpirySweep'
 import { useArtBoardReactionNotifications } from './hooks/useArtBoardReactionNotifications'
+import { useTheme } from './hooks/useTheme'
 import { computeMobileViewportState } from './lib/mobileViewport'
 
 const DirectMessagesView = lazy(() =>
@@ -78,7 +79,7 @@ const getInitialLocationState = (): LocationState => {
 
 function ViewLoadingState() {
   return (
-    <div className="flex flex-1 items-center justify-center bg-[radial-gradient(circle_at_top,rgba(215,170,70,0.06),transparent_28%),linear-gradient(180deg,var(--bg-shell),var(--bg-app))]">
+    <div className="flex flex-1 items-center justify-center bg-[radial-gradient(circle_at_top,var(--bg-app-radial),transparent_28%),linear-gradient(180deg,var(--bg-shell),var(--bg-app))]">
       <div className="glass-panel rounded-[var(--radius-xl)] px-8 py-7 text-center text-[var(--text-muted)]">
         <div className="mb-3 flex justify-center">
           <LoadingSpinner size="lg" className="text-[var(--text-gold)]" />
@@ -94,6 +95,7 @@ function App() {
   useAdminRoleNotifications()
   useChannelBanExpirySweep()
   useArtBoardReactionNotifications()
+  const { scheme, setScheme, mode } = useTheme()
   const [currentView, setCurrentView] = useState<View>(() => getInitialLocationState().view)
   const [boardsResetKey, setBoardsResetKey] = useState(0)
   const [boardsChatFooterActive, setBoardsChatFooterActive] = useState(false)
@@ -102,26 +104,7 @@ function App() {
   const mobileAppHeightRef = useRef<number | null>(null)
   const [dmTarget, setDmTarget] = useState<string | null>(() => getInitialLocationState().conversation)
   const [messageTarget, setMessageTarget] = useState<string | null>(() => getInitialLocationState().message)
-  const [isDarkMode, setIsDarkMode] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('darkMode')
-      if (stored) {
-        return stored === 'true'
-      }
-      return true
-    }
-    return true
-  })
-
-  // Apply dark mode class
-  useEffect(() => {
-    if (isDarkMode) {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-    localStorage.setItem('darkMode', isDarkMode.toString())
-  }, [isDarkMode])
+  const isDarkMode = mode === 'dark'
 
   useEffect(() => {
     if (typeof window === 'undefined' || isDesktop) return
@@ -219,7 +202,7 @@ function App() {
 
 
   const toggleDarkMode = () => {
-    setIsDarkMode(!isDarkMode)
+    setScheme(scheme === 'moonstone-light' ? 'obsidian-gold' : 'moonstone-light')
   }
 
   const toggleSidebar = () => {
@@ -377,7 +360,7 @@ function App() {
           <DirectMessagesProvider>
           <AppBadgeSync />
           <PhoneInstallOnboarding />
-          <div className="app-viewport flex flex-col overflow-hidden bg-[radial-gradient(circle_at_top,rgba(215,170,70,0.08),transparent_28%),linear-gradient(180deg,var(--bg-shell),var(--bg-app))] md:flex-row">
+          <div className="app-viewport flex flex-col overflow-hidden bg-[radial-gradient(circle_at_top,var(--bg-app-radial),transparent_28%),linear-gradient(180deg,var(--bg-shell),var(--bg-app))] md:flex-row">
           {isDesktop && (
             <Sidebar
               currentView={currentView}

--- a/src/components/layout/MobileChatFooter.tsx
+++ b/src/components/layout/MobileChatFooter.tsx
@@ -43,7 +43,7 @@ export function MobileChatFooter({ currentView, onViewChange, children }: Mobile
   return (
     <div
       ref={footerRef}
-      className="fixed inset-x-0 bottom-[var(--shadowchat-keyboard-inset,0px)] z-50 flex flex-col border-t border-[var(--border-panel)] bg-[linear-gradient(180deg,rgba(18,20,21,0.88),rgba(9,10,11,0.98))] pb-[env(safe-area-inset-bottom)] shadow-[0_-14px_36px_rgba(0,0,0,0.32)] backdrop-blur-xl md:hidden"
+      className="fixed inset-x-0 bottom-[var(--shadowchat-keyboard-inset,0px)] z-50 flex flex-col border-t border-[var(--border-panel)] [background:var(--mobile-footer-bg)] pb-[env(safe-area-inset-bottom)] shadow-[var(--mobile-footer-shadow)] backdrop-blur-xl md:hidden"
       data-mobile-chat-footer="true"
     >
       {children}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -47,11 +47,11 @@ export function MobileNav({ currentView, onViewChange, className }: MobileNavPro
               onClick={() => onViewChange(item.id)}
               className={`flex h-full w-full flex-col items-center justify-center rounded-[var(--radius-md)] px-1 py-1.5 text-[10px] focus:outline-none transition-all ${
                 currentView === item.id
-                  ? 'bg-[rgba(255,255,255,0.04)] text-[var(--text-gold)] shadow-[var(--shadow-gold-soft)]'
-                  : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.03)] hover:text-[var(--text-primary)]'
+                  ? 'bg-[var(--nav-active-bg)] text-[var(--text-gold)] shadow-[var(--shadow-gold-soft)]'
+                  : 'text-[var(--text-muted)] hover:bg-[var(--nav-hover-bg)] hover:text-[var(--text-primary)]'
               }`}
             >
-              <span className="relative mb-1 flex h-8 w-8 items-center justify-center rounded-full">
+              <span className="relative mb-1 flex h-8 w-8 items-center justify-center rounded-full bg-[var(--nav-icon-bg)]">
                 <item.icon className="w-[1.15rem] h-[1.15rem]" />
                 {item.badge && (
                   <span className="absolute -right-1 -top-1 rounded-full border border-[rgba(215,170,70,0.3)] bg-[rgba(215,170,70,0.14)] px-1 text-[10px] leading-none text-[var(--text-gold)]">

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -6,6 +6,7 @@ import {
   BookOpen,
   Brain,
   ChevronRight,
+  Check,
   Database,
   Download,
   KeyRound,
@@ -1179,11 +1180,13 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
         <LayoutGrid className="h-5 w-5 text-[var(--text-muted)]" />
         <h2 className="text-lg font-semibold text-[var(--text-primary)]">Color Scheme</h2>
       </div>
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="grid grid-cols-1 gap-3 min-[380px]:grid-cols-2 lg:grid-cols-5">
         {(Object.keys(colorSchemes) as ColorScheme[]).map(key => (
           <button
             key={key}
+            type="button"
             onClick={() => setScheme(key)}
+            aria-pressed={scheme === key}
             className={`rounded-[var(--radius-md)] border p-3 text-left transition-all ${
               scheme === key
                 ? 'border-[var(--border-glow)] bg-[rgba(255,255,255,0.06)] shadow-[var(--shadow-gold-soft)]'
@@ -1192,10 +1195,21 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onToggleSidebar }) =
             aria-label={`Select ${key} color scheme`}
           >
             <span
-              className="mb-2 block h-10 rounded-[var(--radius-sm)] border border-[rgba(255,255,255,0.08)]"
+              className="relative mb-2 block h-12 rounded-[var(--radius-sm)] border border-[var(--border-subtle)]"
               style={{ background: `linear-gradient(135deg, ${colorSchemes[key].start}, ${colorSchemes[key].end})` }}
-            />
-            <span className="block text-sm font-medium text-[var(--text-primary)]">{colorSchemes[key].label}</span>
+            >
+              {scheme === key && (
+                <span className="absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-full border border-[var(--border-glow)] bg-[var(--bg-panel-strong)] text-[var(--text-gold)] shadow-[var(--shadow-panel)]">
+                  <Check className="h-3.5 w-3.5" />
+                </span>
+              )}
+            </span>
+            <span className="flex items-center justify-between gap-2 text-sm font-medium text-[var(--text-primary)]">
+              {colorSchemes[key].label}
+              <span className="rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                {colorSchemes[key].mode}
+              </span>
+            </span>
           </button>
         ))}
       </div>

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -6,41 +6,56 @@ export type ColorScheme =
   | 'obsidian-champagne'
   | 'graphite-amber'
   | 'carbon-ivory'
+  | 'moonstone-light'
+
+export type ThemeMode = 'dark' | 'light'
 
 interface ThemeContextValue {
   scheme: ColorScheme
   setScheme: (scheme: ColorScheme) => void
+  mode: ThemeMode
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
 
 export const colorSchemes: Record<
   ColorScheme,
-  { label: string; start: string; end: string; accent: string }
+  { label: string; start: string; end: string; accent: string; mode: ThemeMode }
 > = {
   'obsidian-gold': {
     label: 'Obsidian Gold',
     start: '#fff0b8',
     end: '#9a7421',
     accent: '#d7aa46',
+    mode: 'dark',
   },
   'obsidian-champagne': {
     label: 'Noir Champagne',
     start: '#f3ddb0',
     end: '#8f6a37',
     accent: '#d2ac69',
+    mode: 'dark',
   },
   'graphite-amber': {
     label: 'Blackened Brass',
     start: '#e6bf7d',
     end: '#7a5628',
     accent: '#b88646',
+    mode: 'dark',
   },
   'carbon-ivory': {
     label: 'Smoked Ivory',
     start: '#e4d5b6',
     end: '#7b694b',
     accent: '#c8b08a',
+    mode: 'dark',
+  },
+  'moonstone-light': {
+    label: 'Moonstone Light',
+    start: '#fff8e8',
+    end: '#d7aa46',
+    accent: '#b9851f',
+    mode: 'light',
   },
 }
 
@@ -74,16 +89,20 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   })
 
   useEffect(() => {
+    const mode = colorSchemes[scheme].mode
     document.documentElement.dataset.scheme = scheme
+    document.documentElement.dataset.themeMode = mode
     document.documentElement.classList.remove(
-      ...(Object.keys(colorSchemes) as ColorScheme[])
+      ...(Object.keys(colorSchemes) as ColorScheme[]),
+      'dark',
+      'light'
     )
-    document.documentElement.classList.add(scheme)
+    document.documentElement.classList.add(scheme, mode)
     localStorage.setItem('colorScheme', scheme)
   }, [scheme])
 
   return (
-    <ThemeContext.Provider value={{ scheme, setScheme }}>
+    <ThemeContext.Provider value={{ scheme, setScheme, mode: colorSchemes[scheme].mode }}>
       {children}
     </ThemeContext.Provider>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,15 @@
     --bg-input: rgba(255, 255, 255, 0.04);
     --bg-input-focus: rgba(255, 255, 255, 0.06);
     --bg-overlay: rgba(5, 6, 7, 0.72);
+    --bg-page-radial: rgba(215, 170, 70, 0.08);
+    --bg-page-start: #0c0d0e;
+    --bg-page-end: #080909;
+    --bg-app-radial: rgba(215, 170, 70, 0.08);
+    --mobile-footer-bg: linear-gradient(180deg, rgba(18, 20, 21, 0.88), rgba(9, 10, 11, 0.98));
+    --mobile-footer-shadow: 0 -14px 36px rgba(0, 0, 0, 0.32);
+    --nav-active-bg: rgba(255, 255, 255, 0.04);
+    --nav-hover-bg: rgba(255, 255, 255, 0.03);
+    --nav-icon-bg: rgba(255, 255, 255, 0.03);
 
     --gold-1: #6f5318;
     --gold-2: #9a7421;
@@ -75,16 +84,20 @@
     color-scheme: dark;
   }
 
+  .light {
+    color-scheme: light;
+  }
+
   html {
     background:
-      radial-gradient(circle at top, rgba(215, 170, 70, 0.08), transparent 30%),
-      linear-gradient(180deg, #0c0d0e 0%, #080909 100%);
+      radial-gradient(circle at top, var(--bg-page-radial), transparent 30%),
+      linear-gradient(180deg, var(--bg-page-start) 0%, var(--bg-page-end) 100%);
   }
 
   body {
     background:
-      radial-gradient(circle at top, rgba(215, 170, 70, 0.08), transparent 30%),
-      linear-gradient(180deg, #0c0d0e 0%, #080909 100%);
+      radial-gradient(circle at top, var(--bg-page-radial), transparent 30%),
+      linear-gradient(180deg, var(--bg-page-start) 0%, var(--bg-page-end) 100%);
     color: var(--text-primary);
   }
 
@@ -180,6 +193,68 @@
   --color-primary-end: var(--gold-2);
   --color-accent: var(--gold-accent);
   --color-accent-light: rgba(200, 176, 138, 0.13);
+}
+
+:root[data-scheme='moonstone-light'] {
+  color-scheme: light;
+  --bg-app: #f7f2e6;
+  --bg-shell: #fffaf0;
+  --bg-panel: rgba(255, 252, 244, 0.88);
+  --bg-panel-strong: rgba(255, 250, 239, 0.96);
+  --bg-panel-soft: rgba(74, 58, 37, 0.045);
+  --bg-elevated: #fff6e6;
+  --bg-input: rgba(255, 255, 255, 0.74);
+  --bg-input-focus: rgba(255, 255, 255, 0.92);
+  --bg-overlay: rgba(58, 45, 28, 0.32);
+  --bg-page-radial: rgba(215, 170, 70, 0.22);
+  --bg-page-start: #fffaf0;
+  --bg-page-end: #efe5d2;
+  --bg-app-radial: rgba(215, 170, 70, 0.18);
+  --mobile-footer-bg: linear-gradient(180deg, rgba(255, 252, 244, 0.9), rgba(245, 236, 219, 0.98));
+  --mobile-footer-shadow: 0 -12px 32px rgba(80, 59, 28, 0.16);
+  --nav-active-bg: rgba(215, 170, 70, 0.14);
+  --nav-hover-bg: rgba(80, 59, 28, 0.055);
+  --nav-icon-bg: rgba(80, 59, 28, 0.06);
+
+  --gold-2: #9f6f16;
+  --gold-3: #b9851f;
+  --gold-4: #d7aa46;
+  --gold-5: #fff2c7;
+  --gold-accent: #b9851f;
+  --gold-accent-strong: #8b5e12;
+  --gold-text: #7b5516;
+
+  --border-subtle: rgba(75, 58, 37, 0.14);
+  --border-panel: rgba(75, 58, 37, 0.18);
+  --border-glow: rgba(185, 133, 31, 0.34);
+  --border-strong: rgba(75, 58, 37, 0.24);
+
+  --text-primary: #282014;
+  --text-secondary: #5c4b33;
+  --text-muted: #806f55;
+  --text-inverse: #fffaf0;
+  --text-gold: #7d5718;
+
+  --state-success: #8b6f25;
+  --state-success-soft: rgba(139, 111, 37, 0.13);
+  --state-warning: #a96f25;
+  --state-warning-soft: rgba(169, 111, 37, 0.13);
+  --state-danger: #a64d58;
+  --state-danger-soft: rgba(166, 77, 88, 0.13);
+  --state-muted: #806f55;
+
+  --shadow-panel: 0 12px 32px rgba(80, 59, 28, 0.12);
+  --shadow-panel-strong: 0 18px 50px rgba(80, 59, 28, 0.18);
+  --shadow-gold-soft: 0 0 0 1px rgba(185, 133, 31, 0.24), 0 8px 22px rgba(185, 133, 31, 0.16);
+  --shadow-gold-cta:
+    0 0 0 1px rgba(139, 94, 18, 0.18),
+    0 10px 24px rgba(185, 133, 31, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.65);
+
+  --color-primary-start: var(--gold-5);
+  --color-primary-end: var(--gold-2);
+  --color-accent: var(--gold-accent);
+  --color-accent-light: rgba(185, 133, 31, 0.14);
 }
 
 .no-scrollbar::-webkit-scrollbar {

--- a/tests/SettingsView.test.tsx
+++ b/tests/SettingsView.test.tsx
@@ -53,8 +53,9 @@ jest.mock('../src/hooks/useSuggestedReplies', () => ({
 jest.mock('../src/hooks/useTheme', () => ({
   useTheme: () => ({ scheme: 'obsidian-gold', setScheme: jest.fn() }),
   colorSchemes: {
-    'obsidian-gold': { label: 'Obsidian Gold', start: '#111111', end: '#d7aa46' },
-    'carbon-ivory': { label: 'Carbon Ivory', start: '#111111', end: '#c8b08a' },
+    'obsidian-gold': { label: 'Obsidian Gold', start: '#111111', end: '#d7aa46', mode: 'dark' },
+    'carbon-ivory': { label: 'Carbon Ivory', start: '#111111', end: '#c8b08a', mode: 'dark' },
+    'moonstone-light': { label: 'Moonstone Light', start: '#fff8e8', end: '#d7aa46', mode: 'light' },
   },
 }))
 

--- a/tests/useTheme.test.tsx
+++ b/tests/useTheme.test.tsx
@@ -34,6 +34,28 @@ test('supports additional color schemes', () => {
   expect(document.documentElement.classList.contains('carbon-ivory')).toBe(true);
 });
 
+test('supports a light theme mode', () => {
+  const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+
+  act(() => {
+    result.current.setScheme('moonstone-light');
+  });
+
+  expect(result.current.mode).toBe('light');
+  expect(document.documentElement.dataset.themeMode).toBe('light');
+  expect(document.documentElement.classList.contains('moonstone-light')).toBe(true);
+  expect(document.documentElement.classList.contains('light')).toBe(true);
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+});
+
+test('dark themes publish dark mode metadata', () => {
+  const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+
+  expect(result.current.mode).toBe('dark');
+  expect(document.documentElement.dataset.themeMode).toBe('dark');
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+});
+
 test('maps legacy saved schemes to the new palette', () => {
   localStorage.setItem('colorScheme', 'teal');
 


### PR DESCRIPTION
## Summary
- add a new Moonstone Light theme alongside the existing dark palettes
- wire theme mode through the ThemeProvider so the sidebar toggle, root classes, and toast styling follow the selected theme
- update shell, mobile footer, and bottom navigation tokens so chat and lower mobile nav inherit light-theme surfaces
- polish the Settings color grid for easier mobile theme switching

## Feedback
- Submission: 60a0f4a3-e666-4a01-9d92-4d4b69c7d01d
- Request: lighter theme and easier mobile-friendly switching for chat/lower menu personalization

## Tests
- npx jest --runInBand tests/useTheme.test.tsx tests/SettingsView.test.tsx tests/Navigation.test.tsx
- npm run lint
- npx tsc --noEmit -p tsconfig.app.json
- npm run build
- production-preview browser check at 390x844 with moonstone-light selected

## Risks / Notes
- Existing hardcoded dark rgba accents remain in some deep feature surfaces, but the app shell, theme selector, chat background tokens, and mobile nav/footer now follow the new light mode.
- Build still reports the existing Browserslist/chunk-size warnings.