### PR TITLE
Fix Android keyboard closing on send

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -695,7 +695,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         </Button>
 
         <Button
-          type="submit"
+          type="button"
           disabled={!message.trim() || inputDisabled}
           className="h-11 w-11 rounded-xl p-0 md:h-12 md:w-12"
           aria-label="Send message"
@@ -706,6 +706,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           onTouchStart={event => {
             retainFocusOnBlurRef.current = true
             event.preventDefault()
+            void handleSubmit(event)
+          }}
+          onClick={event => {
             void handleSubmit(event)
           }}
         >


### PR DESCRIPTION
Fixes mobile (Android Chrome) keyboard collapsing after tapping Send.

Change:
- MessageInput Send button is now type=button and submits via onClick (avoids submit-driven focus loss).

Test:
- npm run lint ✅
- npx tsc --noEmit -p tsconfig.app.json ✅
- npm run build ✅

Manual QA:
- Android Chrome: type message in General Chat, tap Send repeatedly; keyboard should remain open.
- Android Chrome: same flow in DMs.