### PR TITLE
Fix iOS keyboard collapse on send

### DIFF
--- a/src/components/boards/BoardChat.tsx
+++ b/src/components/boards/BoardChat.tsx
@@ -263,9 +263,19 @@ function BoardChatComposer({
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
   className?: string
 }) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const retainFocusOnBlurRef = useRef(false)
+
+  const armFocusRetention = () => {
+    retainFocusOnBlurRef.current = true
+  }
+
   return (
     <form
-      onSubmit={onSubmit}
+      onSubmit={event => {
+        retainFocusOnBlurRef.current = false
+        onSubmit(event)
+      }}
       className={cn(
         'border-t border-[var(--border-panel)] bg-[linear-gradient(180deg,rgba(16,18,19,0.94),rgba(10,11,12,0.98))] p-3',
         className
@@ -273,8 +283,14 @@ function BoardChatComposer({
     >
       <div className="flex items-end gap-2">
         <textarea
+          ref={textareaRef}
           value={draft}
           onChange={event => onDraftChange(event.target.value)}
+          onBlur={() => {
+            if (!retainFocusOnBlurRef.current) return
+            retainFocusOnBlurRef.current = false
+            textareaRef.current?.focus()
+          }}
           onKeyDown={event => {
             if (event.key === 'Enter' && !event.shiftKey) {
               event.preventDefault()
@@ -291,6 +307,13 @@ function BoardChatComposer({
           loading={sending}
           className="h-11 w-11 rounded-xl p-0"
           aria-label={`Send ${board.title} message`}
+          onMouseDown={event => {
+            armFocusRetention()
+            event.preventDefault()
+          }}
+          onTouchStart={() => {
+            armFocusRetention()
+          }}
         >
           <Send className="h-5 w-5" />
         </Button>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -74,6 +74,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const recordingIntervalRef = useRef<NodeJS.Timeout | null>(null)
   const { startTyping, stopTyping } = useTyping(typingChannel)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const retainFocusOnBlurRef = useRef(false)
   const emojiPickerRef = useRef<HTMLDivElement>(null)
   const attachmentMenuRef = useRef<HTMLDivElement>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
@@ -209,6 +210,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   ) => {
      
     e.preventDefault()
+    retainFocusOnBlurRef.current = false
      
     if (!message.trim() || inputDisabled || submittingRef.current) {
       return
@@ -638,6 +640,11 @@ export const MessageInput: React.FC<MessageInputProps> = ({
             value={message}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
+            onBlur={() => {
+              if (!retainFocusOnBlurRef.current) return
+              retainFocusOnBlurRef.current = false
+              textareaRef.current?.focus()
+            }}
             placeholder={placeholder}
             disabled={inputDisabled}
             autoComplete="off"
@@ -681,7 +688,13 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           disabled={!message.trim() || inputDisabled}
           className="h-11 w-11 rounded-xl p-0 md:h-12 md:w-12"
           aria-label="Send message"
-          onMouseDown={e => e.preventDefault()}
+          onMouseDown={event => {
+            retainFocusOnBlurRef.current = true
+            event.preventDefault()
+          }}
+          onTouchStart={() => {
+            retainFocusOnBlurRef.current = true
+          }}
         >
           <Send className="w-5 h-5" />
         </Button>


### PR DESCRIPTION
Fix iOS Safari keyboard collapsing after sending a message.

- Adds a focus-retention guard in `MessageInput` (group chat + DMs)
- Adds the same guard in `BoardChatComposer` (boards + News chat)

Run: 7f14e617-725e-443b-80bb-6e4c880516ff
Submission: cbbf8a87-5b8a-4ea7-8108-52bffc055bb9

Checks:
- npm run lint
- npx tsc --noEmit -p tsconfig.app.json
- npm run build