### PR TITLE
Feedback build: DM button in profile popup

### DIFF
--- a/src/components/profile/PublicProfileDialog.tsx
+++ b/src/components/profile/PublicProfileDialog.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
-import { CalendarDays, Clock3, Ghost, LockKeyhole, Palette, ShieldAlert, ShieldCheck, UserRound, X } from 'lucide-react'
+import { CalendarDays, Clock3, Ghost, LockKeyhole, MessageCircle, Palette, ShieldAlert, ShieldCheck, UserRound, X } from 'lucide-react'
 import type { User } from '../../lib/supabase'
-import { setSubAdminStatus } from '../../lib/supabase'
+import { getOrCreateDMConversation, setSubAdminStatus } from '../../lib/supabase'
 import {
   CHANNEL_BAN_DURATIONS,
   CHANNEL_BAN_OPTIONS,
@@ -75,6 +75,14 @@ export const PublicProfileDialog: React.FC<PublicProfileDialogProps> = ({
   const [banReason, setBanReason] = useState('')
   const [localAdminRole, setLocalAdminRole] = useState(user?.admin_role ?? null)
   const [adminRoleSaving, setAdminRoleSaving] = useState(false)
+  const [dmStarting, setDmStarting] = useState(false)
+
+  const canStartDM = Boolean(
+    open &&
+    user &&
+    currentProfile &&
+    currentProfile.id !== user.id
+  )
 
   const canModerate = Boolean(
     open &&
@@ -252,6 +260,34 @@ export const PublicProfileDialog: React.FC<PublicProfileDialogProps> = ({
     }
   }
 
+  const startDirectMessage = async () => {
+    if (!user || !canStartDM || dmStarting) return
+    if (typeof window === 'undefined') return
+
+    setDmStarting(true)
+
+    try {
+      const conversationId = await getOrCreateDMConversation(user.id)
+
+      if (!conversationId) {
+        throw new Error('Unable to start conversation')
+      }
+
+      const url = new URL(window.location.href)
+      url.searchParams.set('view', 'dms')
+      url.searchParams.set('conversation', conversationId)
+      url.searchParams.delete('message')
+      window.history.replaceState({}, '', url)
+      window.dispatchEvent(new PopStateEvent('popstate'))
+
+      onClose()
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Unable to start conversation'))
+    } finally {
+      setDmStarting(false)
+    }
+  }
+
   if (!user) return null
 
   const statusMessage = user.status_message?.trim()
@@ -347,6 +383,22 @@ export const PublicProfileDialog: React.FC<PublicProfileDialogProps> = ({
                   />
                 </span>
               </div>
+
+              {canStartDM && (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    loading={dmStarting}
+                    onClick={() => void startDirectMessage()}
+                    className="w-full sm:w-auto"
+                  >
+                    <MessageCircle className="mr-2 h-4 w-4" />
+                    Message
+                  </Button>
+                </div>
+              )}
 
               <div className="mt-5 space-y-3">
                 <section className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[rgba(255,255,255,0.035)] p-4">

--- a/src/hooks/useDirectMessages.tsx
+++ b/src/hooks/useDirectMessages.tsx
@@ -346,12 +346,12 @@ function useProvideDirectMessages(): DirectMessagesContextValue {
       throw new Error('User not found');
     }
 
-    const conversation = await getOrCreateDMConversation(match.id);
-    if (conversation) {
+    const conversationId = await getOrCreateDMConversation(match.id);
+    if (conversationId) {
       const convs = await fetchDMConversations();
       setConversations(convs);
-      setCurrentConversation(conversation.id);
-      return conversation.id as string;
+      setCurrentConversation(conversationId);
+      return conversationId;
     }
     return null;
   }, [user]);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1053,7 +1053,15 @@ export const getOrCreateDMConversation = async (otherUserId: string) => {
   if (error) {
     return null
   }
-  return data
+  if (typeof data === 'string') {
+    return data
+  }
+
+  if (data && typeof data === 'object' && 'id' in data && typeof (data as { id?: unknown }).id === 'string') {
+    return (data as { id: string }).id
+  }
+
+  return null
 }
 
 export const markDMMessagesRead = async (conversationId: string) => {

--- a/tests/PublicProfileDialog.test.tsx
+++ b/tests/PublicProfileDialog.test.tsx
@@ -7,6 +7,7 @@ const mockUseAuth = jest.fn()
 const mockUseUserChannelBans = jest.fn()
 const mockSetUserChannelBans = jest.fn()
 const mockSetSubAdminStatus = jest.fn()
+const mockGetOrCreateDMConversation = jest.fn()
 const mockNotifyChannelBansChanged = jest.fn()
 const mockToastSuccess = jest.fn()
 const mockToastError = jest.fn()
@@ -20,6 +21,7 @@ jest.mock('../src/hooks/useUserChannelBans', () => ({
 }))
 
 jest.mock('../src/lib/supabase', () => ({
+  getOrCreateDMConversation: (...args: unknown[]) => mockGetOrCreateDMConversation(...args),
   setSubAdminStatus: (...args: unknown[]) => mockSetSubAdminStatus(...args),
 }))
 
@@ -97,6 +99,7 @@ beforeEach(() => {
   mockUseUserChannelBans.mockReturnValue({ bans: [], loading: false, refresh: jest.fn() })
   mockSetUserChannelBans.mockResolvedValue([])
   mockSetSubAdminStatus.mockResolvedValue(undefined)
+  mockGetOrCreateDMConversation.mockResolvedValue(null)
 })
 
 test('renders public profile details in a dialog', () => {
@@ -171,4 +174,23 @@ test('lets the full admin grant sub-admin access from the profile dialog', async
     expect(mockSetSubAdminStatus).toHaveBeenCalledWith(user.id, true)
   })
   expect(mockToastSuccess).toHaveBeenCalledWith('Sub-admin access granted')
+})
+
+test('offers a Message CTA that jumps into a DM thread', async () => {
+  const browserUser = userEvent.setup()
+  const onClose = jest.fn()
+  mockUseAuth.mockReturnValue({ profile: { ...adminUser, id: 'viewer-1', admin_role: null } })
+  mockGetOrCreateDMConversation.mockResolvedValue('conv-1')
+
+  window.history.replaceState({}, '', 'http://localhost/?view=chat')
+  render(<PublicProfileDialog user={user} open onClose={onClose} />)
+  await act(async () => {
+    await browserUser.click(screen.getByRole('button', { name: /message/i }))
+  })
+  await waitFor(() => {
+    expect(mockGetOrCreateDMConversation).toHaveBeenCalledWith(user.id)
+  })
+  expect(onClose).toHaveBeenCalled()
+  expect(window.location.search).toContain('view=dms')
+  expect(window.location.search).toContain('conversation=conv-1')
 })

--- a/tests/useDirectMessages.test.tsx
+++ b/tests/useDirectMessages.test.tsx
@@ -211,8 +211,7 @@ test('startConversation sets currentConversation', async () => {
   const maybeSingle = jest.fn().mockResolvedValue({ data: { id: 'u2' }, error: null });
   workingClient.from.mockImplementationOnce(() => createQuery({ maybeSingle }) as any);
 
-  const conversation = { id: 'c1' } as any;
-  (getOrCreateDMConversation as jest.Mock).mockResolvedValue(conversation);
+  (getOrCreateDMConversation as jest.Mock).mockResolvedValue('c1');
   (fetchDMConversations as jest.Mock).mockResolvedValue([{ id: 'c1' }]);
 
   const { result } = renderHook(() => useDirectMessages(), { wrapper: DirectMessagesProvider });


### PR DESCRIPTION
Adds a Message button to the public profile popup so users can jump straight into a DM thread with the viewed profile.

Also fixes getOrCreateDMConversation call sites to treat get_or_create_dm_conversation as a UUID-returning RPC.

Tested:
- npm run lint
- npx tsc --noEmit -p tsconfig.app.json
- npm run build
- npx jest --runInBand tests/useDirectMessages.test.tsx tests/PublicProfileDialog.test.tsx