### PR TITLE
Add Netlify PR preview deploys

### DIFF
--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -1,0 +1,120 @@
+name: Netlify Preview Deploy
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: netlify-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy preview
+    runs-on: ubuntu-latest
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_CLI_VERSION: 26.0.0
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify Netlify secrets
+        run: |
+          test -n "$NETLIFY_AUTH_TOKEN" || { echo "NETLIFY_AUTH_TOKEN is not configured."; exit 1; }
+          test -n "$NETLIFY_SITE_ID" || { echo "NETLIFY_SITE_ID is not configured."; exit 1; }
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit -p tsconfig.app.json
+
+      - name: Build with Netlify preview environment
+        run: npx --yes netlify@$NETLIFY_CLI_VERSION build --context deploy-preview
+
+      - name: Deploy Netlify preview
+        run: |
+          npx --yes netlify@$NETLIFY_CLI_VERSION deploy \
+            --context deploy-preview \
+            --dir=dist \
+            --alias="pr-${{ github.event.pull_request.number }}" \
+            --message="GitHub Actions preview deploy PR #${{ github.event.pull_request.number }} ${{ github.sha }}" \
+            --json > netlify-preview.json
+
+      - name: Capture preview URL
+        id: preview
+        run: |
+          node <<'NODE'
+          const fs = require('fs')
+          const data = JSON.parse(fs.readFileSync('netlify-preview.json', 'utf8'))
+          const url = data.deploy_url || data.deployUrl || data.ssl_url || data.url
+          if (!url) {
+            console.error('Netlify deploy output did not include a deploy URL.')
+            console.error(JSON.stringify(data, null, 2))
+            process.exit(1)
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `url=${url}\n`)
+          NODE
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- shadowchat-netlify-preview -->'
+            const body = [
+              marker,
+              'Netlify preview is ready:',
+              process.env.PREVIEW_URL,
+              '',
+              `This preview was built from \`${context.sha.slice(0, 7)}\`.`,
+            ].join('\n')
+
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            })
+            const existing = comments.find(comment => comment.body?.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              })
+            }
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -56,6 +56,31 @@ Pushing `main` automatically starts the GitHub Actions workflow in
 That workflow runs install, lint, typecheck, Netlify build, and Netlify
 production deploy.
 
+Opening or updating a pull request against `main` starts the GitHub Actions
+workflow in
+[.github/workflows/netlify-preview.yml](C:/repos/chat2.0/.github/workflows/netlify-preview.yml:1).
+That workflow runs install, lint, typecheck, a Netlify deploy-preview build, and
+then publishes an alias preview at `pr-<pull-request-number>`. It also writes a
+sticky PR comment containing the preview URL so Feedback Builds and human review
+have a stable place to find the test build before merge.
+
+## Netlify PR Preview Deploys
+
+PR previews require the same GitHub Actions repository secrets as production:
+
+- `NETLIFY_AUTH_TOKEN`
+- `NETLIFY_SITE_ID`
+
+The preview workflow intentionally does not deploy to production. It publishes
+the built `dist` directory with:
+
+```powershell
+npx netlify deploy --context deploy-preview --dir=dist --alias="pr-<number>"
+```
+
+Use the sticky PR comment or the Netlify check output as the source of truth for
+the preview URL during admin verification.
+
 ## Netlify Production Deploy
 
 Manual CLI deploy is now a fallback path, not the normal production path. From

--- a/docs/FEEDBACK_SUBMISSIONS.md
+++ b/docs/FEEDBACK_SUBMISSIONS.md
@@ -96,6 +96,13 @@ marked Included or Excluded, and the stage-by-stage Codex notes. If the PR
 exists but the Netlify preview URL is missing, the run should still be Ready for
 Testing with a warning instead of Failed.
 
+Feedback Builds should get their preview URLs from the GitHub Actions
+`Netlify Preview Deploy` workflow. That workflow runs on PRs against `main`,
+deploys the PR build to Netlify with the alias `pr-<pull-request-number>`, and
+posts a sticky PR comment containing the preview URL. If that workflow is
+temporarily unavailable, the processor can fall back to a manual Netlify draft
+deploy and store that returned URL on `feedback_build_runs.preview_url`.
+
 After a full admin approves a run to merge, the processor reruns the gates,
 squash-merges to `main`, records the merge summary and commit SHA, closes the
 original feedback submission, deletes the remote feature branch, and logs the


### PR DESCRIPTION
## What changed
- Added a `Netlify Preview Deploy` GitHub Actions workflow for pull requests into `main`.
- The workflow installs dependencies, runs lint/typecheck, builds with the Netlify deploy-preview context, deploys `dist` to a stable `pr-<number>` alias, and posts the preview URL back to the PR.
- Documented the preview URL source for normal deploys and Feedback Build verification.

## Why
Feedback Build runs were opening PRs, but there was no dedicated PR preview workflow, so the processor had no reliable Netlify URL to store for admin testing before merge.

## Validation
- Parsed `.github/workflows/netlify-preview.yml` with the repo `yaml` package.
- Ran `git diff --cached --check` before commit.

Note: this workflow must exist on the default branch before GitHub can use it for future pull_request events.
