### PR TITLE
Fix feedback modal double-submit

### DIFF
--- a/src/components/settings/FeedbackSubmissionModal.tsx
+++ b/src/components/settings/FeedbackSubmissionModal.tsx
@@ -66,6 +66,7 @@ export const FeedbackSubmissionModal: React.FC<FeedbackSubmissionModalProps> = (
   const [description, setDescription] = useState('')
   const [attachments, setAttachments] = useState<File[]>([])
   const [submitting, setSubmitting] = useState(false)
+  const submittingRef = useRef(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const remainingSlots = MAX_FEEDBACK_ATTACHMENTS - attachments.length
@@ -76,7 +77,7 @@ export const FeedbackSubmissionModal: React.FC<FeedbackSubmissionModalProps> = (
   )
 
   const resetAndClose = () => {
-    if (submitting) return
+    if (submitting || submittingRef.current) return
     setStep(0)
     setType('bug')
     setTitle('')
@@ -124,6 +125,8 @@ export const FeedbackSubmissionModal: React.FC<FeedbackSubmissionModalProps> = (
   }
 
   const handleSubmit = async () => {
+    if (submittingRef.current || submitting) return
+    submittingRef.current = true
     try {
       setSubmitting(true)
       const result = await submitFeedback({
@@ -140,6 +143,7 @@ export const FeedbackSubmissionModal: React.FC<FeedbackSubmissionModalProps> = (
       console.error(error)
       toast.error(error instanceof Error ? error.message : 'Could not send feedback')
     } finally {
+      submittingRef.current = false
       setSubmitting(false)
     }
   }
@@ -398,6 +402,7 @@ export const FeedbackSubmissionModal: React.FC<FeedbackSubmissionModalProps> = (
                         type="button"
                         onClick={() => void handleSubmit()}
                         loading={submitting}
+                        disabled={submitting || submittingRef.current}
                         className="w-full justify-center sm:w-auto"
                       >
                         <Send className="mr-2 h-4 w-4" />

--- a/tests/FeedbackSubmissionModal.test.tsx
+++ b/tests/FeedbackSubmissionModal.test.tsx
@@ -15,6 +15,10 @@ jest.mock('../src/lib/feedback', () => ({
   submitFeedback: jest.fn(),
 }))
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 test('walks a user through a feature idea submission with an image', async () => {
   const onSubmitted = jest.fn()
   ;(submitFeedback as jest.Mock).mockResolvedValue({ id: 'feedback-123', attachments: [] })
@@ -69,4 +73,36 @@ test('keeps the details step gated until enough detail is present', async () => 
   })
 
   expect(continueButton).toBeDisabled()
+})
+
+test('debounces rapid send feedback taps', async () => {
+  let submitCalls = 0
+  ;(submitFeedback as jest.Mock).mockImplementation(() => {
+    submitCalls += 1
+    return new Promise<{ id: string; attachments: any[] }>(resolve => {
+      setTimeout(() => resolve({ id: `feedback-${submitCalls}`, attachments: [] }), 0)
+    })
+  })
+
+  render(<FeedbackSubmissionModal open onClose={jest.fn()} />)
+
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+
+  fireEvent.change(screen.getByLabelText(/brief description/i), {
+    target: { value: 'Ship debounce' },
+  })
+  fireEvent.change(screen.getByLabelText(/details/i), {
+    target: { value: 'Ensure rapid taps do not submit duplicate feedback entries.' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+
+  const sendButton = screen.getByRole('button', { name: /send feedback/i })
+  fireEvent.click(sendButton)
+  fireEvent.click(sendButton)
+
+  expect(submitFeedback).toHaveBeenCalledTimes(1)
+
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: /feedback sent/i })).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Fixes rapid-tap double submits in the FeedbackSubmissionModal by adding a synchronous ref lock, plus a Jest regression test.

Tests:
- npm run lint
- npx tsc --noEmit -p tsconfig.app.json
- npx jest --runInBand tests/FeedbackSubmissionModal.test.tsx
- npm run build

Feedback build run: b5df7c5d-cf58-4965-b305-429713838980